### PR TITLE
Update IATA-1R-DM-Ontology.ttl

### DIFF
--- a/working_draft/ontology/IATA-1R-DM-Ontology.ttl
+++ b/working_draft/ontology/IATA-1R-DM-Ontology.ttl
@@ -50,12 +50,15 @@
 @prefix sensorGeoloc: <https://onerecord.iata.org/SensorGeoloc#> .
 @prefix bookingOption: <https://onerecord.iata.org/BookingOption#> .
 @prefix co2CalcMethod: <https://onerecord.iata.org/CO2CalcMethod#> .
+@prefix commonobjects: <https://onerecord.iata.org/CommonObjects#> .
 @prefix companybranch: <https://onerecord.iata.org/CompanyBranch#> .
 @prefix dgDeclaration: <https://onerecord.iata.org/DgDeclaration#> .
 @prefix movementTimes: <https://onerecord.iata.org/MovementTimes#> .
 @prefix packagingType: <https://onerecord.iata.org/PackagingType#> .
+@prefix scheduledLegs: <https://onerecord.iata.org/ScheduledLegs#> .
 @prefix bookingSegment: <https://onerecord.iata.org/BookingSegment#> .
 @prefix carrierProduct: <https://onerecord.iata.org/CarrierProduct#> .
+@prefix embeddedobject: <https://onerecord.iata.org/EmbeddedObjects#> .
 @prefix serviceRequest: <https://onerecord.iata.org/ServiceRequest#> .
 @prefix transportMeans: <https://onerecord.iata.org/TransportMeans#> .
 @prefix characteristics: <https://onerecord.iata.org/Characteristics#> .
@@ -93,10 +96,22 @@ Version 1.01 includes some bugfixes to allow for the generation of JSON-LD schem
 Version 1.1 includes improvements and bugfixes, details can be found on GitHub
 
 Version 1.11 includes bugfixes, including:
-- Change of cardinality for CompanyBranch#otherIdentifiers and CompanyBranch#contactPersons (removed max = 1)"""@en ;
+- Change of cardinality for CompanyBranch#otherIdentifiers and CompanyBranch#contactPersons (removed max = 1)
+
+Version 1.2.0 (beta for Version 2.0.0 to come)
+- Change of ratings:chargePaymentType values from (S,P) to (C,P) as it was a mistake
+- Added data properties on BookingTimes
+- Removed Piece#product max cardinality
+- Added Waybill#originCurrency
+- Added Piece#nvdForCarriage and Piece#nvdForCustoms
+- Added Insurance#nvdIndicator
+- Added Waybill#consignorDeclarationSignature / carrierDeclarationPlace / carrierDeclarationDate / carrierDeclarationSignature
+- Improved Ratings objects for Billing&Settlement purposes with new properties
+- Added CommonObjects class and EmbeddedObject class
+- Addded ScheduledLegs object and Routing#scheduledLegs"""@en ;
                                rdfs:isDefinedBy "https://www.iata.org/one-record/"^^xsd:anyURI ;
                                rdfs:label "IATA ONE Record Ontology"@en ;
-                               owl:versionInfo 1.11 .
+                               owl:versionInfo "1.2"@en .
 
 #################################################################
 #    Annotation properties
@@ -1393,6 +1408,30 @@ routing:bookingOption rdf:type owl:ObjectProperty ;
                       rdfs:label "routing:bookingOption"@en .
 
 
+###  https://onerecord.iata.org/Routing#scheduledLegs
+routing:scheduledLegs rdf:type owl:ObjectProperty ;
+                      rdfs:domain :Routing ;
+                      rdfs:range :ScheduledLegs ;
+                      rdfs:comment "Scheduled Legs class to be used to identify legs. Can be used with Booking Option Request as an indicator of preferred Routing or with Booking Option when a carrier proposes a specific Routing."@en ;
+                      rdfs:label "routing:scheduledLegs"@en .
+
+
+###  https://onerecord.iata.org/ScheduledLegs#arrivalLocation
+scheduledLegs:arrivalLocation rdf:type owl:ObjectProperty ;
+                              rdfs:domain :ScheduledLegs ;
+                              rdfs:range :Location ;
+                              rdfs:comment "Arrival location of the leg"@en ;
+                              rdfs:label "scheduledLegs:arrivalLocation"@en .
+
+
+###  https://onerecord.iata.org/ScheduledLegs#departureLocation
+scheduledLegs:departureLocation rdf:type owl:ObjectProperty ;
+                                rdfs:domain :ScheduledLegs ;
+                                rdfs:range :Location ;
+                                rdfs:comment "Departure Location of the leg"@en ;
+                                rdfs:label "scheduledLegs:departureLocation"@en .
+
+
 ###  https://onerecord.iata.org/SecurityDeclaration#issuedBy
 securityDeclaration:issuedBy rdf:type owl:ObjectProperty ;
                              rdfs:domain :SecurityDeclaration ;
@@ -1791,6 +1830,14 @@ waybill:bookingRef rdf:type owl:ObjectProperty ;
                    owl:deprecated "true"@en .
 
 
+###  https://onerecord.iata.org/Waybill#carrierDeclarationPlace
+waybill:carrierDeclarationPlace rdf:type owl:ObjectProperty ;
+                                rdfs:domain :Waybill ;
+                                rdfs:range :Location ;
+                                rdfs:comment "Location of individual or company involved in the movement of a consignment or Coded representation of a specific airport/city code"@en ;
+                                rdfs:label "waybill:carrierDeclarationPlace"@en .
+
+
 ###  https://onerecord.iata.org/Waybill#containedWaybills
 waybill:containedWaybills rdf:type owl:ObjectProperty ;
                           rdfs:domain :Waybill ;
@@ -1958,7 +2005,7 @@ bookingOption:bookingStatus rdf:type owl:DatatypeProperty ;
                                                               ]
                                                    ]
                                        ] ;
-                            rdfs:comment "Status of the Booking with regards to the step in the Quote & Book process: Quoted, Booked"@en ;
+                            rdfs:comment "Status of the Booking with regards to the step in the Quote & Book process: Quoted, Booked (to be confirmed)"@en ;
                             rdfs:label "bookingOption:bookingStatus"@en .
 
 
@@ -2022,8 +2069,16 @@ bookingOptionRequest:expectedCommodities rdf:type owl:DatatypeProperty ;
 ###  https://onerecord.iata.org/BookingOptionRequest#requestType
 bookingOptionRequest:requestType rdf:type owl:DatatypeProperty ;
                                  rdfs:domain :BookingOptionRequest ;
-                                 rdfs:range xsd:string ;
-                                 rdfs:comment "Identification of the request type: Quote or Booking"@en ;
+                                 rdfs:range [ rdf:type rdfs:Datatype ;
+                                              owl:oneOf [ rdf:type rdf:List ;
+                                                          rdf:first "Booking" ;
+                                                          rdf:rest [ rdf:type rdf:List ;
+                                                                     rdf:first "Quote" ;
+                                                                     rdf:rest rdf:nil
+                                                                   ]
+                                                        ]
+                                            ] ;
+                                 rdfs:comment "Identification of the request type: Quote or Booking (to be confirmed)"@en ;
                                  rdfs:label "bookingOptionRequest:requestType"@en .
 
 
@@ -2213,7 +2268,7 @@ carrierProduct:productDescription rdf:type owl:DatatypeProperty ;
 characteristics:characteristicsType rdf:type owl:DatatypeProperty ;
                                     rdfs:domain :Characteristics ;
                                     rdfs:range xsd:string ;
-                                    rdfs:comment "Product characteristics code - e.g. CLR - Color"@en ;
+                                    rdfs:comment "Product characteristics code - e.g. CLR - Color. Not restricted to a list."@en ;
                                     rdfs:label "characteristics:characteristicsType"@en .
 
 
@@ -2225,12 +2280,21 @@ characteristics:value rdf:type owl:DatatypeProperty ;
                       rdfs:label "characteristics:value"@en .
 
 
+###  https://onerecord.iata.org/CommonObjects#companyIdentifier
+commonobjects:companyIdentifier rdf:type owl:DatatypeProperty ;
+                                rdfs:domain :CommonObjects ;
+                                rdfs:range xsd:string ;
+                                rdfs:comment "Company identifier from the Internet of Logistics of the entity that hosts the Common Object."@en ;
+                                rdfs:label "commonobjects:companyIdentifier"@en .
+
+
 ###  https://onerecord.iata.org/Company#airlineCode
 company:airlineCode rdf:type owl:DatatypeProperty ;
                     rdfs:domain :Company ;
                     rdfs:range xsd:string ;
                     rdfs:comment "IATA two-character airline code "@en ;
-                    rdfs:label "company:airlineCode"@en .
+                    rdfs:label "company:airlineCode"@en ;
+                    owl:deprecated "true"^^xsd:boolean .
 
 
 ###  https://onerecord.iata.org/Company#airlinePrefix
@@ -2238,7 +2302,8 @@ company:airlinePrefix rdf:type owl:DatatypeProperty ;
                       rdfs:domain :Company ;
                       rdfs:range xsd:integer ;
                       rdfs:comment "IATA three-numeric airline prefix number "@en ;
-                      rdfs:label "company:airlinePrefix"@en .
+                      rdfs:label "company:airlinePrefix"@en ;
+                      owl:deprecated "true"^^xsd:boolean .
 
 
 ###  https://onerecord.iata.org/Company#companyName
@@ -2309,12 +2374,15 @@ contact:contactType rdf:type owl:DatatypeProperty ;
                                                                    rdf:rest [ rdf:type rdf:List ;
                                                                               rdf:first "Fax number" ;
                                                                               rdf:rest [ rdf:type rdf:List ;
-                                                                                         rdf:first "Phone number" ;
+                                                                                         rdf:first "Other" ;
                                                                                          rdf:rest [ rdf:type rdf:List ;
-                                                                                                    rdf:first "Telex" ;
+                                                                                                    rdf:first "Phone number" ;
                                                                                                     rdf:rest [ rdf:type rdf:List ;
-                                                                                                               rdf:first "Website" ;
-                                                                                                               rdf:rest rdf:nil
+                                                                                                               rdf:first "Telex" ;
+                                                                                                               rdf:rest [ rdf:type rdf:List ;
+                                                                                                                          rdf:first "Website" ;
+                                                                                                                          rdf:rest rdf:nil
+                                                                                                                        ]
                                                                                                              ]
                                                                                                   ]
                                                                                        ]
@@ -2385,7 +2453,7 @@ country:countryCode rdf:type owl:DatatypeProperty ;
 country:countryName rdf:type owl:DatatypeProperty ;
                     rdfs:domain :Country ;
                     rdfs:range xsd:string ;
-                    rdfs:comment "Full country name"@en ;
+                    rdfs:comment "Full country name, Refer ISO 3166-2"@en ;
                     rdfs:label "country:countryName"@en .
 
 
@@ -2401,7 +2469,7 @@ customsInfo:customsInfoContentCode rdf:type owl:DatatypeProperty ;
 customsInfo:customsInfoCountryCode rdf:type owl:DatatypeProperty ;
                                    rdfs:domain :CustomsInfo ;
                                    rdfs:range xsd:string ;
-                                   rdfs:comment "Customs country code."@en ;
+                                   rdfs:comment "Customs country code. Refer ISO 3166-2"@en ;
                                    rdfs:label "customsInfo:customsInfoCountryCode"@en .
 
 
@@ -2472,7 +2540,18 @@ dgDeclaration:shipperDeclarationText rdf:type owl:DatatypeProperty ;
 ###  https://onerecord.iata.org/DgProductRadioactive#dgRaTypeCode
 dgProductRadioactive:dgRaTypeCode rdf:type owl:DatatypeProperty ;
                                   rdfs:domain :DgProductRadioactive ;
-                                  rdfs:range xsd:string ;
+                                  rdfs:range [ rdf:type rdfs:Datatype ;
+                                               owl:oneOf [ rdf:type rdf:List ;
+                                                           rdf:first "I=-White" ;
+                                                           rdf:rest [ rdf:type rdf:List ;
+                                                                      rdf:first "II-Yellow" ;
+                                                                      rdf:rest [ rdf:type rdf:List ;
+                                                                                 rdf:first "III-Yellow" ;
+                                                                                 rdf:rest rdf:nil
+                                                                               ]
+                                                                    ]
+                                                         ]
+                                             ] ;
                                   rdfs:comment "The category of the package or all packed in one. Complete text to be transmitted: I-White, II-Yellow, III-Yellow instead of I, II, III"@en ;
                                   rdfs:label "dgProductRadioactive:dgRaTypeCode"@en .
 
@@ -2544,7 +2623,18 @@ dgRadioactiveIsotope:lowDispersibleIndicator rdf:type owl:DatatypeProperty ;
 ###  https://onerecord.iata.org/DgRadioactiveIsotope#physicalChemicalForm
 dgRadioactiveIsotope:physicalChemicalForm rdf:type owl:DatatypeProperty ;
                                           rdfs:domain :DgRadioactiveIsotope ;
-                                          rdfs:range xsd:string ;
+                                          rdfs:range [ rdf:type rdfs:Datatype ;
+                                                       owl:oneOf [ rdf:type rdf:List ;
+                                                                   rdf:first "LowDispersible" ;
+                                                                   rdf:rest [ rdf:type rdf:List ;
+                                                                              rdf:first "PhysicalChemicalForm" ;
+                                                                              rdf:rest [ rdf:type rdf:List ;
+                                                                                         rdf:first "SpecialForm" ;
+                                                                                         rdf:rest rdf:nil
+                                                                                       ]
+                                                                            ]
+                                                                 ]
+                                                     ] ;
                                           rdfs:comment "A description of the physical and chemical form of the material."@en ;
                                           rdfs:label "dgRadioactiveIsotope:physicalChemicalForm"@en .
 
@@ -2555,6 +2645,12 @@ dgRadioactiveIsotope:specialFormIndicator rdf:type owl:DatatypeProperty ;
                                           rdfs:range xsd:boolean ;
                                           rdfs:comment "A notation that the material is special form"@en ;
                                           rdfs:label "dgRadioactiveIsotope:specialFormIndicator"@en .
+
+
+###  https://onerecord.iata.org/EmbeddedObjects#companyIdentifier
+embeddedobject:companyIdentifier rdf:type owl:DatatypeProperty ;
+                                 rdfs:comment "Company identifier from the Internet of Logistics of the entity that hosts the Embedded Object."@en ;
+                                 rdfs:label "embeddedobject:companyIdentifier"@en .
 
 
 ###  https://onerecord.iata.org/EpermitConsignment#usedToDateQuotaQuantity
@@ -2579,12 +2675,15 @@ epermitSignature:signatoryRole rdf:type owl:DatatypeProperty ;
                                             owl:oneOf [ rdf:type rdf:List ;
                                                         rdf:first "Applicant" ;
                                                         rdf:rest [ rdf:type rdf:List ;
-                                                                   rdf:first "Examining authority" ;
+                                                                   rdf:first "Examining Authority" ;
                                                                    rdf:rest [ rdf:type rdf:List ;
                                                                               rdf:first "Issuing Authority" ;
                                                                               rdf:rest [ rdf:type rdf:List ;
-                                                                                         rdf:first "Permit issuer" ;
-                                                                                         rdf:rest rdf:nil
+                                                                                         rdf:first "Management Authority" ;
+                                                                                         rdf:rest [ rdf:type rdf:List ;
+                                                                                                    rdf:first "Permit issuer" ;
+                                                                                                    rdf:rest rdf:nil
+                                                                                                  ]
                                                                                        ]
                                                                             ]
                                                                  ]
@@ -2613,8 +2712,22 @@ epermitSignature:signatureStatement rdf:type owl:DatatypeProperty ;
 ###  https://onerecord.iata.org/EpermitSignature#signatureTypeCode
 epermitSignature:signatureTypeCode rdf:type owl:DatatypeProperty ;
                                    rdfs:domain :EpermitSignature ;
-                                   rdfs:range xsd:string ;
-                                   rdfs:comment "Code specifying a type of government action such asinspection, detention, fumigation, security."@en ;
+                                   rdfs:range [ rdf:type rdfs:Datatype ;
+                                                owl:oneOf [ rdf:type rdf:List ;
+                                                            rdf:first "Detention" ;
+                                                            rdf:rest [ rdf:type rdf:List ;
+                                                                       rdf:first "Fumigaton" ;
+                                                                       rdf:rest [ rdf:type rdf:List ;
+                                                                                  rdf:first "Inspection" ;
+                                                                                  rdf:rest [ rdf:type rdf:List ;
+                                                                                             rdf:first "Security" ;
+                                                                                             rdf:rest rdf:nil
+                                                                                           ]
+                                                                                ]
+                                                                     ]
+                                                          ]
+                                              ] ;
+                                   rdfs:comment "Code specifying a type of government action such as inspection, detention, fumigation, security."@en ;
                                    rdfs:label "epermitSignature:signatureTypeCode"@en .
 
 
@@ -2630,7 +2743,7 @@ event:dateTime rdf:type owl:DatatypeProperty ;
 event:eventCode rdf:type owl:DatatypeProperty ;
                 rdfs:domain :Event ;
                 rdfs:range xsd:string ;
-                rdfs:comment "Movement or milestone code. Refer CXML Code List 1.18, e.g. DEP, ARR, FOH, RCS"@en ;
+                rdfs:comment "Movement or milestone code. Can refer to CXML Code List 1.18, e.g. DEP, ARR, FOH, RCS but not restricted to it."@en ;
                 rdfs:label "event:eventCode"@en .
 
 
@@ -2708,7 +2821,7 @@ externalReference:documentName rdf:type owl:DatatypeProperty ;
 externalReference:documentType rdf:type owl:DatatypeProperty ;
                                rdfs:domain :ExternalReference ;
                                rdfs:range xsd:string ;
-                               rdfs:comment "Type of the referenced document . Refer UNEDIFACT 1001  e.g. 740 - Air Waybill"@en ;
+                               rdfs:comment "Type of the referenced document . Can refer UNEDIFACT 1001  e.g. 740 - Air Waybill, but not limited to"@en ;
                                rdfs:label "externalReference:documentType"@en .
 
 
@@ -2758,6 +2871,14 @@ geolocation:longitude rdf:type owl:DatatypeProperty ;
                       rdfs:range xsd:double ;
                       rdfs:comment "Location longitude - Change of data type to string as of version 1.2"@en ;
                       rdfs:label "geolocation:longitude"@en .
+
+
+###  https://onerecord.iata.org/Insurance#nvdIndicator
+insurance:nvdIndicator rdf:type owl:DatatypeProperty ;
+                       rdfs:domain :Insurance ;
+                       rdfs:range xsd:boolean ;
+                       rdfs:comment "When no value is declared for Insurance this field should be completed with the value TRUE otherwise FALSE"@en ;
+                       rdfs:label "insurance:nvdIndicator"@en .
 
 
 ###  https://onerecord.iata.org/IotDevice#associatedObject
@@ -2923,7 +3044,45 @@ liveAnimalsEpermit:specialConditions rdf:type owl:DatatypeProperty ;
 ###  https://onerecord.iata.org/LiveAnimalsEpermit#transactionPurposeCode
 liveAnimalsEpermit:transactionPurposeCode rdf:type owl:DatatypeProperty ;
                                           rdfs:domain :LiveAnimalsEpermit ;
-                                          rdfs:range xsd:string ;
+                                          rdfs:range [ rdf:type rdfs:Datatype ;
+                                                       owl:oneOf [ rdf:type rdf:List ;
+                                                                   rdf:first "B" ;
+                                                                   rdf:rest [ rdf:type rdf:List ;
+                                                                              rdf:first "E" ;
+                                                                              rdf:rest [ rdf:type rdf:List ;
+                                                                                         rdf:first "G" ;
+                                                                                         rdf:rest [ rdf:type rdf:List ;
+                                                                                                    rdf:first "H" ;
+                                                                                                    rdf:rest [ rdf:type rdf:List ;
+                                                                                                               rdf:first "L" ;
+                                                                                                               rdf:rest [ rdf:type rdf:List ;
+                                                                                                                          rdf:first "M" ;
+                                                                                                                          rdf:rest [ rdf:type rdf:List ;
+                                                                                                                                     rdf:first "N" ;
+                                                                                                                                     rdf:rest [ rdf:type rdf:List ;
+                                                                                                                                                rdf:first "P" ;
+                                                                                                                                                rdf:rest [ rdf:type rdf:List ;
+                                                                                                                                                           rdf:first "Q" ;
+                                                                                                                                                           rdf:rest [ rdf:type rdf:List ;
+                                                                                                                                                                      rdf:first "S" ;
+                                                                                                                                                                      rdf:rest [ rdf:type rdf:List ;
+                                                                                                                                                                                 rdf:first "T" ;
+                                                                                                                                                                                 rdf:rest [ rdf:type rdf:List ;
+                                                                                                                                                                                            rdf:first "Z" ;
+                                                                                                                                                                                            rdf:rest rdf:nil
+                                                                                                                                                                                          ]
+                                                                                                                                                                               ]
+                                                                                                                                                                    ]
+                                                                                                                                                         ]
+                                                                                                                                              ]
+                                                                                                                                   ]
+                                                                                                                        ]
+                                                                                                             ]
+                                                                                                  ]
+                                                                                       ]
+                                                                            ]
+                                                                 ]
+                                                     ] ;
                                           rdfs:comment "Code indicating the purpose of the transaction (box 5a)"@en ;
                                           rdfs:label "liveAnimalsEpermit:transactionPurposeCode"@en .
 
@@ -3269,6 +3428,22 @@ piece:loadType rdf:type owl:DatatypeProperty ;
                rdfs:label "piece:loadType"@en .
 
 
+###  https://onerecord.iata.org/Piece#nvdForCarriage
+piece:nvdForCarriage rdf:type owl:DatatypeProperty ;
+                     rdfs:domain :Piece ;
+                     rdfs:range xsd:boolean ;
+                     rdfs:comment "When no value is declared for Carriage, this field may be completed with the value TRUE otherwise FALSE"@en ;
+                     rdfs:label "piece:nvdForCarriage"@en .
+
+
+###  https://onerecord.iata.org/Piece#nvdForCustoms
+piece:nvdForCustoms rdf:type owl:DatatypeProperty ;
+                    rdfs:domain :Piece ;
+                    rdfs:range xsd:boolean ;
+                    rdfs:comment "When no value is declared for Customs, this field may be completed with the value TRUE otherwise FALSE"@en ;
+                    rdfs:label "piece:nvdForCustoms"@en .
+
+
 ###  https://onerecord.iata.org/Piece#packageMarkCoded
 piece:packageMarkCoded rdf:type owl:DatatypeProperty ;
                        rdfs:domain :Piece ;
@@ -3565,8 +3740,13 @@ product:commodityItemNumber rdf:type owl:DatatypeProperty ;
 ###  https://onerecord.iata.org/Product#hsCode
 product:hsCode rdf:type owl:DatatypeProperty ;
                rdfs:domain :Product ;
-               rdfs:range xsd:string ;
-               rdfs:comment "Reference identifying the type of standard code to be used for the Commodity Classification (Brussels Tariff Nomenclature, EU Harmonized System Code, UN Standard International Trade Classification). Mandatory if the commodity code is more than 6 digits"@en ;
+               rdfs:range [ rdf:type rdfs:Datatype ;
+                            owl:onDatatype xsd:string ;
+                            owl:withRestrictions ( [ xsd:minLength "6"
+                                                   ]
+                                                 )
+                          ] ;
+               rdfs:comment "Harmonized Commodity code, refer to hsType used. 6 minimum digits are expected."@en ;
                rdfs:label "product:hsCode"@en .
 
 
@@ -3590,7 +3770,7 @@ product:hsCommodityName rdf:type owl:DatatypeProperty ;
 product:hsType rdf:type owl:DatatypeProperty ;
                rdfs:domain :Product ;
                rdfs:range xsd:string ;
-               rdfs:comment "Issuer of the Commodity Code - e.g. Brussels Tariff Nomenclature, EU Harmonized System Code, UN Standard International Trade, etc."@en ;
+               rdfs:comment "Reference identifying the type of standard code to be used for the Commodity Classification (Brussels Tariff Nomenclature, EU Harmonized System Code, UN Standard International Trade Classification). Mandatory if the commodity code is more than 6 digits"@en ;
                rdfs:label "product:hsType"@en .
 
 
@@ -3718,7 +3898,7 @@ ranges:minimumQuantity rdf:type owl:DatatypeProperty ;
 ranges:rateClassCode rdf:type owl:DatatypeProperty ;
                      rdfs:domain :Ranges ;
                      rdfs:range xsd:string ;
-                     rdfs:comment "Rate class code e.g. Q"@en ;
+                     rdfs:comment "Rate class code e.g. Q. Refer to CXML Code List 1.4 Rate Class Codes"@en ;
                      rdfs:label "ranges:rateClassCode"@en .
 
 
@@ -3726,7 +3906,7 @@ ranges:rateClassCode rdf:type owl:DatatypeProperty ;
 ranges:ratingType rdf:type owl:DatatypeProperty ;
                   rdfs:domain :Ranges ;
                   rdfs:range xsd:string ;
-                  rdfs:comment "rating type - list uldRatingType"@en ;
+                  rdfs:comment "rating type - Refer to CXML Code List 1.44 ULD Charge Codes"@en ;
                   rdfs:label "ranges:ratingType"@en .
 
 
@@ -3746,11 +3926,19 @@ ranges:unitBasis rdf:type owl:DatatypeProperty ;
                  rdfs:label "ranges:unitBasis"@en .
 
 
+###  https://onerecord.iata.org/Ratings#billingChargeIdentifier
+ratings:billingChargeIdentifier rdf:type owl:DatatypeProperty ;
+                                rdfs:domain :Ratings ;
+                                rdfs:range xsd:string ;
+                                rdfs:comment "Billig charge identifiers to be used for CASS. Refer to CargoXML Code List 1.33"@en ;
+                                rdfs:label "ratings:billingChargeIdentifier"@en .
+
+
 ###  https://onerecord.iata.org/Ratings#chargeCode
 ratings:chargeCode rdf:type owl:DatatypeProperty ;
                    rdfs:domain :Ratings ;
                    rdfs:range xsd:string ;
-                   rdfs:comment "Code of the charge e.g. MY, SC, etc."@en ;
+                   rdfs:comment "Charge code, refer to CargoXML Code List 1.1"@en ;
                    rdfs:label "ratings:chargeCode"@en .
 
 
@@ -3767,14 +3955,14 @@ ratings:chargePaymentType rdf:type owl:DatatypeProperty ;
                           rdfs:domain :Ratings ;
                           rdfs:range [ rdf:type rdfs:Datatype ;
                                        owl:oneOf [ rdf:type rdf:List ;
-                                                   rdf:first "P" ;
+                                                   rdf:first "C" ;
                                                    rdf:rest [ rdf:type rdf:List ;
-                                                              rdf:first "S" ;
+                                                              rdf:first "P" ;
                                                               rdf:rest rdf:nil
                                                             ]
                                                  ]
                                      ] ;
-                          rdfs:comment "Indicates if charge is prepaid or collect (S, P)"@en ;
+                          rdfs:comment "Indicates if charge is prepaid or collect (P, C)"@en ;
                           rdfs:label "ratings:chargePaymentType"@en .
 
 
@@ -3784,6 +3972,14 @@ ratings:chargeType rdf:type owl:DatatypeProperty ;
                    rdfs:range xsd:string ;
                    rdfs:comment "Type of charge e.g. Freight, Surcharges, etc."@en ;
                    rdfs:label "ratings:chargeType"@en .
+
+
+###  https://onerecord.iata.org/Ratings#otherChargeCode
+ratings:otherChargeCode rdf:type owl:DatatypeProperty ;
+                        rdfs:domain :Ratings ;
+                        rdfs:range xsd:string ;
+                        rdfs:comment "Refer to CargoXML Code List 1.2 for Other Charges"@en ;
+                        rdfs:label "ratings:otherChargeCode" .
 
 
 ###  https://onerecord.iata.org/Ratings#priceSpecification
@@ -3963,6 +4159,38 @@ schedule:totalTransitTime rdf:type owl:DatatypeProperty ;
                           rdfs:label "schedule:totalTransitTime"@en .
 
 
+###  https://onerecord.iata.org/ScheduledLegs#arrivalDate
+scheduledLegs:arrivalDate rdf:type owl:DatatypeProperty ;
+                          rdfs:domain :ScheduledLegs ;
+                          rdfs:range xsd:dateTime ;
+                          rdfs:comment "Arrival date and time of the leg"@en ;
+                          rdfs:label "scheduledLegs:arrivalDate"@en .
+
+
+###  https://onerecord.iata.org/ScheduledLegs#departureDate
+scheduledLegs:departureDate rdf:type owl:DatatypeProperty ;
+                            rdfs:domain :ScheduledLegs ;
+                            rdfs:range xsd:dateTime ;
+                            rdfs:comment "Departure date and time of the leg"@en ;
+                            rdfs:label "scheduledLegs:departureDate"@en .
+
+
+###  https://onerecord.iata.org/ScheduledLegs#sequenceNumber
+scheduledLegs:sequenceNumber rdf:type owl:DatatypeProperty ;
+                             rdfs:domain :ScheduledLegs ;
+                             rdfs:range xsd:integer ;
+                             rdfs:comment "Sequence number of the leg"@en ;
+                             rdfs:label "scheduledLegs:sequenceNumber"@en .
+
+
+###  https://onerecord.iata.org/ScheduledLegs#transportId
+scheduledLegs:transportId rdf:type owl:DatatypeProperty ;
+                          rdfs:domain :ScheduledLegs ;
+                          rdfs:range xsd:string ;
+                          rdfs:comment "Transport Id of the leg. E.g. Flight number, truck route identifier, etc."@en ;
+                          rdfs:label "scheduledLegs:transportId"@en .
+
+
 ###  https://onerecord.iata.org/SecurityDeclaration#additionalSecurityInformation
 securityDeclaration:additionalSecurityInformation rdf:type owl:DatatypeProperty ;
                                                   rdfs:domain :SecurityDeclaration ;
@@ -3974,8 +4202,30 @@ securityDeclaration:additionalSecurityInformation rdf:type owl:DatatypeProperty 
 ###  https://onerecord.iata.org/SecurityDeclaration#groundsForExemption
 securityDeclaration:groundsForExemption rdf:type owl:DatatypeProperty ;
                                         rdfs:domain :SecurityDeclaration ;
-                                        rdfs:range xsd:string ;
-                                        rdfs:comment "Exemption code - e.g. BIOM- Bio-Medical Samples "@en ;
+                                        rdfs:range [ rdf:type rdfs:Datatype ;
+                                                     owl:oneOf [ rdf:type rdf:List ;
+                                                                 rdf:first "BIOM" ;
+                                                                 rdf:rest [ rdf:type rdf:List ;
+                                                                            rdf:first "DIPL" ;
+                                                                            rdf:rest [ rdf:type rdf:List ;
+                                                                                       rdf:first "LFSM" ;
+                                                                                       rdf:rest [ rdf:type rdf:List ;
+                                                                                                  rdf:first "SMUS" ;
+                                                                                                  rdf:rest [ rdf:type rdf:List ;
+                                                                                                             rdf:first "TRNS" ;
+                                                                                                             rdf:rest rdf:nil
+                                                                                                           ]
+                                                                                                ]
+                                                                                     ]
+                                                                          ]
+                                                               ]
+                                                   ] ;
+                                        rdfs:comment """Exemption code - e.g. BIOM- Bio-Medical Samples 
+SMUS - small undersized shipments MAIL - mail
+BIOM - bio-medical samples
+DIPL - diplomatic bags or diplomatic mail
+LFSM - life-saving materials NUCL - nuclear materials
+TRNS - transfer or transshipment"""@en ;
                                         rdfs:label "securityDeclaration:groundsForExemption"@en .
 
 
@@ -3998,15 +4248,63 @@ securityDeclaration:otherScreeningMethods rdf:type owl:DatatypeProperty ;
 ###  https://onerecord.iata.org/SecurityDeclaration#screeningMethod
 securityDeclaration:screeningMethod rdf:type owl:DatatypeProperty ;
                                     rdfs:domain :SecurityDeclaration ;
-                                    rdfs:range xsd:string ;
-                                    rdfs:comment "Screening methods which have been used to secure the cargo - e.g. EDS- Explosive Detection System  "@en ;
+                                    rdfs:range [ rdf:type rdfs:Datatype ;
+                                                 owl:oneOf [ rdf:type rdf:List ;
+                                                             rdf:first "AOM" ;
+                                                             rdf:rest [ rdf:type rdf:List ;
+                                                                        rdf:first "CMD" ;
+                                                                        rdf:rest [ rdf:type rdf:List ;
+                                                                                   rdf:first "EDD" ;
+                                                                                   rdf:rest [ rdf:type rdf:List ;
+                                                                                              rdf:first "EDS" ;
+                                                                                              rdf:rest [ rdf:type rdf:List ;
+                                                                                                         rdf:first "ETD" ;
+                                                                                                         rdf:rest [ rdf:type rdf:List ;
+                                                                                                                    rdf:first "PHS" ;
+                                                                                                                    rdf:rest [ rdf:type rdf:List ;
+                                                                                                                               rdf:first "VCK" ;
+                                                                                                                               rdf:rest [ rdf:type rdf:List ;
+                                                                                                                                          rdf:first "XRY" ;
+                                                                                                                                          rdf:rest rdf:nil
+                                                                                                                                        ]
+                                                                                                                             ]
+                                                                                                                  ]
+                                                                                                       ]
+                                                                                            ]
+                                                                                 ]
+                                                                      ]
+                                                           ]
+                                               ] ;
+                                    rdfs:comment """Screening methods which have been used to secure the cargo
+PHS – Physical Inspection and/or hand search 
+VCK - Visual check 
+XRY- X-ray equipment 
+EDS - Explosive detection system 
+EDD - Explosive detection dogs
+ETD - Explosive trace detection equipment - particles or vapor 
+CMD - Cargo metal detection
+AOM - Subjected to any other means: this entry should be followed by free text specifying what other mean was used to secure the cargo"""@en ;
                                     rdfs:label "securityDeclaration:screeningMethod"@en .
 
 
 ###  https://onerecord.iata.org/SecurityDeclaration#securityStatus
 securityDeclaration:securityStatus rdf:type owl:DatatypeProperty ;
                                    rdfs:domain :SecurityDeclaration ;
-                                   rdfs:range xsd:string ;
+                                   rdfs:range [ rdf:type rdfs:Datatype ;
+                                                owl:oneOf [ rdf:type rdf:List ;
+                                                            rdf:first "NSC" ;
+                                                            rdf:rest [ rdf:type rdf:List ;
+                                                                       rdf:first "SCO" ;
+                                                                       rdf:rest [ rdf:type rdf:List ;
+                                                                                  rdf:first "SHR" ;
+                                                                                  rdf:rest [ rdf:type rdf:List ;
+                                                                                             rdf:first "SPX" ;
+                                                                                             rdf:rest rdf:nil
+                                                                                           ]
+                                                                                ]
+                                                                     ]
+                                                          ]
+                                              ] ;
                                    rdfs:comment "Security status indicator (CXML 1.103) - e.g. SPX- Cargo Secure for Passenger and All-Cargo Aircraft "@en ;
                                    rdfs:label "securityDeclaration:securityStatus"@en .
 
@@ -4038,8 +4336,34 @@ sensor:sensorSerialNumber rdf:type owl:DatatypeProperty ;
 ###  https://onerecord.iata.org/Sensor#sensorType
 sensor:sensorType rdf:type owl:DatatypeProperty ;
                   rdfs:domain :Sensor ;
-                  rdfs:range xsd:string ;
-                  rdfs:comment "Type of sensor as described in Interactive Cargo RP"@en ;
+                  rdfs:range [ rdf:type rdfs:Datatype ;
+                               owl:oneOf [ rdf:type rdf:List ;
+                                           rdf:first "Accelerometer" ;
+                                           rdf:rest [ rdf:type rdf:List ;
+                                                      rdf:first "Geolocation" ;
+                                                      rdf:rest [ rdf:type rdf:List ;
+                                                                 rdf:first "Humidity" ;
+                                                                 rdf:rest [ rdf:type rdf:List ;
+                                                                            rdf:first "Light" ;
+                                                                            rdf:rest [ rdf:type rdf:List ;
+                                                                                       rdf:first "Pressure" ;
+                                                                                       rdf:rest [ rdf:type rdf:List ;
+                                                                                                  rdf:first "Thermometer" ;
+                                                                                                  rdf:rest [ rdf:type rdf:List ;
+                                                                                                             rdf:first "Tilt" ;
+                                                                                                             rdf:rest [ rdf:type rdf:List ;
+                                                                                                                        rdf:first "Vibration" ;
+                                                                                                                        rdf:rest rdf:nil
+                                                                                                                      ]
+                                                                                                           ]
+                                                                                                ]
+                                                                                     ]
+                                                                          ]
+                                                               ]
+                                                    ]
+                                         ]
+                             ] ;
+                  rdfs:comment "Type of sensor as described in Interactive Cargo Recommended Practice"@en ;
                   rdfs:label "sensor:sensorType"@en .
 
 
@@ -4189,7 +4513,7 @@ transportMeans:vehicleSize rdf:type owl:DatatypeProperty ;
 transportMeans:vehicleType rdf:type owl:DatatypeProperty ;
                            rdfs:domain :TransportMeans ;
                            rdfs:range xsd:string ;
-                           rdfs:comment "Vehicle or container type. Refer UNECE28, e.g. 4.00.0 - Aircraft, type unknown"@en ;
+                           rdfs:comment "Vehicle or container type. Refer UNECE28, e.g. 4.00.0 - Aircraft, type unknown.For Air refer to IATA Standard Schedules Information Manua in section ATA/IATA Aircraft Types"@en ;
                            rdfs:label "transportMeans:vehicleType"@en .
 
 
@@ -4228,8 +4552,41 @@ transportMovement:fuelType rdf:type owl:DatatypeProperty ;
 transportMovement:modeCode rdf:type owl:DatatypeProperty ;
                            rdfs:domain :TransportMovement ,
                                        :TransportSegment ;
-                           rdfs:range xsd:string ;
-                           rdfs:comment "Mode Code"@en ;
+                           rdfs:range [ rdf:type rdfs:Datatype ;
+                                        owl:oneOf [ rdf:type rdf:List ;
+                                                    rdf:first "0" ;
+                                                    rdf:rest [ rdf:type rdf:List ;
+                                                               rdf:first "1" ;
+                                                               rdf:rest [ rdf:type rdf:List ;
+                                                                          rdf:first "2" ;
+                                                                          rdf:rest [ rdf:type rdf:List ;
+                                                                                     rdf:first "3" ;
+                                                                                     rdf:rest [ rdf:type rdf:List ;
+                                                                                                rdf:first "4" ;
+                                                                                                rdf:rest [ rdf:type rdf:List ;
+                                                                                                           rdf:first "5" ;
+                                                                                                           rdf:rest [ rdf:type rdf:List ;
+                                                                                                                      rdf:first "6" ;
+                                                                                                                      rdf:rest [ rdf:type rdf:List ;
+                                                                                                                                 rdf:first "7" ;
+                                                                                                                                 rdf:rest [ rdf:type rdf:List ;
+                                                                                                                                            rdf:first "8" ;
+                                                                                                                                            rdf:rest [ rdf:type rdf:List ;
+                                                                                                                                                       rdf:first "9" ;
+                                                                                                                                                       rdf:rest rdf:nil
+                                                                                                                                                     ]
+                                                                                                                                          ]
+                                                                                                                               ]
+                                                                                                                    ]
+                                                                                                         ]
+                                                                                              ]
+                                                                                   ]
+                                                                        ]
+                                                             ]
+                                                  ]
+                                      ] ;
+                           rdfs:comment """Mode of transport code, refer to UNECE Rec. 19
+https://unece.org/fileadmin/DAM/cefact/recommendations/rec19/rec19_01cf19e.pdf"""@en ;
                            rdfs:label "transportMovement:modeCode"@en .
 
 
@@ -4237,7 +4594,18 @@ transportMovement:modeCode rdf:type owl:DatatypeProperty ;
 transportMovement:modeQualifier rdf:type owl:DatatypeProperty ;
                                 rdfs:domain :TransportMovement ,
                                             :TransportSegment ;
-                                rdfs:range xsd:string ;
+                                rdfs:range [ rdf:type rdfs:Datatype ;
+                                             owl:oneOf [ rdf:type rdf:List ;
+                                                         rdf:first "Main-Carriage" ;
+                                                         rdf:rest [ rdf:type rdf:List ;
+                                                                    rdf:first "On-Carriage" ;
+                                                                    rdf:rest [ rdf:type rdf:List ;
+                                                                               rdf:first "Pre-Carriage" ;
+                                                                               rdf:rest rdf:nil
+                                                                             ]
+                                                                  ]
+                                                       ]
+                                           ] ;
                                 rdfs:comment "Pre-Carriage, Main-Carriage or On-Carriage"@en ;
                                 rdfs:label "transportMovement:modeQualifier"@en .
 
@@ -4432,7 +4800,7 @@ uld:uldSealNumber rdf:type owl:DatatypeProperty ;
 uld:uldTypeCode rdf:type owl:DatatypeProperty ;
                 rdfs:domain :ULD ;
                 rdfs:range xsd:string ;
-                rdfs:comment "Standard Unit Load Device type code e.g. AKE - Certified Container - Contoured"@en ;
+                rdfs:comment "Standard Unit Load Device type code e.g. AKE - Certified Container - Contoured. Refer to IATA ULD Technical Manual"@en ;
                 rdfs:label "uld:uldTypeCode"@en .
 
 
@@ -4461,6 +4829,30 @@ waybill:accountingInformation rdf:type owl:DatatypeProperty ;
                               owl:versionInfo "Added in v1.1"@en .
 
 
+###  https://onerecord.iata.org/Waybill#carrierDeclarationDate
+waybill:carrierDeclarationDate rdf:type owl:DatatypeProperty ;
+                               rdfs:domain :Waybill ;
+                               rdfs:range xsd:dateTime ;
+                               rdfs:comment "Date upon which the certification is made by the carrier"@en ;
+                               rdfs:label "waybill:carrierDeclarationDate"@en .
+
+
+###  https://onerecord.iata.org/Waybill#carrierDeclarationSignature
+waybill:carrierDeclarationSignature rdf:type owl:DatatypeProperty ;
+                                    rdfs:domain :Waybill ;
+                                    rdfs:range xsd:string ;
+                                    rdfs:comment "Contains the authentication of the Carrier"@en ;
+                                    rdfs:label "waybill:carrierDeclarationSignature"@en .
+
+
+###  https://onerecord.iata.org/Waybill#consignorDeclarationSignature
+waybill:consignorDeclarationSignature rdf:type owl:DatatypeProperty ;
+                                      rdfs:domain :Waybill ;
+                                      rdfs:range xsd:string ;
+                                      rdfs:comment "Name of consignor signatory"@en ;
+                                      rdfs:label "waybil:consignorDeclarationSignature" .
+
+
 ###  https://onerecord.iata.org/Waybill#destinationCharges
 waybill:destinationCharges rdf:type owl:DatatypeProperty ;
                            rdfs:domain :Waybill ;
@@ -4473,7 +4865,7 @@ waybill:destinationCharges rdf:type owl:DatatypeProperty ;
 waybill:destinationCurrencyCode rdf:type owl:DatatypeProperty ;
                                 rdfs:domain :Waybill ;
                                 rdfs:range xsd:string ;
-                                rdfs:comment "ISO 3-letter currency code of destination"@en ;
+                                rdfs:comment "ISO 3-letter currency code of destination. Refer to ISO 4217"@en ;
                                 rdfs:label "destinationCurrencyCode"@en .
 
 
@@ -4499,6 +4891,14 @@ waybill:optionalShippingRefNo rdf:type owl:DatatypeProperty ;
                               rdfs:range xsd:string ;
                               rdfs:comment "Optional shipping reference number if any"@en ,
                                            "waybill:optionalShippingRefNo"@en .
+
+
+###  https://onerecord.iata.org/Waybill#originCurrency
+waybill:originCurrency rdf:type owl:DatatypeProperty ;
+                       rdfs:domain :Waybill ;
+                       rdfs:range xsd:string ;
+                       rdfs:comment "ISO alpha 3 Code used to indicate the Origin Currency, refer to ISO 4217 currency codes"@en ;
+                       rdfs:label "waybill:originCurrency" .
 
 
 ###  https://onerecord.iata.org/Waybill#waybillNumber
@@ -4530,7 +4930,7 @@ waybill:waybillPrefix rdf:type owl:DatatypeProperty ;
                                                           ]
                                                         )
                                  ] ;
-                      rdfs:comment "Prefix used for the Waybill Number"@en ;
+                      rdfs:comment "Prefix used for the Waybill Number. Refer to IATA Airlines Codes"@en ;
                       rdfs:label "waybill:waybillPrefix"@en .
 
 
@@ -5183,6 +5583,38 @@ waybill:waybillType rdf:type owl:DatatypeProperty ;
                               [ rdf:type owl:Restriction ;
                                 owl:onProperty bookingtimes:bookingOptionRequest ;
                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty bookingtimes:earliestAcceptanceTime ;
+                                owl:allValuesFrom xsd:dateTime
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty bookingtimes:latestAcceptanceTime ;
+                                owl:allValuesFrom xsd:dateTime
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty bookingtimes:timeOfAvailability ;
+                                owl:allValuesFrom xsd:dateTime
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty bookingtimes:totalTransitTime ;
+                                owl:allValuesFrom xsd:duration
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty bookingtimes:earliestAcceptanceTime ;
+                                owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty bookingtimes:latestAcceptanceTime ;
+                                owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty bookingtimes:timeOfAvailability ;
+                                owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty bookingtimes:totalTransitTime ;
+                                owl:maxCardinality "1"^^xsd:nonNegativeInteger
                               ] ;
               rdfs:comment "Previsouly called Schedule. This object refers to times used for the Booking Option Request (preferences part of the request) or the Booking Option (times sur as LAT where there is a commitment from the carrier)"@en ;
               rdfs:label "BookingTimes"@en .
@@ -5397,6 +5829,22 @@ waybill:waybillType rdf:type owl:DatatypeProperty ;
                                  ] ;
                  rdfs:comment "Product additional details"@en ;
                  rdfs:label "Characteristics"@en .
+
+
+###  https://onerecord.iata.org/CommonObjects
+:CommonObjects rdf:type owl:Class ;
+               rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                 owl:onProperty commonobjects:companyIdentifier ;
+                                 owl:allValuesFrom xsd:string
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty commonobjects:companyIdentifier ;
+                                 owl:minCardinality "1"^^xsd:nonNegativeInteger
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty commonobjects:companyIdentifier ;
+                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                               ] .
 
 
 ###  https://onerecord.iata.org/Company
@@ -5884,6 +6332,24 @@ waybill:waybillType rdf:type owl:DatatypeProperty ;
             rdfs:label "Dimensions"@en .
 
 
+###  https://onerecord.iata.org/EmbeddedObject
+:EmbeddedObject rdf:type owl:Class ;
+                rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                  owl:onProperty embeddedobject:companyIdentifier ;
+                                  owl:allValuesFrom xsd:string
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty embeddedobject:companyIdentifier ;
+                                  owl:minCardinality "1"^^xsd:nonNegativeInteger
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty embeddedobject:companyIdentifier ;
+                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                ] ;
+                rdfs:comment "Embedded Object parent class, containing all common properties for Embedded Object"@en ;
+                rdfs:label "EmbeddedObject"@en .
+
+
 ###  https://onerecord.iata.org/EpermitConsignment
 :EpermitConsignment rdf:type owl:Class ;
                     rdfs:subClassOf :LogisticsObject ,
@@ -6232,6 +6698,14 @@ waybill:waybillType rdf:type owl:DatatypeProperty ;
                            ] ,
                            [ rdf:type owl:Restriction ;
                              owl:onProperty insurance:insuranceShipment ;
+                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty insurance:nvdIndicator ;
+                             owl:allValuesFrom xsd:boolean
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty insurance:nvdIndicator ;
                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
                            ] ;
            rdfs:comment "Insurance details"@en ;
@@ -6686,7 +7160,7 @@ waybill:waybillType rdf:type owl:DatatypeProperty ;
                                    owl:onProperty logisticsObject:companyIdentifier ;
                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                  ] ;
-                 rdfs:comment "Logistics Object prent class, containing all common properties for logistics objects."@en ;
+                 rdfs:comment "Logistics Object parent class, containing all common properties for logistics objects."@en ;
                  rdfs:label "LogisticsObject"@en .
 
 
@@ -7103,10 +7577,6 @@ waybill:waybillType rdf:type owl:DatatypeProperty ;
                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
                        ] ,
                        [ rdf:type owl:Restriction ;
-                         owl:onProperty piece:product ;
-                         owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                       ] ,
-                       [ rdf:type owl:Restriction ;
                          owl:onProperty piece:productionCountry ;
                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
                        ] ,
@@ -7155,6 +7625,14 @@ waybill:waybillType rdf:type owl:DatatypeProperty ;
                          owl:allValuesFrom xsd:string
                        ] ,
                        [ rdf:type owl:Restriction ;
+                         owl:onProperty piece:nvdForCarriage ;
+                         owl:allValuesFrom xsd:boolean
+                       ] ,
+                       [ rdf:type owl:Restriction ;
+                         owl:onProperty piece:nvdForCustoms ;
+                         owl:allValuesFrom xsd:boolean
+                       ] ,
+                       [ rdf:type owl:Restriction ;
                          owl:onProperty piece:packageMarkCoded ;
                          owl:allValuesFrom xsd:string
                        ] ,
@@ -7196,6 +7674,14 @@ waybill:waybillType rdf:type owl:DatatypeProperty ;
                        ] ,
                        [ rdf:type owl:Restriction ;
                          owl:onProperty piece:loadType ;
+                         owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                       ] ,
+                       [ rdf:type owl:Restriction ;
+                         owl:onProperty piece:nvdForCarriage ;
+                         owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                       ] ,
+                       [ rdf:type owl:Restriction ;
+                         owl:onProperty piece:nvdForCustoms ;
                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
                        ] ,
                        [ rdf:type owl:Restriction ;
@@ -7800,6 +8286,10 @@ waybill:waybillType rdf:type owl:DatatypeProperty ;
                            owl:allValuesFrom :Ranges
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty ratings:billingChargeIdentifier ;
+                           owl:allValuesFrom xsd:string
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty ratings:chargeCode ;
                            owl:allValuesFrom xsd:string
                          ] ,
@@ -7813,6 +8303,10 @@ waybill:waybillType rdf:type owl:DatatypeProperty ;
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty ratings:chargeType ;
+                           owl:allValuesFrom xsd:string
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ratings:otherChargeCode ;
                            owl:allValuesFrom xsd:string
                          ] ,
                          [ rdf:type owl:Restriction ;
@@ -7832,6 +8326,10 @@ waybill:waybillType rdf:type owl:DatatypeProperty ;
                            owl:allValuesFrom xsd:double
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty ratings:billingChargeIdentifier ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty ratings:chargeCode ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
@@ -7841,6 +8339,10 @@ waybill:waybillType rdf:type owl:DatatypeProperty ;
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty ratings:chargeType ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ratings:otherChargeCode ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
@@ -7988,6 +8490,10 @@ waybill:waybillType rdf:type owl:DatatypeProperty ;
                            owl:allValuesFrom :BookingOption
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty routing:scheduledLegs ;
+                           owl:allValuesFrom :ScheduledLegs
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty routing:bookingOption ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
@@ -8083,6 +8589,60 @@ waybill:waybillType rdf:type owl:DatatypeProperty ;
           rdfs:comment "Scheduling details"@en ;
           rdfs:label "Schedule"@en ;
           owl:deprecated "true"@en .
+
+
+###  https://onerecord.iata.org/ScheduledLegs
+:ScheduledLegs rdf:type owl:Class ;
+               rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                 owl:onProperty scheduledLegs:arrivalLocation ;
+                                 owl:allValuesFrom :Location
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty scheduledLegs:departureLocation ;
+                                 owl:allValuesFrom :Location
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty scheduledLegs:arrivalLocation ;
+                                 owl:minCardinality "1"^^xsd:nonNegativeInteger
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty scheduledLegs:departureLocation ;
+                                 owl:minCardinality "1"^^xsd:nonNegativeInteger
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty scheduledLegs:arrivalLocation ;
+                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty scheduledLegs:departureLocation ;
+                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty scheduledLegs:arrivalDate ;
+                                 owl:allValuesFrom xsd:dateTime
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty scheduledLegs:departureDate ;
+                                 owl:allValuesFrom xsd:dateTime
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty scheduledLegs:sequenceNumber ;
+                                 owl:allValuesFrom xsd:integer
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty scheduledLegs:transportId ;
+                                 owl:allValuesFrom xsd:string
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty scheduledLegs:sequenceNumber ;
+                                 owl:minCardinality "1"^^xsd:nonNegativeInteger
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty scheduledLegs:sequenceNumber ;
+                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                               ] ;
+               rdfs:comment "Scheduled Legs class to be used to identify legs. Can be used with Booking Option Request as an indicator of preferred Routing or with Booking Option when a carrier proposes a specific Routing."@en ;
+               rdfs:label "ScheduledLegs" .
 
 
 ###  https://onerecord.iata.org/SecurityDeclaration
@@ -9089,8 +9649,16 @@ waybill:waybillType rdf:type owl:DatatypeProperty ;
                            owl:allValuesFrom :Booking
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty waybill:carrierDeclarationPlace ;
+                           owl:allValuesFrom :Location
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty waybill:containedWaybills ;
                            owl:allValuesFrom :Waybill
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty waybill:carrierDeclarationPlace ;
+                           owl:minCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty waybill:booking ;
@@ -9101,7 +9669,23 @@ waybill:waybillType rdf:type owl:DatatypeProperty ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty waybill:carrierDeclarationPlace ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty waybill:accountingInformation ;
+                           owl:allValuesFrom xsd:string
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty waybill:carrierDeclarationDate ;
+                           owl:allValuesFrom xsd:dateTime
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty waybill:carrierDeclarationSignature ;
+                           owl:allValuesFrom xsd:string
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty waybill:consignorDeclarationSignature ;
                            owl:allValuesFrom xsd:string
                          ] ,
                          [ rdf:type owl:Restriction ;
@@ -9125,6 +9709,10 @@ waybill:waybillType rdf:type owl:DatatypeProperty ;
                            owl:allValuesFrom xsd:string
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty waybill:originCurrency ;
+                           owl:allValuesFrom xsd:string
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty waybill:waybillNumber ;
                            owl:allValuesFrom xsd:string
                          ] ,
@@ -9137,12 +9725,33 @@ waybill:waybillType rdf:type owl:DatatypeProperty ;
                            owl:allValuesFrom xsd:string
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty waybill:carrierDeclarationDate ;
+                           owl:minCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty waybill:carrierDeclarationSignature ;
+                           owl:minCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty waybill:waybillNumber ;
                            owl:minCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty waybill:accountingInformation ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty waybill:carrierDeclarationDate ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty waybill:carrierDeclarationSignature ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty waybill:consignorDeclarationSignature ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onDataRange owl:thing
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty waybill:destinationCurrencyCode ;
@@ -9158,6 +9767,10 @@ waybill:waybillType rdf:type owl:DatatypeProperty ;
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty waybill:optionalShippingRefNo ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty waybill:originCurrency ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
@@ -9190,10 +9803,10 @@ waybill:waybillType rdf:type owl:DatatypeProperty ;
 [ owl:maxCardinality "1"^^xsd:nonNegativeInteger
 ] .
 
-[ owl:maxCardinality "1"^^xsd:nonNegativeInteger
+[ owl:minCardinality "1"^^xsd:nonNegativeInteger
  ] .
 
-[ owl:minCardinality "1"^^xsd:nonNegativeInteger
+[ owl:maxCardinality "1"^^xsd:nonNegativeInteger
  ] .
 
 #################################################################


### PR DESCRIPTION
Version 1.2.0 of the ontology which is the beta for Version 2.0.0 to come.

Included changes are:
Version 1.2.0 (beta for Version 2.0.0 to come)
- Change of ratings:chargePaymentType values from (S,P) to (C,P) as it was a mistake
- Added data properties on BookingTimes
- Removed Piece#product max cardinality
- Added Waybill#originCurrency
- Added Piece#nvdForCarriage and Piece#nvdForCustoms
- Added Insurance#nvdIndicator
- Added Waybill#consignorDeclarationSignature / carrierDeclarationPlace / carrierDeclarationDate / carrierDeclarationSignature
- Improved Ratings objects for Billing&Settlement purposes with new properties
- Added CommonObjects class and EmbeddedObject class
- Addded ScheduledLegs object and Routing#scheduledLegs