### PR TITLE
Add subscription and server information model

### DIFF
--- a/working_draft/API/models/error.json
+++ b/working_draft/API/models/error.json
@@ -10,5 +10,5 @@
     "attribute": ".AirWayBillNumber",
     "resource": "http://cargo.iata.org/AirWayBill",
     "message": "AirWaybill number could not be dereferenced, an error occurred"
-    }]
+  }]
 }

--- a/working_draft/API/models/error.json
+++ b/working_draft/API/models/error.json
@@ -1,13 +1,13 @@
 {
   "@context": {
-    "@vocab" : "https://github.com/IATA-Cargo/ONE-Record/schema/"
+    "@vocab" : "https://tcfplayground.org/"
   },
   "@type": "Error",
   "title": "Request contains invalid field",
   "details": [{
     "code": "1234",
     "attribute": ".AirWayBillNumber",
-    "resource": "http://cargo.iata.org/AirWayBill",
+    "resource": "https://tcfplayground.org/AirWayBill",
     "message": "AirWaybill number could not be dereferenced, an error occurred"
   }]
 }

--- a/working_draft/API/models/error.json
+++ b/working_draft/API/models/error.json
@@ -3,7 +3,6 @@
     "@vocab" : "https://github.com/IATA-Cargo/ONE-Record/schema/"
   },
   "@type": "Error",
-  "@id": "http://onerecordserver.com/errors/1234",
   "title": "Request contains invalid field",
   "details": [{
     "code": "1234",

--- a/working_draft/API/models/error.json
+++ b/working_draft/API/models/error.json
@@ -1,5 +1,7 @@
 {
-  "@context": "https://github.com/IATA-Cargo/ONE-Record/schema/",
+  "@context": {
+    "@vocab" : "https://github.com/IATA-Cargo/ONE-Record/schema/"
+  },
   "@type": "Error",
   "@id": "http://onerecordserver.com/errors/1234",
   "title": "Request contains invalid field",
@@ -8,5 +10,5 @@
     "attribute": ".AirWayBillNumber",
     "resource": "http://cargo.iata.org/AirWayBill",
     "message": "AirWaybill number could not be dereferenced, an error occurred"
-  }]
+    }]
 }

--- a/working_draft/API/models/serverInformation.json
+++ b/working_draft/API/models/serverInformation.json
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab" : "https://github.com/IATA-Cargo/ONE-Record/schema/"
   },
-  "@id": "https://myonerecordserver/my_license_plate",
+  "@id": "https://myonerecordserver.org/my_license_plate",
   "@type": "ServerInformation",
   "company": {
      "@type": "Company",
@@ -78,5 +78,5 @@
    },
   "supportedLogisticsObjects": ["https://github.com/IATA-Cargo/ONE-Record/schema/HouseManifest", "https://github.com/IATA-Cargo/ONE-Record/schema/Airwaybill"],
   "supportedContentTypes": ["application/ld+json", "application/x-turtle", "text/turtle"],
-  "serverEndpoint": "https://subscriberonerecordserver/callback"
+  "serverEndpoint": "https://myonerecordserver.org"
 }

--- a/working_draft/API/models/serverInformation.json
+++ b/working_draft/API/models/serverInformation.json
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "@vocab" : "https://github.com/IATA-Cargo/ONE-Record/schema/"
+    "@vocab" : "https://tcfplayground.org"
   },
   "@id": "https://myonerecordserver.org/my_license_plate",
   "@type": "ServerInformation",
@@ -76,7 +76,7 @@
      "airlineCode": "text",
      "airlinePrefix": "text"
    },
-  "supportedLogisticsObjects": ["https://github.com/IATA-Cargo/ONE-Record/schema/HouseManifest", "https://github.com/IATA-Cargo/ONE-Record/schema/Airwaybill"],
+  "supportedLogisticsObjects": ["https://tcfplayground.org/HouseManifest", "https://tcfplayground.org/AirWaybill"],
   "supportedContentTypes": ["application/ld+json", "application/x-turtle", "text/turtle"],
   "serverEndpoint": "https://myonerecordserver.org"
 }

--- a/working_draft/API/models/serverInformation.json
+++ b/working_draft/API/models/serverInformation.json
@@ -1,0 +1,82 @@
+{
+  "@context": {
+    "@vocab" : "https://github.com/IATA-Cargo/ONE-Record/schema/"
+  },
+  "@id": "https://myonerecordserver/my_license_plate",
+  "@type": "ServerInformation",
+  "company": {
+     "@type": "Company",
+     "name": "text",
+     "IATACargoAgentCode": "numeric",
+     "branch": [{
+        "branchName": "text",
+        "IATACargoAgentLocationIdentifier": "numeric",
+        "otherIdentifier": [{
+           "identifierName": "text",
+           "identifer": "text"
+        }],
+        "location": {
+           "@type": "Location",
+           "type": "text",
+           "code": "text",
+           "name": "text",
+           "geoLocation": {
+             "@type": "GeoLocation",
+             "latitude": {
+               "@type": "Value",
+               "value": "text",
+               "unit": "text"
+             },
+             "longitude": {
+               "@type": "Value",
+               "value": "text",
+               "unit": "text"
+             },
+             "elevation": {
+               "@type": "Value",
+               "value": "text",
+               "unit": "text"
+             }
+           },
+           "address": {
+             "@type": "Address",
+             "street": "text",
+             "POBox": "text",
+             "postalCode": "text",
+             "cityCode": "text",
+             "cityName": "text",
+             "regionCode": "text",
+             "regionName": "text",
+             "countryCode": "text",
+             "countryName": "text",
+             "addressCodeType": "text",
+             "addressCode": "text"
+           }
+        },
+        "contactPerson": {
+           "@type": "Person",
+           "contactType": "text",
+           "salutation": "text",
+           "firstName": "text",
+           "middleName": "text",
+           "lastName": "text",
+           "jobTitle": "text",
+           "department": "text",
+           "employeeID": "text",
+           "contactDetails": [{
+              "phoneNumber": "text",
+              "emailAddress": "text",
+              "other": {
+                 "type": "text",
+                 "detail": "text"
+              }
+           }]
+        }
+     }],
+     "airlineCode": "text",
+     "airlinePrefix": "text"
+   },
+  "supportedLogisticsObjects": ["https://github.com/IATA-Cargo/ONE-Record/schema/HouseManifest", "https://github.com/IATA-Cargo/ONE-Record/schema/Airwaybill"],
+  "supportedContentTypes": ["application/ld+json", "application/x-turtle", "text/turtle"],
+  "serverEndpoint": "https://subscriberonerecordserver/callback"
+}

--- a/working_draft/API/models/subscription.json
+++ b/working_draft/API/models/subscription.json
@@ -7,7 +7,7 @@
   "subscribedTo": "https://publisheronerecordserver.net/yourCompany",
   "topic": "https://github.com/IATA-Cargo/ONE-Record/schema/HouseManifest",
   "callbackUrl": "https://subscriberonerecordserver/callback",
-  "contentType": "application/ld+json",
+  "contentType": ["application/ld+json"],
   "secret": "C89583BA9B1FEEAB25F715A3BA2F3",
   "subscribeToStatusUpdates": "true",
   "cacheFor": "86400"

--- a/working_draft/API/models/subscription.json
+++ b/working_draft/API/models/subscription.json
@@ -1,0 +1,14 @@
+{
+  "@context": {
+    "@vocab" : "https://github.com/IATA-Cargo/ONE-Record/schema/"
+  },
+  "@id": "https://myORS.net/mySubscriptionToHouseManifest",
+  "@type": "Subscription",
+  "subscribedTo": "https://publisheronerecordserver.net/yourCompany",
+  "topic": "https://github.com/IATA-Cargo/ONE-Record/schema/HouseManifest",
+  "callbackUrl": "https://subscriberonerecordserver/callback",
+  "contentType": "application/ld+json",
+  "secret": "C89583BA9B1FEEAB25F715A3BA2F3",
+  "subscribeToStatusUpdates": "true",
+  "cacheFor": "86400"
+}

--- a/working_draft/API/models/subscription.json
+++ b/working_draft/API/models/subscription.json
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab" : "https://github.com/IATA-Cargo/ONE-Record/schema/"
   },
-  "@id": "https://myORS.net/mySubscriptionToHouseManifest",
+  "@id": "https://subscriberonerecordserver?topic=HouseManifest",
   "@type": "Subscription",
   "subscribedTo": "https://publisheronerecordserver.net/yourCompany",
   "topic": "https://github.com/IATA-Cargo/ONE-Record/schema/HouseManifest",

--- a/working_draft/API/models/subscription.json
+++ b/working_draft/API/models/subscription.json
@@ -1,11 +1,11 @@
 {
   "@context": {
-    "@vocab" : "https://github.com/IATA-Cargo/ONE-Record/schema/"
+    "@vocab" : "https://tcfplayground.org/"
   },
   "@id": "https://subscriberonerecordserver?topic=HouseManifest",
   "@type": "Subscription",
   "subscribedTo": "https://publisheronerecordserver.net/yourCompany",
-  "topic": "https://github.com/IATA-Cargo/ONE-Record/schema/HouseManifest",
+  "topic": "https://tcfplayground.org/HouseManifest",
   "callbackUrl": "https://subscriberonerecordserver/callback",
   "contentType": ["application/ld+json"],
   "secret": "C89583BA9B1FEEAB25F715A3BA2F3",


### PR DESCRIPTION
Add `subscription `and `serverInformation `models according to the API specifications in the working draft. Update `error `model according to comments from the industry. 