### PR TITLE
Update IATA-1R-DM-Ontology.ttl

### DIFF
--- a/working_draft/ontology/IATA-1R-DM-Ontology.ttl
+++ b/working_draft/ontology/IATA-1R-DM-Ontology.ttl
@@ -7316,10 +7316,6 @@ waybill:waybillType rdf:type owl:DatatypeProperty ;
                          owl:minCardinality "1"^^xsd:nonNegativeInteger
                        ] ,
                        [ rdf:type owl:Restriction ;
-                         owl:onProperty piece:volumetricWeight ;
-                         owl:minCardinality "1"^^xsd:nonNegativeInteger
-                       ] ,
-                       [ rdf:type owl:Restriction ;
                          owl:onProperty piece:dimensions ;
                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
                        ] ,


### PR DESCRIPTION
Why is volumetric weight mandatory for Piece? It shouldn´t be!