### PR TITLE
DM 3.0.0 RC5

### DIFF
--- a/working_draft/ontology/IATA-1R-CCL-Ontology.ttl
+++ b/working_draft/ontology/IATA-1R-CCL-Ontology.ttl
@@ -1,0 +1,11013 @@
+@prefix : <https://onerecord.iata.org/ns/coreCodeLists#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix terms: <http://purl.org/dc/terms/> .
+@base <https://onerecord.iata.org/ns/coreCodeLists> .
+
+<https://onerecord.iata.org/ns/coreCodeLists> rdf:type owl:Ontology ;
+                                               owl:versionIRI <https://onerecord.iata.org/ns/coreCodeLists/0.0.3> ;
+                                               dc:description "ONE Record core code lists, described using W3C RDF Schema and the Web Ontology Language."@en ;
+                                               dc:title "ONE Record Core Code Lists Ontology"@en ;
+                                               terms:abstract "The core code lists ontology of the ONE Record standard covers the code lists used in the standard, currently corresponding to cXML code lists, IATA Resolutions, CITES, UN recommended codes and 1R-specific codes."@en ;
+                                               terms:modified "31-08-2023" ;
+                                               terms:title "ONE Record Core Code List Ontology"@en ;
+                                               rdfs:comment """Attention: Note that each Individual has a code list-specific prefix in their IRI which is not shown in the labels (default view in tools such as Protege). 
+
+Furthermore, DGR and Security Status codes have the respective DangerousGoodsCode and SecurityStatus prefix, even though they are part of the Special Handling Code List, too."""@en ,
+                                                            """Details availalble on GitHub https://github.com/IATA-Cargo/ONE-Record
+Version 0.0.1
+- Initial version covering 20 restricted code lists and 2 open code lists*, predominantly based on cXML 2023
+* Open code lists can be instanced to add own, additional codes in ONE Record using the inherited properties from CodeListElement
+* Restricted code lists are defined classes and cannot be expanded
+
+Version 0.0.2
+- Inclusion of 10 further restricted code lists and one open code list, covering predominantly DGR and CITES
+
+Version 0.0.3
+- Inclusion of MCD code lists, including CommodityCode
+- Inclusion of open currency code list
+- GLAS and Automotive parts in CommodityCode list need to be clearified still!"""@en ;
+                                               rdfs:isDefinedBy "https://www.iata.org/one-record/"^^xsd:anyURI ;
+                                               rdfs:label "ONE Record Core Code Lists Ontology"@en ;
+                                               owl:versionInfo "0.0.3"@en .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://purl.org/dc/elements/1.1/description
+dc:description rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/title
+dc:title rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/abstract
+terms:abstract rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/modified
+terms:modified rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/title
+terms:title rdf:type owl:AnnotationProperty .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  https://onerecord.iata.org/ns/coreCodeLists#AWBUseIndicator
+:AWBUseIndicator rdf:type owl:Class ;
+                 owl:equivalentClass [ rdf:type owl:Class ;
+                                       owl:oneOf ( :AWBUseIndicator_R
+                                                   :AWBUseIndicator_S
+                                                   :AWBUseIndicator_V
+                                                 )
+                                     ] ;
+                 rdfs:comment "Restricted code list to describe Revenue, Service and Void AWBs based on CASS 2.0"@en ;
+                 rdfs:label "AWBUseIndicator"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#AircraftPossibilityCode
+:AircraftPossibilityCode rdf:type owl:Class ;
+                         owl:equivalentClass [ rdf:type owl:Class ;
+                                               owl:oneOf ( :AircraftPossibilityCode_BBF
+                                                           :AircraftPossibilityCode_BBQ
+                                                           :AircraftPossibilityCode_BBV
+                                                           :AircraftPossibilityCode_LLF
+                                                           :AircraftPossibilityCode_LLJ
+                                                           :AircraftPossibilityCode_LLQ
+                                                           :AircraftPossibilityCode_LLV
+                                                           :AircraftPossibilityCode_LPF
+                                                           :AircraftPossibilityCode_LPJ
+                                                           :AircraftPossibilityCode_LPQ
+                                                           :AircraftPossibilityCode_LPV
+                                                           :AircraftPossibilityCode_PPF
+                                                           :AircraftPossibilityCode_PPJ
+                                                           :AircraftPossibilityCode_PPQ
+                                                           :AircraftPossibilityCode_PPV
+                                                         )
+                                             ] ;
+                         rdfs:comment "Restricted code list corresponding to cXML code list 1.46 Aircraft Possibility Codes"@en ;
+                         rdfs:label "AircraftPossibilityCode"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#BasicRateClassCode
+:BasicRateClassCode rdf:type owl:Class ;
+                    owl:equivalentClass [ rdf:type owl:Class ;
+                                          owl:oneOf ( :RateClassCode_C
+                                                      :RateClassCode_M
+                                                      :RateClassCode_N
+                                                      :RateClassCode_Q
+                                                      :RateClassCode_U
+                                                    )
+                                        ] ;
+                    rdfs:comment "Restricted sub-code list corresponding to elements of cXML code list 1.4 Rate Class Codes"@en ,
+                                 "Source: CSC Resolutions Manual, 25th Edition, Resolution 600a"@en ;
+                    rdfs:label "BasicRateClassCode"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeCode
+:ChargeCode rdf:type owl:Class ;
+            owl:equivalentClass [ rdf:type owl:Class ;
+                                  owl:oneOf ( :ChargeCode_CA
+                                              :ChargeCode_CB
+                                              :ChargeCode_CC
+                                              :ChargeCode_CE
+                                              :ChargeCode_CG
+                                              :ChargeCode_CH
+                                              :ChargeCode_CM
+                                              :ChargeCode_CP
+                                              :ChargeCode_CX
+                                              :ChargeCode_CZ
+                                              :ChargeCode_NC
+                                              :ChargeCode_NG
+                                              :ChargeCode_NP
+                                              :ChargeCode_NT
+                                              :ChargeCode_NX
+                                              :ChargeCode_NZ
+                                              :ChargeCode_PC
+                                              :ChargeCode_PD
+                                              :ChargeCode_PE
+                                              :ChargeCode_PF
+                                              :ChargeCode_PG
+                                              :ChargeCode_PH
+                                              :ChargeCode_PP
+                                              :ChargeCode_PX
+                                              :ChargeCode_PZ
+                                            )
+                                ] ;
+            rdfs:comment "Restricted code list corresponding to cXML code list 1.1 Charge Codes"@en ,
+                         "Source: CSC Resolutions Manual, 25th Edition, Resolution 600a"@en ;
+            rdfs:label "ChargeCode"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeIdentifier
+:ChargeIdentifier rdf:type owl:Class ;
+                  owl:equivalentClass [ rdf:type owl:Class ;
+                                        owl:oneOf ( :ChargeIdentifier_CN
+                                                    :ChargeIdentifier_CO
+                                                    :ChargeIdentifier_CT
+                                                    :ChargeIdentifier_IN
+                                                    :ChargeIdentifier_NI
+                                                    :ChargeIdentifier_OA
+                                                    :ChargeIdentifier_OC
+                                                    :ChargeIdentifier_SI
+                                                    :ChargeIdentifier_TX
+                                                    :ChargeIdentifier_VC
+                                                    :ChargeIdentifier_WT
+                                                  )
+                                      ] ;
+                  rdfs:comment "Restricted code list corresponding to cXML code list 1.33 Charge Identifiers"@en ;
+                  rdfs:label "ChargeIdentifier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode
+:CommodityCode rdf:type owl:Class ;
+               owl:equivalentClass [ rdf:type owl:Class ;
+                                     owl:oneOf ( <<https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Portuguese_Podengo Pequeno>
+                                                 :CommodityCode_CHEM
+                                                 :CommodityCode_CHEM_CDGR
+                                                 :CommodityCode_CHEM_CLNG
+                                                 :CommodityCode_CHEM_CNDG
+                                                 :CommodityCode_CHEM_CNMD
+                                                 :CommodityCode_CHEM_COSM
+                                                 :CommodityCode_CHEM_COSM_COSD
+                                                 :CommodityCode_CHEM_COSM_PERF
+                                                 :CommodityCode_CHEM_DGRG
+                                                 :CommodityCode_CHEM_DGRG_EXPL
+                                                 :CommodityCode_CHEM_DICE
+                                                 :CommodityCode_CHEM_PAIN
+                                                 :CommodityCode_CHEM_PETRO
+                                                 :CommodityCode_CHEM_RADA
+                                                 :CommodityCode_CHEM_REAG
+                                                 :CommodityCode_CONS
+                                                 :CommodityCode_CONS_CMPY
+                                                 :CommodityCode_CONS_CWRE
+                                                 :CommodityCode_CONS_DIPL
+                                                 :CommodityCode_CONS_EXHB
+                                                 :CommodityCode_CONS_FRNT
+                                                 :CommodityCode_CONS_GLAS
+                                                 :CommodityCode_CONS_HAID
+                                                 :CommodityCode_CONS_HHGD
+                                                 :CommodityCode_CONS_HRSE
+                                                 :CommodityCode_CONS_HSER
+                                                 :CommodityCode_CONS_OFSP
+                                                 :CommodityCode_CONS_PERS
+                                                 :CommodityCode_CONS_SPEC
+                                                 :CommodityCode_CONS_SPRT
+                                                 :CommodityCode_CONS_TOYS
+                                                 :CommodityCode_CONS_UBAG
+                                                 :CommodityCode_ELEC
+                                                 :CommodityCode_ELEC_AVEQ
+                                                 :CommodityCode_ELEC_CALC
+                                                 :CommodityCode_ELEC_CMPT
+                                                 :CommodityCode_ELEC_CPRT
+                                                 :CommodityCode_ELEC_ECOM
+                                                 :CommodityCode_ELEC_EEQP
+                                                 :CommodityCode_ELEC_EGDS
+                                                 :CommodityCode_ELEC_ELQP
+                                                 :CommodityCode_ELEC_OFEQ
+                                                 :CommodityCode_ELEC_QUAN
+                                                 :CommodityCode_ELEC_TELC
+                                                 :CommodityCode_FLWR
+                                                 :CommodityCode_FLWR_FLWR
+                                                 :CommodityCode_FLWR_FLWR_CFLW
+                                                 :CommodityCode_FLWR_FLWR_TFLW
+                                                 :CommodityCode_FLWR_FLWR_TULP
+                                                 :CommodityCode_FLWR_FMNT
+                                                 :CommodityCode_FLWR_HERBS
+                                                 :CommodityCode_FLWR_PLNT
+                                                 :CommodityCode_FLWR_PLNT_APLN
+                                                 :CommodityCode_FLWR_PLNT_BULB
+                                                 :CommodityCode_FLWR_PLNT_MPLN
+                                                 :CommodityCode_FLWR_PLNT_TPLN
+                                                 :CommodityCode_FLWR_SEED
+                                                 :CommodityCode_FOOD
+                                                 :CommodityCode_FOOD_BVRG
+                                                 :CommodityCode_FOOD_BVRG_BEER
+                                                 :CommodityCode_FOOD_BVRG_COFY
+                                                 :CommodityCode_FOOD_BVRG_TEA
+                                                 :CommodityCode_FOOD_BVRG_WINE
+                                                 :CommodityCode_FOOD_CERE
+                                                 :CommodityCode_FOOD_CERE_BRED
+                                                 :CommodityCode_FOOD_CERE_CAKE
+                                                 :CommodityCode_FOOD_DARY
+                                                 :CommodityCode_FOOD_DARY_CHSE
+                                                 :CommodityCode_FOOD_DARY_EGGS
+                                                 :CommodityCode_FOOD_DARY_ICEC
+                                                 :CommodityCode_FOOD_FISH
+                                                 :CommodityCode_FOOD_FISH_ALBA
+                                                 :CommodityCode_FOOD_FISH_CAVR
+                                                 :CommodityCode_FOOD_FISH_FFSH
+                                                 :CommodityCode_FOOD_FISH_FRZF
+                                                 :CommodityCode_FOOD_FISH_FRZS
+                                                 :CommodityCode_FOOD_FISH_HAKE
+                                                 :CommodityCode_FOOD_FISH_LOBS
+                                                 :CommodityCode_FOOD_FISH_REPA
+                                                 :CommodityCode_FOOD_FISH_SFIN
+                                                 :CommodityCode_FOOD_FISH_SFSH
+                                                 :CommodityCode_FOOD_FISH_SHRI
+                                                 :CommodityCode_FOOD_FISH_SLMN
+                                                 :CommodityCode_FOOD_FISH_TUNA
+                                                 :CommodityCode_FOOD_FRTV
+                                                 :CommodityCode_FOOD_FRTV_APPL
+                                                 :CommodityCode_FOOD_FRTV_ASPA
+                                                 :CommodityCode_FOOD_FRTV_AVOC
+                                                 :CommodityCode_FOOD_FRTV_BANA
+                                                 :CommodityCode_FOOD_FRTV_BEAN
+                                                 :CommodityCode_FOOD_FRTV_BERR
+                                                 :CommodityCode_FOOD_FRTV_CHER
+                                                 :CommodityCode_FOOD_FRTV_CMBR
+                                                 :CommodityCode_FOOD_FRTV_DURI
+                                                 :CommodityCode_FOOD_FRTV_GARL
+                                                 :CommodityCode_FOOD_FRTV_GRAP
+                                                 :CommodityCode_FOOD_FRTV_LITC
+                                                 :CommodityCode_FOOD_FRTV_MANG
+                                                 :CommodityCode_FOOD_FRTV_MLNS
+                                                 :CommodityCode_FOOD_FRTV_MUSH
+                                                 :CommodityCode_FOOD_FRTV_PEPP
+                                                 :CommodityCode_FOOD_FRTV_PINE
+                                                 :CommodityCode_FOOD_FRTV_PPYA
+                                                 :CommodityCode_FOOD_FRTV_PROD
+                                                 :CommodityCode_FOOD_FRTV_STRW
+                                                 :CommodityCode_FOOD_FRTV_TOMA
+                                                 :CommodityCode_FOOD_MEAT
+                                                 :CommodityCode_FOOD_MEAT_BEEF
+                                                 :CommodityCode_FOOD_MEAT_DRIM
+                                                 :CommodityCode_FOOD_MEAT_FRZM
+                                                 :CommodityCode_FOOD_MEAT_GOSL
+                                                 :CommodityCode_FOOD_MEAT_GUTS
+                                                 :CommodityCode_FOOD_MEAT_HRSP
+                                                 :CommodityCode_FOOD_MEAT_MEAT
+                                                 :CommodityCode_FOOD_MEAT_PORK
+                                                 :CommodityCode_FOOD_MEAT_SAUS
+                                                 :CommodityCode_FOOD_PERI
+                                                 :CommodityCode_FOOD_STUF
+                                                 :CommodityCode_FOOD_STUF_CATE
+                                                 :CommodityCode_FOOD_STUF_CHOC
+                                                 :CommodityCode_FOOD_STUF_DFRU
+                                                 :CommodityCode_FOOD_STUF_MPWD
+                                                 :CommodityCode_FOOD_STUF_NUTS
+                                                 :CommodityCode_FOOD_STUF_OOIL
+                                                 :CommodityCode_FOOD_STUF_SPCE
+                                                 :CommodityCode_FOOD_TBCO
+                                                 :CommodityCode_FOOD_TBCO_CGRT
+                                                 :CommodityCode_FOOD_TBCO_CIGA
+                                                 :CommodityCode_GENE
+                                                 :CommodityCode_HUMR
+                                                 :CommodityCode_HUMR_HUMB
+                                                 :CommodityCode_HUMR_HUMC
+                                                 :CommodityCode_LIVE
+                                                 :CommodityCode_LIVE_BRDH
+                                                 :CommodityCode_LIVE_BRDH_BIRD
+                                                 :CommodityCode_LIVE_BRDH_CHIC
+                                                 :CommodityCode_LIVE_BRDH_DUCK
+                                                 :CommodityCode_LIVE_BRDH_HEGG
+                                                 :CommodityCode_LIVE_BRDH_OSTR
+                                                 :CommodityCode_LIVE_BRDH_PARR
+                                                 :CommodityCode_LIVE_BRDH_TRKY
+                                                 :CommodityCode_LIVE_INSC
+                                                 :CommodityCode_LIVE_INSC_BEES
+                                                 :CommodityCode_LIVE_LFSH
+                                                 :CommodityCode_LIVE_LFSH_EELS
+                                                 :CommodityCode_LIVE_LFSH_KOIF
+                                                 :CommodityCode_LIVE_LFSH_TRPF
+                                                 :CommodityCode_LIVE_MLKS
+                                                 :CommodityCode_LIVE_MLKS_LUGW
+                                                 :CommodityCode_LIVE_MLKS_SNAI
+                                                 :CommodityCode_LIVE_MMLS
+                                                 :CommodityCode_LIVE_MMLS_CATL
+                                                 :CommodityCode_LIVE_MMLS_CATS
+                                                 :CommodityCode_LIVE_MMLS_CATS_Abyssinian
+                                                 :CommodityCode_LIVE_MMLS_CATS_American_Bobtail
+                                                 :CommodityCode_LIVE_MMLS_CATS_American_Curl
+                                                 :CommodityCode_LIVE_MMLS_CATS_American_Keuda
+                                                 :CommodityCode_LIVE_MMLS_CATS_American_Lynx
+                                                 :CommodityCode_LIVE_MMLS_CATS_American_Polydactyl
+                                                 :CommodityCode_LIVE_MMLS_CATS_American_Shorthair
+                                                 :CommodityCode_LIVE_MMLS_CATS_American_Wirehair
+                                                 :CommodityCode_LIVE_MMLS_CATS_Asian
+                                                 :CommodityCode_LIVE_MMLS_CATS_Australian_Mist
+                                                 :CommodityCode_LIVE_MMLS_CATS_Balinese
+                                                 :CommodityCode_LIVE_MMLS_CATS_Bengal
+                                                 :CommodityCode_LIVE_MMLS_CATS_Birman
+                                                 :CommodityCode_LIVE_MMLS_CATS_Bombay
+                                                 :CommodityCode_LIVE_MMLS_CATS_Bristol
+                                                 :CommodityCode_LIVE_MMLS_CATS_British_Shorthair
+                                                 :CommodityCode_LIVE_MMLS_CATS_Burmese
+                                                 :CommodityCode_LIVE_MMLS_CATS_California_Spangled
+                                                 :CommodityCode_LIVE_MMLS_CATS_Chartreux
+                                                 :CommodityCode_LIVE_MMLS_CATS_Chausie
+                                                 :CommodityCode_LIVE_MMLS_CATS_Chinese_Harlequin
+                                                 :CommodityCode_LIVE_MMLS_CATS_Color_Point_Shorthair
+                                                 :CommodityCode_LIVE_MMLS_CATS_Copper
+                                                 :CommodityCode_LIVE_MMLS_CATS_Cornish_Rex
+                                                 :CommodityCode_LIVE_MMLS_CATS_Cymric
+                                                 :CommodityCode_LIVE_MMLS_CATS_Desert_Lynx
+                                                 :CommodityCode_LIVE_MMLS_CATS_Devon_Rex
+                                                 :CommodityCode_LIVE_MMLS_CATS_Donskoy
+                                                 :CommodityCode_LIVE_MMLS_CATS_Egyptian_Mau
+                                                 :CommodityCode_LIVE_MMLS_CATS_Exotic_Shorthair
+                                                 :CommodityCode_LIVE_MMLS_CATS_Havana
+                                                 :CommodityCode_LIVE_MMLS_CATS_Highland_Lynx
+                                                 :CommodityCode_LIVE_MMLS_CATS_Himalayan
+                                                 :CommodityCode_LIVE_MMLS_CATS_Japanese_Bobtail
+                                                 :CommodityCode_LIVE_MMLS_CATS_Javanese
+                                                 :CommodityCode_LIVE_MMLS_CATS_Korat
+                                                 :CommodityCode_LIVE_MMLS_CATS_LaPerm
+                                                 :CommodityCode_LIVE_MMLS_CATS_Maine_Coon
+                                                 :CommodityCode_LIVE_MMLS_CATS_Manx
+                                                 :CommodityCode_LIVE_MMLS_CATS_Mojave_Spotted
+                                                 :CommodityCode_LIVE_MMLS_CATS_Munchkin
+                                                 :CommodityCode_LIVE_MMLS_CATS_Niebelung
+                                                 :CommodityCode_LIVE_MMLS_CATS_Norwegian_Forest
+                                                 :CommodityCode_LIVE_MMLS_CATS_Ocicat
+                                                 :CommodityCode_LIVE_MMLS_CATS_Ojos_Azules
+                                                 :CommodityCode_LIVE_MMLS_CATS_Oriental
+                                                 :CommodityCode_LIVE_MMLS_CATS_Pantherette
+                                                 :CommodityCode_LIVE_MMLS_CATS_Persian
+                                                 :CommodityCode_LIVE_MMLS_CATS_Peterbald
+                                                 :CommodityCode_LIVE_MMLS_CATS_Pixiebob
+                                                 :CommodityCode_LIVE_MMLS_CATS_Ragamuffin
+                                                 :CommodityCode_LIVE_MMLS_CATS_Ragdoll
+                                                 :CommodityCode_LIVE_MMLS_CATS_Russian_Blue
+                                                 :CommodityCode_LIVE_MMLS_CATS_Safari
+                                                 :CommodityCode_LIVE_MMLS_CATS_Savannah
+                                                 :CommodityCode_LIVE_MMLS_CATS_Scottish_Fold
+                                                 :CommodityCode_LIVE_MMLS_CATS_Selkirk_Rex
+                                                 :CommodityCode_LIVE_MMLS_CATS_Serengeti
+                                                 :CommodityCode_LIVE_MMLS_CATS_Siamese
+                                                 :CommodityCode_LIVE_MMLS_CATS_Siberian
+                                                 :CommodityCode_LIVE_MMLS_CATS_Singapura
+                                                 :CommodityCode_LIVE_MMLS_CATS_Snowshoe
+                                                 :CommodityCode_LIVE_MMLS_CATS_Somali
+                                                 :CommodityCode_LIVE_MMLS_CATS_Sphynx
+                                                 :CommodityCode_LIVE_MMLS_CATS_Tiffany
+                                                 :CommodityCode_LIVE_MMLS_CATS_Tonkinese
+                                                 :CommodityCode_LIVE_MMLS_CATS_Traditional_Siamese
+                                                 :CommodityCode_LIVE_MMLS_CATS_Turkish_Angora
+                                                 :CommodityCode_LIVE_MMLS_CATS_Turkish_Van
+                                                 :CommodityCode_LIVE_MMLS_CATS_Vienna_Woods
+                                                 :CommodityCode_LIVE_MMLS_CATS_Viverral_Hybrid_Cat
+                                                 :CommodityCode_LIVE_MMLS_CATS_York_Chocolate
+                                                 :CommodityCode_LIVE_MMLS_DOGS
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Affenpinscher
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Afghan_Hound
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Airedale_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Akita
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Alangu_Mastiff
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Alano
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Alaskan_Malamute
+                                                 :CommodityCode_LIVE_MMLS_DOGS_American_Bulldog
+                                                 :CommodityCode_LIVE_MMLS_DOGS_American_Bully
+                                                 :CommodityCode_LIVE_MMLS_DOGS_American_Cocker_Spaniel
+                                                 :CommodityCode_LIVE_MMLS_DOGS_American_English_Coonhound
+                                                 :CommodityCode_LIVE_MMLS_DOGS_American_Eskimo_Dog_Miniature
+                                                 :CommodityCode_LIVE_MMLS_DOGS_American_Eskimo_Dog_Standard
+                                                 :CommodityCode_LIVE_MMLS_DOGS_American_Eskimo_Dog_Toy
+                                                 :CommodityCode_LIVE_MMLS_DOGS_American_Foxhound
+                                                 :CommodityCode_LIVE_MMLS_DOGS_American_Hairless_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_American_Pit_Bull_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_American_Staffordshire_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_American_Water_Spaniel
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Anatolian_Shepherd_Dog
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Argentinian_Mastiff
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Aussiedoodle
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Australian_Cattle_Dog
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Australian_Shepherd
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Australian_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Ba_Shar_Basset_Hound_Shar_pei_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Basenji
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Basset_Hound
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Beagle
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Bearded_Collie
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Beauceron
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Bedlington_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Belgian_Malinois
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Belgian_Sheepdog
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Belgian_Tervuren
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Bergamasco
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Berger_Picard
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Bernedoodle
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Bernese_Mountain_Dog
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Bichon_Frise
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Black_Russian_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Black_and_Tan_Coonhound
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Bloodhound
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Bluetick_Coonhound
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Boerboel
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Border_Collie
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Border_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Borzoi
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Boston_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Bouvier_des_Flandres
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Boweimar_Boxer_Weimaraner_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Boxer
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Boykin_Spaniel
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Brazilian_Mastiff
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Briard
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Brittany
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Brussels_Griffon
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Bull_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Bull_Terrier_Miniature
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Bulldog
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Bulli_Kutta
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Bullmastiff
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Bully_Kutta_Mastiff_breed
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Cairn_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Campeiro_Bulldog_Brazilian_Bulldog
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Canaan_Dog
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Canary_Mastiff
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Cane_Corso
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Cardigan_Welsh_Corgi
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Catahoula_Bulldog_Catahoula_Leopard_Bulldog
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Cavachon_King_Charles_Spaniel_Bichon_Frise
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Cavalier_King_Charles_Spaniel
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Cavapoo_Cavalier_King_Charles_Spaniel_Poodle
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Cesky_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Chesapeake_Bay_Retriever
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Chihuahua
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Chinese_Crested_Dog
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Chinese_Pug
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Chinese_Shar_Pei
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Chinook
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Chipin_Chihuahua_Minature_Pinscher_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Chiweenie_Chihuahua_Dachshund_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Chorkie_Chihuahua_Yorkshire_Terrier_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Chow_Chow
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Chow_Pei_Chow_Chow_Shar_Pei_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Cirneco_dell_Etna
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Clumber_Spaniel
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Cockapoo_Cocker_Spaniel_Poodle_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Cocker_Spaniel
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Collie
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Coton_de_Tulear
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Curly_Coated_Retriever
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Dachshund
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Dalmatian
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Dandie_Dinmont_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Doberman_Pinscher
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Dogo_Argentino
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Dogue_de_Bordeaux
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Doxiepoo_Dachshund_Poodle_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Dutch_Pug
+                                                 :CommodityCode_LIVE_MMLS_DOGS_English_Bulldog
+                                                 :CommodityCode_LIVE_MMLS_DOGS_English_Cocker_Spaniel
+                                                 :CommodityCode_LIVE_MMLS_DOGS_English_Foxhound
+                                                 :CommodityCode_LIVE_MMLS_DOGS_English_Mastiff
+                                                 :CommodityCode_LIVE_MMLS_DOGS_English_Setter
+                                                 :CommodityCode_LIVE_MMLS_DOGS_English_Springer_Spaniel
+                                                 :CommodityCode_LIVE_MMLS_DOGS_English_Toy_Spaniel
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Entlebucher_Mountain_Dog
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Eurasier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Field_Spaniel
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Fila_Brasileiro_Brazilian_Mastiff
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Finnish_Lapphund
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Finnish_Spitz
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Flat_Coated_Retriever
+                                                 :CommodityCode_LIVE_MMLS_DOGS_French_Bulldog
+                                                 :CommodityCode_LIVE_MMLS_DOGS_French_Mastiff
+                                                 :CommodityCode_LIVE_MMLS_DOGS_German_Mastiff_Great_Dane
+                                                 :CommodityCode_LIVE_MMLS_DOGS_German_Pinscher
+                                                 :CommodityCode_LIVE_MMLS_DOGS_German_Shepherd_Dog
+                                                 :CommodityCode_LIVE_MMLS_DOGS_German_Shorthaired_Pointer
+                                                 :CommodityCode_LIVE_MMLS_DOGS_German_Wirehaired_Pointer
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Giant_Schnauzer
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Glen_of_Imaal_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Goldador_Golden_Retriever_Labrador_Retriever
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Golden_Retriever
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Goldendoodle_Golden_Retriever_Poodle_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Gordon_Setter
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Great_Dane
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Great_Pyrenees
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Greater_Swiss_Mountain_Dog
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Greyhound
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Harrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Havanese
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Ibizan_Hound
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Icelandic_Sheepdog
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Irish_Red_and_White_Setter
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Irish_Setter
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Irish_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Irish_Water_Spaniel
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Irish_Wolfhound
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Italian_Greyhound
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Italian_Mastiff
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Jack_Chi_Chihuahua_Jack_Russell_Terrier_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Jack_Russell_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Japanese_Boxer
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Japanese_Chin
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Japanese_Mastiff
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Japanese_Pug
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Japanese_Spaniel
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Kangal_Shepherd_Dog
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Keeshond
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Kerry_Blue_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_King_Charles_Spaniel
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Komondor
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Kuvasz
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Kyi_Leo_Maltese_Lhasa_Apso_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Labrabull_Labrador_Retriever_American_Pit_Bull
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Labradane_Labrador_Retriever_Great_Dane_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Labradoodle_Labrador_Retriever_Poodle_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Labrador_Retriever
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Lagotto_Romagnolo
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Lakeland_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Leonberger
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Lhasa_Apso
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Löwchen
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Mal_Shi_Maltese_Shih_Tzu_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Malt_Tzu_Maltese_Shih_Tzu_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Maltese
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Maltese_Shih_Tzu
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Malti_Zu_Maltese_Shih_Tzu_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Maltipoo_Maltese_Poodle_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Manchester_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Mastador_Bullmastiff_Labrador_Retriever_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Mastiff
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Mastin_Espanol_Spanish_Mastiff
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Mastino_Napoletano_Neopolitan_Mastiff
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Miniature_American_Shepherd
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Miniature_Bull_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Miniature_Pinscher
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Miniature_Schnauzer
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Mixed_Invalid_Breed_Type
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Neapolitan_Mastiff
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Newfoundland
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Norfolk_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Norwegian_Buhund
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Norwegian_Elkhound
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Norwegian_Lundehund
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Norwich_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Nova_Scotia_Duck_Tolling_Retriever
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Old_English_Bulldog
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Old_English_Sheepdog
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Olde_English_Bulldog
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Otterhound
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Papillon
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Parson_Russell_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Peekapoo_Pekingese_Poodle_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Pekingese
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Pembroke_Welsh_Corgi
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Petit_Basset_Griffon_Vendéen
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Pharaoh_Hound
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Pit_Bull
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Pit_Plott_Pitbull_Plott_Hound_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Plott_Hound
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Pointer
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Polish_Lowland_Sheepdog
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Pomapoo_Pomeranian_Poodle_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Pomchi_Pomeranian_Chihuahua_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Pomeranian
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Pomsky_Pomeranian_Siberian_Husky_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Poochon_Poodle_Bichon_Frise_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Poodle
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Portuguese_Water_Dog
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Presa_Canario
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Pug
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Pugapoo_Pug_Poodle_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Puggle_Pug_Beagle_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Puli
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Pyrenean_Mastiff
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Pyrenean_Shepherd
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Rat_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Redbone_Coonhound
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Rhodesian_Ridgeback
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Rottweiler
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Russell_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Saint_Bernard
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Saluki
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Samoyed
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Schipperke
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Schnoodle_Schnauzer_Poodle_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Scottish_Deerhound
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Scottish_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Sealyham_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Shar_Pei
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Sheepadoodle_Old_English_Sheepdog_Poodle_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Shetland_Sheepdog
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Shiba_Inu
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Shih_Poo
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Shih_Tzu
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Shihpoo_Shih_Tzu_Poodle_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Siberian_Husky
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Silky_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Skye_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Sloughi_Arabian_Greyhound
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Smooth_Fox_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Soft_Coated_Wheaten_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_South_African_Mastiff
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Spanish_Mastiff
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Spanish_Water_Dog
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Spinone_Italiano
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Staffordshire_Bull_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Standard_Schnauzer
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Sussex_Spaniel
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Swedish_Vallhund
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Tibetan_Mastiff
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Tibetan_Spaniel
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Tibetan_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Tosa_Japanese_Mastiff
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Toy_Fox_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Treeing_Walker_Coonhound
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Utonagan_Northern_Inuit_Dog
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Valley_Bulldog
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Vizsla
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Weimaraner
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Welsh_Springer_Spaniel
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Welsh_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_West_Highland_White_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Whippet
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Wire_Fox_Terrier
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Wirehaired_Pointing_Griffon
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Wirehaired_Vizsla
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Xoloitzcuintli_Mexican_Hairless_Dog
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Yorkipoo_Yorkshire_Terrier_Poodle_Mix
+                                                 :CommodityCode_LIVE_MMLS_DOGS_Yorkshire_Terrier
+                                                 :CommodityCode_LIVE_MMLS_FERR
+                                                 :CommodityCode_LIVE_MMLS_GOAT
+                                                 :CommodityCode_LIVE_MMLS_HORS
+                                                 :CommodityCode_LIVE_MMLS_MNKY
+                                                 :CommodityCode_LIVE_MMLS_PIGS
+                                                 :CommodityCode_LIVE_MMLS_RDNT
+                                                 :CommodityCode_LIVE_MMLS_SHEP
+                                                 :CommodityCode_LIVE_REPT
+                                                 :CommodityCode_LIVE_VANI
+                                                 :CommodityCode_LIVE_ZOOA
+                                                 :CommodityCode_MAIL
+                                                 :CommodityCode_MART
+                                                 :CommodityCode_MART_ART
+                                                 :CommodityCode_MART_ENGR
+                                                 :CommodityCode_MART_HAND
+                                                 :CommodityCode_MART_MUEQ
+                                                 :CommodityCode_MART_MUSI
+                                                 :CommodityCode_MART_PNTG
+                                                 :CommodityCode_MLTY
+                                                 :CommodityCode_MLTY_AMUN
+                                                 :CommodityCode_MLTY_MSUP
+                                                 :CommodityCode_MLTY_SPWE
+                                                 :CommodityCode_MLTY_WPNS
+                                                 :CommodityCode_PHAR
+                                                 :CommodityCode_PHAR_BIOP
+                                                 :CommodityCode_PHAR_BIOP_BIOC
+                                                 :CommodityCode_PHAR_BIOP_HEMO
+                                                 :CommodityCode_PHAR_BIOP_HUBL
+                                                 :CommodityCode_PHAR_BIOP_HUSR
+                                                 :CommodityCode_PHAR_BIOP_LHOR
+                                                 :CommodityCode_PHAR_BIOP_SEME
+                                                 :CommodityCode_PHAR_BIOP_SMPL
+                                                 :CommodityCode_PHAR_MDCN
+                                                 :CommodityCode_PHAR_MDCN_ANTB
+                                                 :CommodityCode_PHAR_MDCN_VACC
+                                                 :CommodityCode_PHAR_MDCN_VETE
+                                                 :CommodityCode_PHAR_MEDI
+                                                 :CommodityCode_PHAR_PHAR
+                                                 :CommodityCode_PHAR_PHAR_SUEQ
+                                                 :CommodityCode_PRIN
+                                                 :CommodityCode_PRIN_ADVM
+                                                 :CommodityCode_PRIN_BOOK
+                                                 :CommodityCode_PRIN_DOCU
+                                                 :CommodityCode_PRIN_EDUM
+                                                 :CommodityCode_PRIN_NEWS
+                                                 :CommodityCode_PRIN_PPRP
+                                                 :CommodityCode_RAWM
+                                                 :CommodityCode_RAWM_BLDM
+                                                 :CommodityCode_RAWM_CLAY
+                                                 :CommodityCode_RAWM_GLAS
+                                                 :CommodityCode_RAWM_GRAN
+                                                 :CommodityCode_RAWM_GUMS
+                                                 :CommodityCode_RAWM_MARB
+                                                 :CommodityCode_RAWM_METL
+                                                 :CommodityCode_RAWM_METP
+                                                 :CommodityCode_RAWM_MICA
+                                                 :CommodityCode_RAWM_MINE
+                                                 :CommodityCode_RAWM_MIRR
+                                                 :CommodityCode_RAWM_OILS
+                                                 :CommodityCode_RAWM_PLST
+                                                 :CommodityCode_RAWM_QRTZ
+                                                 :CommodityCode_RAWM_RUBR
+                                                 :CommodityCode_RAWM_RUBR_RTYR
+                                                 :CommodityCode_RAWM_STNS
+                                                 :CommodityCode_RAWM_WOOD
+                                                 :CommodityCode_SCIN
+                                                 :CommodityCode_SCIN_DEEQ
+                                                 :CommodityCode_SCIN_DIAG
+                                                 :CommodityCode_SCIN_HEAR
+                                                 :CommodityCode_SCIN_LBEQ
+                                                 :CommodityCode_SCIN_MEEQ
+                                                 :CommodityCode_SCIN_OPTI
+                                                 :CommodityCode_SCIN_PRCI
+                                                 :CommodityCode_TRPH
+                                                 :CommodityCode_TRPH_HTRH
+                                                 :CommodityCode_TRPH_OTRH
+                                                 :CommodityCode_TXTL
+                                                 :CommodityCode_TXTL_FREW
+                                                 :CommodityCode_TXTL_FUR
+                                                 :CommodityCode_TXTL_FURW
+                                                 :CommodityCode_TXTL_LEXW
+                                                 :CommodityCode_TXTL_LTHR
+                                                 :CommodityCode_TXTL_LTWR
+                                                 :CommodityCode_TXTL_TXEW
+                                                 :CommodityCode_TXTL_TXEW_CARP
+                                                 :CommodityCode_TXTL_TXEW_CURT
+                                                 :CommodityCode_TXTL_TXEW_FABR
+                                                 :CommodityCode_TXTL_TXEW_FURN
+                                                 :CommodityCode_TXTL_TXEW_HIDE
+                                                 :CommodityCode_TXTL_TXEW_NDLE
+                                                 :CommodityCode_TXTL_TXEW_SKIN
+                                                 :CommodityCode_TXTL_TXEW_TRLS
+                                                 :CommodityCode_TXTL_TXEW_YARN
+                                                 :CommodityCode_TXTL_TXLW
+                                                 :CommodityCode_TXTL_TXLW_APPR
+                                                 :CommodityCode_TXTL_TXLW_CLTH
+                                                 :CommodityCode_TXTL_TXLW_FOOT
+                                                 :CommodityCode_TXTL_TXLW_GARM
+                                                 :CommodityCode_TXTL_TXTL
+                                                 :CommodityCode_VALU
+                                                 :CommodityCode_VALU_BANK
+                                                 :CommodityCode_VALU_DIAM
+                                                 :CommodityCode_VALU_GOLD
+                                                 :CommodityCode_VALU_JWRY
+                                                 :CommodityCode_VALU_PLAT
+                                                 :CommodityCode_VALU_PMET
+                                                 :CommodityCode_VALU_PSTN
+                                                 :CommodityCode_VALU_SLVR
+                                                 :CommodityCode_VALU_WTCH
+                                                 :CommodityCode_VHCL
+                                                 :CommodityCode_VHCL_AIRC
+                                                 :CommodityCode_VHCL_AIRC_AACC
+                                                 :CommodityCode_VHCL_AIRC_AENG
+                                                 :CommodityCode_VHCL_AIRC_AMTR
+                                                 :CommodityCode_VHCL_AIRC_APRT
+                                                 :CommodityCode_VHCL_AIRC_ASUP
+                                                 :CommodityCode_VHCL_AIRC_AWHL
+                                                 :CommodityCode_VHCL_AIRC_HELI
+                                                 :CommodityCode_VHCL_AIRC_HPRT
+                                                 :CommodityCode_VHCL_MACH
+                                                 :CommodityCode_VHCL_MACH_COIL
+                                                 :CommodityCode_VHCL_MACH_COMP
+                                                 :CommodityCode_VHCL_MACH_HRDW
+                                                 :CommodityCode_VHCL_MACH_MECH
+                                                 :CommodityCode_VHCL_MACH_MTSP
+                                                 :CommodityCode_VHCL_MACH_OILD
+                                                 :CommodityCode_VHCL_MACH_PART
+                                                 :CommodityCode_VHCL_MACH_PUEQ
+                                                 :CommodityCode_VHCL_SHIP
+                                                 :CommodityCode_VHCL_SHIP_SENG
+                                                 :CommodityCode_VHCL_SHIP_SMTR
+                                                 :CommodityCode_VHCL_SHIP_SPAR
+                                                 :CommodityCode_VHCL_SHIP_SSPA
+                                                 :CommodityCode_VHCL_SVCL
+                                                 :CommodityCode_VHCL_SVCL_AUTO
+                                                 :CommodityCode_VHCL_SVCL_BICY
+                                                 :CommodityCode_VHCL_SVCL_CRTA
+                                                 :CommodityCode_VHCL_SVCL_MOTO
+                                                 :CommodityCode_VHCL_SVCL_PENDING
+                                                 :CommodityCode_VHCL_SVCL_TIRE
+                                               )
+                                   ] ;
+               rdfs:comment "Restricted code list of accepted commodities in carrier bookings when no HS code available"@en ;
+               rdfs:label "CommodityCode"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode
+:CurrencyCode rdf:type owl:Class ;
+              rdfs:comment "Open code list of currency codes based on ISO 4217"@en ,
+                           "Source: ISO 4217"@en ;
+              rdfs:label "CurrencyCode"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode
+:DangerousGoodsCode rdf:type owl:Class ;
+                    owl:equivalentClass [ rdf:type owl:Class ;
+                                          owl:oneOf ( :DangerousGoodsCode_CAO
+                                                      :DangerousGoodsCode_EBI
+                                                      :DangerousGoodsCode_EBM
+                                                      :DangerousGoodsCode_ELI
+                                                      :DangerousGoodsCode_ELM
+                                                      :DangerousGoodsCode_ICE
+                                                      :DangerousGoodsCode_MAG
+                                                      :DangerousGoodsCode_RBI
+                                                      :DangerousGoodsCode_RBM
+                                                      :DangerousGoodsCode_RCL
+                                                      :DangerousGoodsCode_RCM
+                                                      :DangerousGoodsCode_RCX
+                                                      :DangerousGoodsCode_REX
+                                                      :DangerousGoodsCode_RFG
+                                                      :DangerousGoodsCode_RFL
+                                                      :DangerousGoodsCode_RFS
+                                                      :DangerousGoodsCode_RFW
+                                                      :DangerousGoodsCode_RGX
+                                                      :DangerousGoodsCode_RIS
+                                                      :DangerousGoodsCode_RLI
+                                                      :DangerousGoodsCode_RLM
+                                                      :DangerousGoodsCode_RMD
+                                                      :DangerousGoodsCode_RNG
+                                                      :DangerousGoodsCode_ROP
+                                                      :DangerousGoodsCode_ROX
+                                                      :DangerousGoodsCode_RPB
+                                                      :DangerousGoodsCode_RPG
+                                                      :DangerousGoodsCode_RRW
+                                                      :DangerousGoodsCode_RRY
+                                                      :DangerousGoodsCode_RSB
+                                                      :DangerousGoodsCode_RSC
+                                                      :DangerousGoodsCode_RXB
+                                                      :DangerousGoodsCode_RXC
+                                                      :DangerousGoodsCode_RXD
+                                                      :DangerousGoodsCode_RXE
+                                                      :DangerousGoodsCode_RXG
+                                                      :DangerousGoodsCode_RXS
+                                                    )
+                                        ] ;
+                    rdfs:comment "Restricted code list corresponding to cXML code list 1.14 Dangerous Goods Codes"@en ,
+                                 "Source: Dangerous Goods Regulations, 46th Edition"@en ;
+                    rdfs:label "DangerousGoodsCode"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DemurrageCode
+:DemurrageCode rdf:type owl:Class ;
+               owl:equivalentClass [ rdf:type owl:Class ;
+                                     owl:oneOf ( :DemurrageCode_BCC
+                                                 :DemurrageCode_HHH
+                                                 :DemurrageCode_XXX
+                                                 :DemurrageCode_ZZZ
+                                               )
+                                   ] ;
+               rdfs:comment "Restricted code list based on RP 1654"@en ,
+                            "Source: CSC RP 1654"@en ;
+               rdfs:label "DemurrageCode"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DimensionsUnitCode
+:DimensionsUnitCode rdf:type owl:Class ;
+                    owl:equivalentClass [ rdf:type owl:Class ;
+                                          owl:oneOf ( :MeasurementUnitCode_CMT
+                                                      :MeasurementUnitCode_FOT
+                                                      :MeasurementUnitCode_INH
+                                                      :MeasurementUnitCode_MTR
+                                                    )
+                                        ] ;
+                    rdfs:comment "Restricted sub-code list of length units from MeasurementUnitCode"@en ;
+                    rdfs:label "DimensionsUnitCode"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#EntitlementCode
+:EntitlementCode rdf:type owl:Class ;
+                 owl:equivalentClass [ rdf:type owl:Class ;
+                                       owl:oneOf ( :EntitlementCode_A
+                                                   :EntitlementCode_C
+                                                 )
+                                     ] ;
+                 rdfs:comment "Restricted code list corresponding to cXML code list 1.3 Entitlement Codes"@en ,
+                              "Source: CSC Resolutions Manual, 25th Edition, Resolution 600a"@en ;
+                 rdfs:label "EntitlementCode"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ExplosiveCompatibilityGroupCode
+:ExplosiveCompatibilityGroupCode rdf:type owl:Class ;
+                                 owl:equivalentClass [ rdf:type owl:Class ;
+                                                       owl:oneOf ( :ExplosiveCompatibilityGroupCode_A
+                                                                   :ExplosiveCompatibilityGroupCode_B
+                                                                   :ExplosiveCompatibilityGroupCode_C
+                                                                   :ExplosiveCompatibilityGroupCode_D
+                                                                   :ExplosiveCompatibilityGroupCode_E
+                                                                   :ExplosiveCompatibilityGroupCode_F
+                                                                   :ExplosiveCompatibilityGroupCode_G
+                                                                   :ExplosiveCompatibilityGroupCode_H
+                                                                   :ExplosiveCompatibilityGroupCode_J
+                                                                   :ExplosiveCompatibilityGroupCode_K
+                                                                   :ExplosiveCompatibilityGroupCode_L
+                                                                   :ExplosiveCompatibilityGroupCode_N
+                                                                   :ExplosiveCompatibilityGroupCode_S
+                                                                 )
+                                                     ] ;
+                                 rdfs:comment "Restricted code list based on DGR Table 3.1.A"@en ,
+                                              "Source: DGR Table 3.1.A Compatibility group for explosives"@en ;
+                                 rdfs:label "ExplosiveCompatibilityGroupCode"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#GoodsTypeCode
+:GoodsTypeCode rdf:type owl:Class ;
+               owl:equivalentClass [ rdf:type owl:Class ;
+                                     owl:oneOf ( :GoodsTypeCode_I
+                                                 :GoodsTypeCode_II
+                                                 :GoodsTypeCode_III
+                                               )
+                                   ] ;
+               rdfs:comment "Restricted code list referring to the CITES appendices"@en ,
+                            "Source: CITES"@en ;
+               rdfs:label "GoodsTypeCode"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#GoodsTypeExtensionCode
+:GoodsTypeExtensionCode rdf:type owl:Class ;
+                        owl:equivalentClass [ rdf:type owl:Class ;
+                                              owl:oneOf ( :GoodsTypeExtensionCode_A
+                                                          :GoodsTypeExtensionCode_C
+                                                          :GoodsTypeExtensionCode_D
+                                                          :GoodsTypeExtensionCode_F
+                                                          :GoodsTypeExtensionCode_I
+                                                          :GoodsTypeExtensionCode_O
+                                                          :GoodsTypeExtensionCode_R
+                                                          :GoodsTypeExtensionCode_U
+                                                          :GoodsTypeExtensionCode_W
+                                                          :GoodsTypeExtensionCode_X
+                                                        )
+                                            ] ;
+                        rdfs:comment "Restricted code list referring to the CITES source codes"@en ,
+                                     "Source: CITES"@en ;
+                        rdfs:label "GoodsTypeExtensionCode"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode
+:MeasurementUnitCode rdf:type owl:Class ;
+                     rdfs:comment "Open code list extended from cXML code list 1.48 Measurement Unit Code and based on UNECE Rec. 20"@en ,
+                                  "Source: UNECE Rec. 20 Rev. 17e-2021"@en ;
+                     rdfs:label "MeasurementUnitCode"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator
+:MovementIndicator rdf:type owl:Class ;
+                   owl:equivalentClass [ rdf:type owl:Class ;
+                                         owl:oneOf ( :MovementIndicator_AA
+                                                     :MovementIndicator_AB
+                                                     :MovementIndicator_AD
+                                                     :MovementIndicator_AG
+                                                     :MovementIndicator_AH
+                                                     :MovementIndicator_AK
+                                                     :MovementIndicator_AL
+                                                     :MovementIndicator_AO
+                                                     :MovementIndicator_AR
+                                                     :MovementIndicator_CN
+                                                     :MovementIndicator_DA
+                                                     :MovementIndicator_DL
+                                                     :MovementIndicator_DV
+                                                     :MovementIndicator_EA
+                                                     :MovementIndicator_EB
+                                                     :MovementIndicator_ED
+                                                     :MovementIndicator_EK
+                                                     :MovementIndicator_EL
+                                                     :MovementIndicator_EO
+                                                     :MovementIndicator_ER
+                                                     :MovementIndicator_FR
+                                                     :MovementIndicator_NI
+                                                     :MovementIndicator_PA
+                                                     :MovementIndicator_RR
+                                                     :MovementIndicator_SA
+                                                     :MovementIndicator_SD
+                                                     :MovementIndicator_SK
+                                                     :MovementIndicator_SL
+                                                     :MovementIndicator_SR
+                                                     :MovementIndicator_SS
+                                                   )
+                                       ] ;
+                   rdfs:comment "NOT FINAL YET - Open code list corresponding to cXML code list 1.92 Movement Indicators"@en ;
+                   rdfs:label "MovementIndicator"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode
+:OtherChargeCode rdf:type owl:Class ;
+                 owl:equivalentClass [ rdf:type owl:Class ;
+                                       owl:oneOf ( :OtherChargeCode_AC
+                                                   :OtherChargeCode_AS
+                                                   :OtherChargeCode_AT
+                                                   :OtherChargeCode_AW
+                                                   :OtherChargeCode_BA
+                                                   :OtherChargeCode_BB
+                                                   :OtherChargeCode_BC
+                                                   :OtherChargeCode_BE
+                                                   :OtherChargeCode_BF
+                                                   :OtherChargeCode_BH
+                                                   :OtherChargeCode_BI
+                                                   :OtherChargeCode_BL
+                                                   :OtherChargeCode_BM
+                                                   :OtherChargeCode_BR
+                                                   :OtherChargeCode_CA
+                                                   :OtherChargeCode_CB
+                                                   :OtherChargeCode_CC
+                                                   :OtherChargeCode_CD
+                                                   :OtherChargeCode_CE
+                                                   :OtherChargeCode_CF
+                                                   :OtherChargeCode_CG
+                                                   :OtherChargeCode_CH
+                                                   :OtherChargeCode_CI
+                                                   :OtherChargeCode_CJ
+                                                   :OtherChargeCode_DB
+                                                   :OtherChargeCode_DC
+                                                   :OtherChargeCode_DD
+                                                   :OtherChargeCode_DF
+                                                   :OtherChargeCode_DG
+                                                   :OtherChargeCode_DH
+                                                   :OtherChargeCode_DI
+                                                   :OtherChargeCode_DJ
+                                                   :OtherChargeCode_DK
+                                                   :OtherChargeCode_DV
+                                                   :OtherChargeCode_EA
+                                                   :OtherChargeCode_FA
+                                                   :OtherChargeCode_FB
+                                                   :OtherChargeCode_FC
+                                                   :OtherChargeCode_FD
+                                                   :OtherChargeCode_FE
+                                                   :OtherChargeCode_FF
+                                                   :OtherChargeCode_FI
+                                                   :OtherChargeCode_GA
+                                                   :OtherChargeCode_GT
+                                                   :OtherChargeCode_HB
+                                                   :OtherChargeCode_HR
+                                                   :OtherChargeCode_IA
+                                                   :OtherChargeCode_IN
+                                                   :OtherChargeCode_JA
+                                                   :OtherChargeCode_KA
+                                                   :OtherChargeCode_KB
+                                                   :OtherChargeCode_LA
+                                                   :OtherChargeCode_LC
+                                                   :OtherChargeCode_LE
+                                                   :OtherChargeCode_LF
+                                                   :OtherChargeCode_LG
+                                                   :OtherChargeCode_LH
+                                                   :OtherChargeCode_LI
+                                                   :OtherChargeCode_LJ
+                                                   :OtherChargeCode_MA
+                                                   :OtherChargeCode_MB
+                                                   :OtherChargeCode_MC
+                                                   :OtherChargeCode_MD
+                                                   :OtherChargeCode_ME
+                                                   :OtherChargeCode_MF
+                                                   :OtherChargeCode_MG
+                                                   :OtherChargeCode_MH
+                                                   :OtherChargeCode_MI
+                                                   :OtherChargeCode_MJ
+                                                   :OtherChargeCode_MK
+                                                   :OtherChargeCode_ML
+                                                   :OtherChargeCode_MM
+                                                   :OtherChargeCode_MN
+                                                   :OtherChargeCode_MO
+                                                   :OtherChargeCode_MP
+                                                   :OtherChargeCode_MQ
+                                                   :OtherChargeCode_MR
+                                                   :OtherChargeCode_MS
+                                                   :OtherChargeCode_MT
+                                                   :OtherChargeCode_MU
+                                                   :OtherChargeCode_MV
+                                                   :OtherChargeCode_MW
+                                                   :OtherChargeCode_MX
+                                                   :OtherChargeCode_MY
+                                                   :OtherChargeCode_MZ
+                                                   :OtherChargeCode_NS
+                                                   :OtherChargeCode_PA
+                                                   :OtherChargeCode_PB
+                                                   :OtherChargeCode_PK
+                                                   :OtherChargeCode_PU
+                                                   :OtherChargeCode_RA
+                                                   :OtherChargeCode_RB
+                                                   :OtherChargeCode_RC
+                                                   :OtherChargeCode_RD
+                                                   :OtherChargeCode_RF
+                                                   :OtherChargeCode_SA
+                                                   :OtherChargeCode_SB
+                                                   :OtherChargeCode_SC
+                                                   :OtherChargeCode_SD
+                                                   :OtherChargeCode_SE
+                                                   :OtherChargeCode_SF
+                                                   :OtherChargeCode_SI
+                                                   :OtherChargeCode_SO
+                                                   :OtherChargeCode_SP
+                                                   :OtherChargeCode_SR
+                                                   :OtherChargeCode_SS
+                                                   :OtherChargeCode_ST
+                                                   :OtherChargeCode_SU
+                                                   :OtherChargeCode_TA
+                                                   :OtherChargeCode_TB
+                                                   :OtherChargeCode_TC
+                                                   :OtherChargeCode_TD
+                                                   :OtherChargeCode_TE
+                                                   :OtherChargeCode_TI
+                                                   :OtherChargeCode_TR
+                                                   :OtherChargeCode_TV
+                                                   :OtherChargeCode_TX
+                                                   :OtherChargeCode_UB
+                                                   :OtherChargeCode_UC
+                                                   :OtherChargeCode_UD
+                                                   :OtherChargeCode_UE
+                                                   :OtherChargeCode_UF
+                                                   :OtherChargeCode_UG
+                                                   :OtherChargeCode_UH
+                                                   :OtherChargeCode_VA
+                                                   :OtherChargeCode_VB
+                                                   :OtherChargeCode_VC
+                                                   :OtherChargeCode_WA
+                                                   :OtherChargeCode_XB
+                                                   :OtherChargeCode_XC
+                                                   :OtherChargeCode_XD
+                                                   :OtherChargeCode_XE
+                                                   :OtherChargeCode_ZA
+                                                   :OtherChargeCode_ZB
+                                                   :OtherChargeCode_ZC
+                                                 )
+                                     ] ;
+                 rdfs:comment "Restricted code list corresponding to cXML code list 1.2 Other Charge Codes"@en ,
+                              "Source: CSC Resolutions Manual, 25th Edition, Resolution 600a"@en ;
+                 rdfs:label "OtherChargeCode"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#PackageMarkCode
+:PackageMarkCode rdf:type owl:Class ;
+                 rdfs:comment "Open code list of indicators of how a package is marked"@en ;
+                 rdfs:label "PackageMarkCode"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#PackagingDangerLevelCode
+:PackagingDangerLevelCode rdf:type owl:Class ;
+                          owl:equivalentClass [ rdf:type owl:Class ;
+                                                owl:oneOf ( :PackagingDangerLevelCode_I
+                                                            :PackagingDangerLevelCode_II
+                                                            :PackagingDangerLevelCode_III
+                                                          )
+                                              ] ;
+                          rdfs:comment "Restricted code lists for indication of the relative degree of danger presented by substances within a class or division"@en ;
+                          rdfs:label "PackagingDangerLevelCode"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ParticipantIdentifier
+:ParticipantIdentifier rdf:type owl:Class ;
+                       rdfs:comment "Open code list corresponding to cXML code list 1.36 Participant Identifiers"@en ;
+                       rdfs:label "ParticipantIdentifier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#PrepaidCollectIndicator
+:PrepaidCollectIndicator rdf:type owl:Class ;
+                         owl:equivalentClass [ rdf:type owl:Class ;
+                                               owl:oneOf ( :PrepaidCollectIndicator_C
+                                                           :PrepaidCollectIndicator_P
+                                                         )
+                                             ] ;
+                         rdfs:comment "Restricted code list corresponding to cXML code list 1.5 Prepaid/Collect Indicators"@en ;
+                         rdfs:label "PrepaidCollectIndicator"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RaTypeCode
+:RaTypeCode rdf:type owl:Class ;
+            owl:equivalentClass [ rdf:type owl:Class ;
+                                  owl:oneOf ( :RaTypeCode_III_YELLOW
+                                              :RaTypeCode_II_YELLOW
+                                              :RaTypeCode_I_WHITE
+                                            )
+                                ] ;
+            rdfs:comment "Restricted code list based on cXML code list 1.84 Category Colour"@en ;
+            rdfs:label "RaTypeCode"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RateClassCode
+:RateClassCode rdf:type owl:Class ;
+               owl:equivalentClass [ rdf:type owl:Class ;
+                                     owl:oneOf ( :RateClassCode_B
+                                                 :RateClassCode_C
+                                                 :RateClassCode_E
+                                                 :RateClassCode_K
+                                                 :RateClassCode_M
+                                                 :RateClassCode_N
+                                                 :RateClassCode_P
+                                                 :RateClassCode_Q
+                                                 :RateClassCode_R
+                                                 :RateClassCode_S
+                                                 :RateClassCode_U
+                                                 :RateClassCode_W
+                                                 :RateClassCode_X
+                                                 :RateClassCode_Y
+                                               )
+                                   ] ;
+               rdfs:comment "Restricted code list corresponding to cXML code list 1.4 Rate Class Codes"@en ,
+                            "Source: CSC Resolutions Manual, 25th Edition, Resolution 600a"@en ;
+               rdfs:label "RateClassCode"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RatingsType
+:RatingsType rdf:type owl:Class ;
+             owl:equivalentClass [ rdf:type owl:Class ;
+                                   owl:oneOf ( :RatingsType_A
+                                               :RatingsType_C
+                                               :RatingsType_F
+                                             )
+                                 ] ;
+             rdfs:comment "Restricted code list to describe whether a rating is Face, Published or Actual"@en ;
+             rdfs:label "RatingsType"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RegulatedEntityCategoryCode
+:RegulatedEntityCategoryCode rdf:type owl:Class ;
+                             owl:equivalentClass [ rdf:type owl:Class ;
+                                                   owl:oneOf ( :RegulatedEntityCategoryCode_AO
+                                                               :RegulatedEntityCategoryCode_KC
+                                                               :RegulatedEntityCategoryCode_RA
+                                                               :RegulatedEntityCategoryCode_RC
+                                                             )
+                                                 ] ;
+                             rdfs:comment "Full detailed descriptions for RA, KC & AC are contained in Cargo Services Conference Recommended Practice 1630 CARGO SECURITY"@en ,
+                                          "Restricted code list of regulated entity categories, partially corresponding to cXML code list 1.100 Customs, Security and Regulatory Control Information Identifiers"@en ;
+                             rdfs:label "RegulatedEntityCategoryCode"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ScreeningExemption
+:ScreeningExemption rdf:type owl:Class ;
+                    owl:equivalentClass [ rdf:type owl:Class ;
+                                          owl:oneOf ( :ScreeningExemption_BIOM
+                                                      :ScreeningExemption_DIPL
+                                                      :ScreeningExemption_LFSM
+                                                      :ScreeningExemption_MAIL
+                                                      :ScreeningExemption_NUCL
+                                                      :ScreeningExemption_SMUS
+                                                      :ScreeningExemption_TRNS
+                                                    )
+                                        ] ;
+                    rdfs:comment "Restricted code list corresponding to cXML code list 1.104 Screening Exemptions"@en ;
+                    rdfs:label "ScreeningExemption"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ScreeningMethod
+:ScreeningMethod rdf:type owl:Class ;
+                 owl:equivalentClass [ rdf:type owl:Class ;
+                                       owl:oneOf ( :ScreeningMethod_AOM
+                                                   :ScreeningMethod_CMD
+                                                   :ScreeningMethod_EDD
+                                                   :ScreeningMethod_EDS
+                                                   :ScreeningMethod_ETD
+                                                   :ScreeningMethod_PHS
+                                                   :ScreeningMethod_VCK
+                                                   :ScreeningMethod_XRY
+                                                 )
+                                     ] ;
+                 rdfs:comment "Restricted code list corresponding to cXML code list 1.102 Screening Methods"@en ;
+                 rdfs:label "ScreeningMethod"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SecurityStatus
+:SecurityStatus rdf:type owl:Class ;
+                owl:equivalentClass [ rdf:type owl:Class ;
+                                      owl:oneOf ( :SecurityStatus_NSC
+                                                  :SecurityStatus_SCO
+                                                  :SecurityStatus_SHR
+                                                  :SecurityStatus_SPX
+                                                )
+                                    ] ;
+                rdfs:comment "Restricted code list corresponding to cXML code list 1.103 Security Statuses"@en ;
+                rdfs:label "SecurityStatus"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ServiceCode
+:ServiceCode rdf:type owl:Class ;
+             owl:equivalentClass [ rdf:type owl:Class ;
+                                   owl:oneOf ( :ServiceCode_A
+                                               :ServiceCode_B
+                                               :ServiceCode_C
+                                               :ServiceCode_D
+                                               :ServiceCode_E
+                                               :ServiceCode_F
+                                               :ServiceCode_G
+                                               :ServiceCode_H
+                                               :ServiceCode_I
+                                               :ServiceCode_J
+                                               :ServiceCode_P
+                                               :ServiceCode_S
+                                               :ServiceCode_T
+                                               :ServiceCode_X
+                                             )
+                                 ] ;
+             rdfs:comment "Restricted code list corresponding to cXML code list 1.38 Service Codes"@en ,
+                          "Source: CSC Resolutions Manual, 25th Edition, Recommended Practice 1600d"@en ;
+             rdfs:label "ServiceCode"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ShipmentSecurityStatus
+:ShipmentSecurityStatus rdf:type owl:Class ;
+                        owl:equivalentClass [ rdf:type owl:Class ;
+                                              owl:oneOf ( :ShipmentSecurityStatus_NCR
+                                                          :ShipmentSecurityStatus_SCR
+                                                        )
+                                            ] ;
+                        rdfs:comment "Restricted code list indicating whether a shipment is secured or not secured"@en ;
+                        rdfs:label "ShipmentSecurityStatus"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SignatoryRole
+:SignatoryRole rdf:type owl:Class ;
+               owl:equivalentClass [ rdf:type owl:Class ;
+                                     owl:oneOf ( :SignatoryRole_APPLICANT
+                                                 :SignatoryRole_EXAMINING_AUTHORITY
+                                                 :SignatoryRole_ISSUING_AUTHORITY
+                                                 :SignatoryRole_MANAGEMENT_AUTHORITY
+                                                 :SignatoryRole_PERMIT_ISSUER
+                                               )
+                                   ] ;
+               rdfs:comment "Restricted code list indicating the role of the signatory in CITES context"@en ,
+                            "Source: CITES"@en ;
+               rdfs:label "SignatoryRole"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SignatureTypeCode
+:SignatureTypeCode rdf:type owl:Class ;
+                   owl:equivalentClass [ rdf:type owl:Class ;
+                                         owl:oneOf ( :SignatureTypeCode_DETENTION
+                                                     :SignatureTypeCode_FUMIGATION
+                                                     :SignatureTypeCode_INSPECTION
+                                                     :SignatureTypeCode_SECURITY
+                                                   )
+                                       ] ;
+                   rdfs:comment "Restricted code list of governmental action in CITES context"@en ,
+                                "Source: CITES"@en ;
+                   rdfs:label "SignatureTypeCode"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode
+:SpecialHandlingCode rdf:type owl:Class ;
+                     rdfs:comment "Open code list corresponding to cXML code lists 1.16 Special Handling Codes, 1.14 Dangerous Goods Codes and 1.103 Security Statuses. Note that the codes from 1.14 and 1.103 have different IRI prefixes"@en ,
+                                  "Source of DGR codes: Dangerous Goods Regulations, 46th Edition"@en ;
+                     rdfs:label "SpecialHandlingCode"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode
+:StatusCode rdf:type owl:Class ;
+            owl:equivalentClass [ rdf:type owl:Class ;
+                                  owl:oneOf ( :StatusCode_ARR
+                                              :StatusCode_AWD
+                                              :StatusCode_AWR
+                                              :StatusCode_BKD
+                                              :StatusCode_CCD
+                                              :StatusCode_CRC
+                                              :StatusCode_DDL
+                                              :StatusCode_DEP
+                                              :StatusCode_DIS_DFLD
+                                              :StatusCode_DIS_FDAV
+                                              :StatusCode_DIS_FDAW
+                                              :StatusCode_DIS_FDCA
+                                              :StatusCode_DIS_FDMB
+                                              :StatusCode_DIS_MSAV
+                                              :StatusCode_DIS_MSAW
+                                              :StatusCode_DIS_MSCA
+                                              :StatusCode_DIS_MSMB
+                                              :StatusCode_DIS_OFLD
+                                              :StatusCode_DIS_OVCD
+                                              :StatusCode_DIS_SSPD
+                                              :StatusCode_DLV
+                                              :StatusCode_DOC
+                                              :StatusCode_DPU
+                                              :StatusCode_FIW
+                                              :StatusCode_FOH
+                                              :StatusCode_FOW
+                                              :StatusCode_MAN
+                                              :StatusCode_NFD
+                                              :StatusCode_OCI
+                                              :StatusCode_OSI
+                                              :StatusCode_PRE
+                                              :StatusCode_RCF
+                                              :StatusCode_RCS
+                                              :StatusCode_RCT
+                                              :StatusCode_TFD
+                                              :StatusCode_TGC
+                                              :StatusCode_TRM
+                                            )
+                                ] ;
+            rdfs:comment "Restricted code list corresponding to cXML code list 1.18 Status Codes, including DIS discrepancy codes"@en ;
+            rdfs:label "StatusCode"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#TemperatureUnitCode
+:TemperatureUnitCode rdf:type owl:Class ;
+                     owl:equivalentClass [ rdf:type owl:Class ;
+                                           owl:oneOf ( :MeasurementUnitCode_CEL
+                                                       :MeasurementUnitCode_FAH
+                                                       :MeasurementUnitCode_KEL
+                                                     )
+                                         ] ;
+                     rdfs:comment "Restricted sub-code list of temperature units from MeasurementUnitCode"@en ;
+                     rdfs:label "TemperatureUnitCode"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#TransactionPurposeCode
+:TransactionPurposeCode rdf:type owl:Class ;
+                        owl:equivalentClass [ rdf:type owl:Class ;
+                                              owl:oneOf ( :TransactionPurposeCode_B
+                                                          :TransactionPurposeCode_E
+                                                          :TransactionPurposeCode_G
+                                                          :TransactionPurposeCode_H
+                                                          :TransactionPurposeCode_L
+                                                          :TransactionPurposeCode_M
+                                                          :TransactionPurposeCode_N
+                                                          :TransactionPurposeCode_P
+                                                          :TransactionPurposeCode_Q
+                                                          :TransactionPurposeCode_S
+                                                          :TransactionPurposeCode_T
+                                                          :TransactionPurposeCode_Z
+                                                        )
+                                            ] ;
+                        rdfs:comment "Restricted code list of purpose-of-transaction-codes"@en ,
+                                     "Source: CITES"@en ;
+                        rdfs:label "TransactionPurposeCode"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#TransportMeansServiceType
+:TransportMeansServiceType rdf:type owl:Class ;
+                           owl:equivalentClass [ rdf:type owl:Class ;
+                                                 owl:oneOf ( :TransportMeansServiceType_FREIGHTER
+                                                             :TransportMeansServiceType_MIXED_CONFIGURATION_COMBI
+                                                             :TransportMeansServiceType_PASSENGER
+                                                             :TransportMeansServiceType_TRUCK
+                                                           )
+                                               ] ;
+                           rdfs:comment "Restricted code list of listable transport means in transport legs in carrier bookings"@en ;
+                           rdfs:label "TransportMeansServiceType"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ULDChargeCode
+:ULDChargeCode rdf:type owl:Class ;
+               owl:equivalentClass [ rdf:type owl:Class ;
+                                     owl:oneOf ( :ULDChargeCode_A
+                                                 :ULDChargeCode_B
+                                                 :ULDChargeCode_C
+                                                 :ULDChargeCode_D
+                                                 :ULDChargeCode_E
+                                                 :ULDChargeCode_F
+                                                 :ULDChargeCode_G
+                                                 :ULDChargeCode_H
+                                                 :ULDChargeCode_I
+                                               )
+                                   ] ;
+               rdfs:comment "Restricted code list corresponding to cXML code list 1.44 ULD Charge Codes"@en ,
+                            "Source: CTCC Documentation"@en ;
+               rdfs:label "ULDChargeCode"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ULDConditionCode
+:ULDConditionCode rdf:type owl:Class ;
+                  owl:equivalentClass [ rdf:type owl:Class ;
+                                        owl:oneOf ( :ULDConditionCode_DAM
+                                                    :ULDConditionCode_SER
+                                                  )
+                                      ] ;
+                  rdfs:comment "Restricted code list corresponding to cXML code list 1.21 ULD Condition Codes"@en ;
+                  rdfs:label "ULDConditionCode"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ULDLoadingIndicator
+:ULDLoadingIndicator rdf:type owl:Class ;
+                     owl:equivalentClass [ rdf:type owl:Class ;
+                                           owl:oneOf ( :ULDLoadingIndicator_L
+                                                       :ULDLoadingIndicator_M
+                                                       :ULDLoadingIndicator_N
+                                                       :ULDLoadingIndicator_R
+                                                       :ULDLoadingIndicator_U
+                                                     )
+                                         ] ;
+                     rdfs:comment "Restricted code list corresponding to cXML code list 1.47 ULD Loading Indicators"@en ;
+                     rdfs:label "ULDLoadingIndicator"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#VolumeUnitCode
+:VolumeUnitCode rdf:type owl:Class ;
+                owl:equivalentClass [ rdf:type owl:Class ;
+                                      owl:oneOf ( :MeasurementUnitCode_CMQ
+                                                  :MeasurementUnitCode_FTQ
+                                                  :MeasurementUnitCode_GLL
+                                                  :MeasurementUnitCode_INQ
+                                                  :MeasurementUnitCode_LTR
+                                                  :MeasurementUnitCode_MTQ
+                                                )
+                                    ] ;
+                rdfs:comment "Restricted sub-code list of volume units from MeasurementUnitCode"@en ;
+                rdfs:label "VolumeUnitCode"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#WeightUnitCode
+:WeightUnitCode rdf:type owl:Class ;
+                owl:equivalentClass [ rdf:type owl:Class ;
+                                      owl:oneOf ( :MeasurementUnitCode_KGM
+                                                  :MeasurementUnitCode_LBR
+                                                  :MeasurementUnitCode_ONZ
+                                                )
+                                    ] ;
+                rdfs:comment "Restricted sub-code list of weight units from MeasurementUnitCode"@en ;
+                rdfs:label "WeightUnitCode"@en .
+
+
+#################################################################
+#    Individuals
+#################################################################
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Portuguese_Podengo Pequeno
+<<https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Portuguese_Podengo Pequeno> rdf:type owl:NamedIndividual ,
+                                                                                                                :CommodityCode ;
+                                                                                                       rdfs:comment "Portuguese Podengo Pequeno"@en ;
+                                                                                                       rdfs:label "LIVE_MMLS_DOGS_Portuguese_Podengo Pequeno"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#AWBUseIndicator_R
+:AWBUseIndicator_R rdf:type owl:NamedIndividual ,
+                            :AWBUseIndicator ;
+                   rdfs:comment "Revenue AWB"@en ;
+                   rdfs:label "R"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#AWBUseIndicator_S
+:AWBUseIndicator_S rdf:type owl:NamedIndividual ,
+                            :AWBUseIndicator ;
+                   rdfs:comment "Service AWB"@en ;
+                   rdfs:label "S"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#AWBUseIndicator_V
+:AWBUseIndicator_V rdf:type owl:NamedIndividual ,
+                            :AWBUseIndicator ;
+                   rdfs:comment "Void AWB"@en ;
+                   rdfs:label "V"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#AircraftPossibilityCode_BBF
+:AircraftPossibilityCode_BBF rdf:type owl:NamedIndividual ,
+                                      :AircraftPossibilityCode ;
+                             rdfs:comment "Pure freighter flight carrying Loose Load Cargo"@en ;
+                             rdfs:label "BBF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#AircraftPossibilityCode_BBQ
+:AircraftPossibilityCode_BBQ rdf:type owl:NamedIndividual ,
+                                      :AircraftPossibilityCode ;
+                             rdfs:comment "Mixed configuration (Combi) aircraft carrying Loose Load Cargo on the passenger deck"@en ;
+                             rdfs:label "BBQ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#AircraftPossibilityCode_BBV
+:AircraftPossibilityCode_BBV rdf:type owl:NamedIndividual ,
+                                      :AircraftPossibilityCode ;
+                             rdfs:comment "Truck carrying Loose Load Cargo"@en ;
+                             rdfs:label "BBV"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#AircraftPossibilityCode_LLF
+:AircraftPossibilityCode_LLF rdf:type owl:NamedIndividual ,
+                                      :AircraftPossibilityCode ;
+                             rdfs:comment "Pure freighter flight carrying Containerized Cargo (ULDs)"@en ;
+                             rdfs:label "LLF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#AircraftPossibilityCode_LLJ
+:AircraftPossibilityCode_LLJ rdf:type owl:NamedIndividual ,
+                                      :AircraftPossibilityCode ;
+                             rdfs:comment "Passenger flight operated by wide-bodied aircraft carrying Containerized (ULDs)"@en ;
+                             rdfs:label "LLJ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#AircraftPossibilityCode_LLQ
+:AircraftPossibilityCode_LLQ rdf:type owl:NamedIndividual ,
+                                      :AircraftPossibilityCode ;
+                             rdfs:comment "Mixed configuration (Combi) aircraft carrying Containerized Cargo (ULDs) on the passenger deck"@en ;
+                             rdfs:label "LLQ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#AircraftPossibilityCode_LLV
+:AircraftPossibilityCode_LLV rdf:type owl:NamedIndividual ,
+                                      :AircraftPossibilityCode ;
+                             rdfs:comment "Truck carrying Containerized Cargo (ULDs)"@en ;
+                             rdfs:label "LLV"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#AircraftPossibilityCode_LPF
+:AircraftPossibilityCode_LPF rdf:type owl:NamedIndividual ,
+                                      :AircraftPossibilityCode ;
+                             rdfs:comment "Pure freighter flight carrying Containerized (ULDs)/Palletized Cargo"@en ;
+                             rdfs:label "LPF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#AircraftPossibilityCode_LPJ
+:AircraftPossibilityCode_LPJ rdf:type owl:NamedIndividual ,
+                                      :AircraftPossibilityCode ;
+                             rdfs:comment "Passenger flight operated by wide-bodied aircraft carrying Containerized (ULDs)/ Palletized Cargo"@en ;
+                             rdfs:label "LPJ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#AircraftPossibilityCode_LPQ
+:AircraftPossibilityCode_LPQ rdf:type owl:NamedIndividual ,
+                                      :AircraftPossibilityCode ;
+                             rdfs:comment "Mixed configuration (Combi) aircraft carrying Containerized (ULDs)/Palletized Cargo on the passenger deck"@en ;
+                             rdfs:label "LPQ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#AircraftPossibilityCode_LPV
+:AircraftPossibilityCode_LPV rdf:type owl:NamedIndividual ,
+                                      :AircraftPossibilityCode ;
+                             rdfs:comment "Truck carrying Containerized (ULDs)/Palletized Cargo"@en ;
+                             rdfs:label "LPV"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#AircraftPossibilityCode_PPF
+:AircraftPossibilityCode_PPF rdf:type owl:NamedIndividual ,
+                                      :AircraftPossibilityCode ;
+                             rdfs:comment "Pure freighter flight carrying Palletized Cargo"@en ;
+                             rdfs:label "PPF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#AircraftPossibilityCode_PPJ
+:AircraftPossibilityCode_PPJ rdf:type owl:NamedIndividual ,
+                                      :AircraftPossibilityCode ;
+                             rdfs:comment "Passenger flight operated by wide-bodied aircraft carrying Palletized Cargo"@en ;
+                             rdfs:label "PPJ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#AircraftPossibilityCode_PPQ
+:AircraftPossibilityCode_PPQ rdf:type owl:NamedIndividual ,
+                                      :AircraftPossibilityCode ;
+                             rdfs:comment "Mixed configuration aircraft carrying Palletized Cargo on the passenger deck"@en ;
+                             rdfs:label "PPQ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#AircraftPossibilityCode_PPV
+:AircraftPossibilityCode_PPV rdf:type owl:NamedIndividual ,
+                                      :AircraftPossibilityCode ;
+                             rdfs:comment "Truck carrying Palletized Cargo"@en ;
+                             rdfs:label "PPV"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeCode_CA
+:ChargeCode_CA rdf:type owl:NamedIndividual ,
+                        :ChargeCode ;
+               rdfs:comment "Partial Collect Credit — Partial Prepaid Cash"@en ;
+               rdfs:label "CA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeCode_CB
+:ChargeCode_CB rdf:type owl:NamedIndividual ,
+                        :ChargeCode ;
+               rdfs:comment "Partial Collect Credit — Partial Prepaid Credit"@en ;
+               rdfs:label "CB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeCode_CC
+:ChargeCode_CC rdf:type owl:NamedIndividual ,
+                        :ChargeCode ;
+               rdfs:comment "All Charges Collect"@en ;
+               rdfs:label "CC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeCode_CE
+:ChargeCode_CE rdf:type owl:NamedIndividual ,
+                        :ChargeCode ;
+               rdfs:comment "Partial Collect Credit Card — Partial Prepaid Cash"@en ;
+               rdfs:label "CE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeCode_CG
+:ChargeCode_CG rdf:type owl:NamedIndividual ,
+                        :ChargeCode ;
+               rdfs:comment "All Charges Collect by GBL"@en ;
+               rdfs:label "CG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeCode_CH
+:ChargeCode_CH rdf:type owl:NamedIndividual ,
+                        :ChargeCode ;
+               rdfs:comment "Partial Collect Credit Card — Partial Prepaid Credit"@en ;
+               rdfs:label "CH"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeCode_CM
+:ChargeCode_CM rdf:type owl:NamedIndividual ,
+                        :ChargeCode ;
+               rdfs:comment "Destination Collect by MCO"@en ;
+               rdfs:label "CM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeCode_CP
+:ChargeCode_CP rdf:type owl:NamedIndividual ,
+                        :ChargeCode ;
+               rdfs:comment "Destination Collect Cash"@en ;
+               rdfs:label "CP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeCode_CX
+:ChargeCode_CX rdf:type owl:NamedIndividual ,
+                        :ChargeCode ;
+               rdfs:comment "Destination Collect Credit"@en ;
+               rdfs:label "CX"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeCode_CZ
+:ChargeCode_CZ rdf:type owl:NamedIndividual ,
+                        :ChargeCode ;
+               rdfs:comment "All Charges Collect by Credit Card"@en ;
+               rdfs:label "CZ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeCode_NC
+:ChargeCode_NC rdf:type owl:NamedIndividual ,
+                        :ChargeCode ;
+               rdfs:comment "No Charge"@en ;
+               rdfs:label "NC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeCode_NG
+:ChargeCode_NG rdf:type owl:NamedIndividual ,
+                        :ChargeCode ;
+               rdfs:comment "No Weight Charge — Other Charges Prepaid by GBL"@en ;
+               rdfs:label "NG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeCode_NP
+:ChargeCode_NP rdf:type owl:NamedIndividual ,
+                        :ChargeCode ;
+               rdfs:comment "No Weight Charge — Other Charges Prepaid Cash"@en ;
+               rdfs:label "NP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeCode_NT
+:ChargeCode_NT rdf:type owl:NamedIndividual ,
+                        :ChargeCode ;
+               rdfs:comment "No Weight Charge — Other Charges Collect"@en ;
+               rdfs:label "NT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeCode_NX
+:ChargeCode_NX rdf:type owl:NamedIndividual ,
+                        :ChargeCode ;
+               rdfs:comment "No Weight Charge — Other Charges Prepaid Credit"@en ;
+               rdfs:label "NX"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeCode_NZ
+:ChargeCode_NZ rdf:type owl:NamedIndividual ,
+                        :ChargeCode ;
+               rdfs:comment "No Weight Charge — Other Charges Prepaid by Credit Card"@en ;
+               rdfs:label "NZ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeCode_PC
+:ChargeCode_PC rdf:type owl:NamedIndividual ,
+                        :ChargeCode ;
+               rdfs:comment "Partial Prepaid Cash — Partial Collect Cash"@en ;
+               rdfs:label "PC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeCode_PD
+:ChargeCode_PD rdf:type owl:NamedIndividual ,
+                        :ChargeCode ;
+               rdfs:comment "Partial Prepaid Credit — Partial Collect Cash"@en ;
+               rdfs:label "PD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeCode_PE
+:ChargeCode_PE rdf:type owl:NamedIndividual ,
+                        :ChargeCode ;
+               rdfs:comment "Partial Prepaid Credit Card — Partial Collect Cash"@en ;
+               rdfs:label "PE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeCode_PF
+:ChargeCode_PF rdf:type owl:NamedIndividual ,
+                        :ChargeCode ;
+               rdfs:comment "Partial Prepaid Credit Card — Partial Collect Credit Card"@en ;
+               rdfs:label "PF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeCode_PG
+:ChargeCode_PG rdf:type owl:NamedIndividual ,
+                        :ChargeCode ;
+               rdfs:comment "All Charges Prepaid by GBL"@en ;
+               rdfs:label "PG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeCode_PH
+:ChargeCode_PH rdf:type owl:NamedIndividual ,
+                        :ChargeCode ;
+               rdfs:comment "Partial Prepaid Credit Card — Partial Collect Credit"@en ;
+               rdfs:label "PH"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeCode_PP
+:ChargeCode_PP rdf:type owl:NamedIndividual ,
+                        :ChargeCode ;
+               rdfs:comment "All Charges Prepaid Cash"@en ;
+               rdfs:label "PP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeCode_PX
+:ChargeCode_PX rdf:type owl:NamedIndividual ,
+                        :ChargeCode ;
+               rdfs:comment "All Charges Prepaid Credit"@en ;
+               rdfs:label "PX"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeCode_PZ
+:ChargeCode_PZ rdf:type owl:NamedIndividual ,
+                        :ChargeCode ;
+               rdfs:comment "All Charges Prepaid by Credit Card"@en ;
+               rdfs:label "PZ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeIdentifier_CN
+:ChargeIdentifier_CN rdf:type owl:NamedIndividual ,
+                              :ChargeIdentifier ;
+                     rdfs:comment "CASS Net Amount"@en ;
+                     rdfs:label "CN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeIdentifier_CO
+:ChargeIdentifier_CO rdf:type owl:NamedIndividual ,
+                              :ChargeIdentifier ;
+                     rdfs:comment "Commission"@en ;
+                     rdfs:label "CO"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeIdentifier_CT
+:ChargeIdentifier_CT rdf:type owl:NamedIndividual ,
+                              :ChargeIdentifier ;
+                     rdfs:comment "Charge Summary Total"@en ;
+                     rdfs:label "CT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeIdentifier_IN
+:ChargeIdentifier_IN rdf:type owl:NamedIndividual ,
+                              :ChargeIdentifier ;
+                     rdfs:comment "Insurance"@en ;
+                     rdfs:label "IN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeIdentifier_NI
+:ChargeIdentifier_NI rdf:type owl:NamedIndividual ,
+                              :ChargeIdentifier ;
+                     rdfs:comment "CASS Invoice Amount"@en ;
+                     rdfs:label "NI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeIdentifier_OA
+:ChargeIdentifier_OA rdf:type owl:NamedIndividual ,
+                              :ChargeIdentifier ;
+                     rdfs:comment "Total Other Charges Due Agent"@en ;
+                     rdfs:label "OA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeIdentifier_OC
+:ChargeIdentifier_OC rdf:type owl:NamedIndividual ,
+                              :ChargeIdentifier ;
+                     rdfs:comment "Total Other Charges Due Carrier"@en ;
+                     rdfs:label "OC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeIdentifier_SI
+:ChargeIdentifier_SI rdf:type owl:NamedIndividual ,
+                              :ChargeIdentifier ;
+                     rdfs:comment "Sales Incentive"@en ;
+                     rdfs:label "SI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeIdentifier_TX
+:ChargeIdentifier_TX rdf:type owl:NamedIndividual ,
+                              :ChargeIdentifier ;
+                     rdfs:comment "Taxes"@en ;
+                     rdfs:label "TX"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeIdentifier_VC
+:ChargeIdentifier_VC rdf:type owl:NamedIndividual ,
+                              :ChargeIdentifier ;
+                     rdfs:comment "Valuation Charge"@en ;
+                     rdfs:label "VC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeIdentifier_WT
+:ChargeIdentifier_WT rdf:type owl:NamedIndividual ,
+                              :ChargeIdentifier ;
+                     rdfs:comment "Total Weight Charge"@en ;
+                     rdfs:label "WT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CHEM
+:CommodityCode_CHEM rdf:type owl:NamedIndividual ,
+                             :CommodityCode ;
+                    rdfs:comment "Chemicals"@en ;
+                    rdfs:label "CHEM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CHEM_CDGR
+:CommodityCode_CHEM_CDGR rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Chemicals - Dangerous"@en ;
+                         rdfs:label "CHEM_CDGR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CHEM_CLNG
+:CommodityCode_CHEM_CLNG rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Cleaning products"@en ;
+                         rdfs:label "CHEM_CLNG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CHEM_CNDG
+:CommodityCode_CHEM_CNDG rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Chemicals - Not dangerous"@en ;
+                         rdfs:label "CHEM_CNDG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CHEM_CNMD
+:CommodityCode_CHEM_CNMD rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Chemicals - Not Medical"@en ;
+                         rdfs:label "CHEM_CNMD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CHEM_COSM
+:CommodityCode_CHEM_COSM rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Cosmetics"@en ;
+                         rdfs:label "CHEM_COSM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CHEM_COSM_COSD
+:CommodityCode_CHEM_COSM_COSD rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Cosmetics - DGR"@en ;
+                              rdfs:label "CHEM_COSM_COSD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CHEM_COSM_PERF
+:CommodityCode_CHEM_COSM_PERF rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Perfume"@en ;
+                              rdfs:label "CHEM_COSM_PERF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CHEM_DGRG
+:CommodityCode_CHEM_DGRG rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Dangerous Goods"@en ;
+                         rdfs:label "CHEM_DGRG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CHEM_DGRG_EXPL
+:CommodityCode_CHEM_DGRG_EXPL rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Explosives"@en ;
+                              rdfs:label "CHEM_DGRG_EXPL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CHEM_DICE
+:CommodityCode_CHEM_DICE rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Dry ice"@en ;
+                         rdfs:label "CHEM_DICE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CHEM_PAIN
+:CommodityCode_CHEM_PAIN rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Paint"@en ;
+                         rdfs:label "CHEM_PAIN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CHEM_PETRO
+:CommodityCode_CHEM_PETRO rdf:type owl:NamedIndividual ,
+                                   :CommodityCode ;
+                          rdfs:comment "Petroleum derivatives"@en ;
+                          rdfs:label "CHEM_PETRO"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CHEM_RADA
+:CommodityCode_CHEM_RADA rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Radioactive materials"@en ;
+                         rdfs:label "CHEM_RADA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CHEM_REAG
+:CommodityCode_CHEM_REAG rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Reagents"@en ;
+                         rdfs:label "CHEM_REAG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CONS
+:CommodityCode_CONS rdf:type owl:NamedIndividual ,
+                             :CommodityCode ;
+                    rdfs:comment "Consumer goods"@en ;
+                    rdfs:label "CONS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CONS_CMPY
+:CommodityCode_CONS_CMPY rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Company material"@en ;
+                         rdfs:label "CONS_CMPY"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CONS_CWRE
+:CommodityCode_CONS_CWRE rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Chinaware and Ceramics"@en ;
+                         rdfs:label "CONS_CWRE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CONS_DIPL
+:CommodityCode_CONS_DIPL rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Diplomatic mail and goods"@en ;
+                         rdfs:label "CONS_DIPL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CONS_EXHB
+:CommodityCode_CONS_EXHB rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Exhibition goods"@en ;
+                         rdfs:label "CONS_EXHB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CONS_FRNT
+:CommodityCode_CONS_FRNT rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Furniture"@en ;
+                         rdfs:label "CONS_FRNT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CONS_GLAS
+:CommodityCode_CONS_GLAS rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Glassware"@en ;
+                         rdfs:label "CONS_GLAS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CONS_HAID
+:CommodityCode_CONS_HAID rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Humanitarian aid"@en ;
+                         rdfs:label "CONS_HAID"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CONS_HHGD
+:CommodityCode_CONS_HHGD rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Household goods"@en ;
+                         rdfs:label "CONS_HHGD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CONS_HRSE
+:CommodityCode_CONS_HRSE rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Horse equipment"@en ;
+                         rdfs:label "CONS_HRSE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CONS_HSER
+:CommodityCode_CONS_HSER rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "House removal"@en ;
+                         rdfs:label "CONS_HSER"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CONS_OFSP
+:CommodityCode_CONS_OFSP rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Office supplies"@en ;
+                         rdfs:label "CONS_OFSP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CONS_PERS
+:CommodityCode_CONS_PERS rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Personal effects"@en ;
+                         rdfs:label "CONS_PERS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CONS_SPEC
+:CommodityCode_CONS_SPEC rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Spectacles"@en ;
+                         rdfs:label "CONS_SPEC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CONS_SPRT
+:CommodityCode_CONS_SPRT rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Sports equipment"@en ;
+                         rdfs:label "CONS_SPRT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CONS_TOYS
+:CommodityCode_CONS_TOYS rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Toys and Games"@en ;
+                         rdfs:label "CONS_TOYS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_CONS_UBAG
+:CommodityCode_CONS_UBAG rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Unaccompagnied baggage"@en ;
+                         rdfs:label "CONS_UBAG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_ELEC
+:CommodityCode_ELEC rdf:type owl:NamedIndividual ,
+                             :CommodityCode ;
+                    rdfs:comment "Electronic equipment"@en ;
+                    rdfs:label "ELEC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_ELEC_AVEQ
+:CommodityCode_ELEC_AVEQ rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Audio-Video-HiFi equipment"@en ;
+                         rdfs:label "ELEC_AVEQ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_ELEC_CALC
+:CommodityCode_ELEC_CALC rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Calculators"@en ;
+                         rdfs:label "ELEC_CALC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_ELEC_CMPT
+:CommodityCode_ELEC_CMPT rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Computers"@en ;
+                         rdfs:label "ELEC_CMPT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_ELEC_CPRT
+:CommodityCode_ELEC_CPRT rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Computer parts"@en ;
+                         rdfs:label "ELEC_CPRT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_ELEC_ECOM
+:CommodityCode_ELEC_ECOM rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Electronic components"@en ;
+                         rdfs:label "ELEC_ECOM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_ELEC_EEQP
+:CommodityCode_ELEC_EEQP rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Electronic equipment"@en ;
+                         rdfs:label "ELEC_EEQP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_ELEC_EGDS
+:CommodityCode_ELEC_EGDS rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Electronic goods"@en ;
+                         rdfs:label "ELEC_EGDS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_ELEC_ELQP
+:CommodityCode_ELEC_ELQP rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Electrical equipment"@en ;
+                         rdfs:label "ELEC_ELQP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_ELEC_OFEQ
+:CommodityCode_ELEC_OFEQ rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Office equipment"@en ;
+                         rdfs:label "ELEC_OFEQ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_ELEC_QUAN
+:CommodityCode_ELEC_QUAN rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Quantum"@en ;
+                         rdfs:label "ELEC_QUAN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_ELEC_TELC
+:CommodityCode_ELEC_TELC rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Telecom equipment"@en ;
+                         rdfs:label "ELEC_TELC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FLWR
+:CommodityCode_FLWR rdf:type owl:NamedIndividual ,
+                             :CommodityCode ;
+                    rdfs:comment "Plants, Flowers, Seeds"@en ;
+                    rdfs:label "FLWR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FLWR_FLWR
+:CommodityCode_FLWR_FLWR rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Fresh flowers"@en ;
+                         rdfs:label "FLWR_FLWR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FLWR_FLWR_CFLW
+:CommodityCode_FLWR_FLWR_CFLW rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Cut flowers"@en ;
+                              rdfs:label "FLWR_FLWR_CFLW"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FLWR_FLWR_TFLW
+:CommodityCode_FLWR_FLWR_TFLW rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Tropical flowers"@en ;
+                              rdfs:label "FLWR_FLWR_TFLW"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FLWR_FLWR_TULP
+:CommodityCode_FLWR_FLWR_TULP rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Fresh tulips"@en ;
+                              rdfs:label "FLWR_FLWR_TULP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FLWR_FMNT
+:CommodityCode_FLWR_FMNT rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Fresh mint"@en ;
+                         rdfs:label "FLWR_FMNT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FLWR_HERBS
+:CommodityCode_FLWR_HERBS rdf:type owl:NamedIndividual ,
+                                   :CommodityCode ;
+                          rdfs:comment "Herbs, Leaves and Foliage"@en ;
+                          rdfs:label "FLWR_HERBS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FLWR_PLNT
+:CommodityCode_FLWR_PLNT rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Plants"@en ;
+                         rdfs:label "FLWR_PLNT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FLWR_PLNT_APLN
+:CommodityCode_FLWR_PLNT_APLN rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Aquatic plants"@en ;
+                              rdfs:label "FLWR_PLNT_APLN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FLWR_PLNT_BULB
+:CommodityCode_FLWR_PLNT_BULB rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Bulbs and Tubers"@en ;
+                              rdfs:label "FLWR_PLNT_BULB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FLWR_PLNT_MPLN
+:CommodityCode_FLWR_PLNT_MPLN rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Medicinal plants"@en ;
+                              rdfs:label "FLWR_PLNT_MPLN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FLWR_PLNT_TPLN
+:CommodityCode_FLWR_PLNT_TPLN rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Tropical plants"@en ;
+                              rdfs:label "FLWR_PLNT_TPLN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FLWR_SEED
+:CommodityCode_FLWR_SEED rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Seeds"@en ;
+                         rdfs:label "FLWR_SEED"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD
+:CommodityCode_FOOD rdf:type owl:NamedIndividual ,
+                             :CommodityCode ;
+                    rdfs:comment "Foodstuffs, Drinks and Tobacco"@en ;
+                    rdfs:label "FOOD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_BVRG
+:CommodityCode_FOOD_BVRG rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Beverages"@en ;
+                         rdfs:label "FOOD_BVRG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_BVRG_BEER
+:CommodityCode_FOOD_BVRG_BEER rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Beer"@en ;
+                              rdfs:label "FOOD_BVRG_BEER"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_BVRG_COFY
+:CommodityCode_FOOD_BVRG_COFY rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Coffee"@en ;
+                              rdfs:label "FOOD_BVRG_COFY"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_BVRG_TEA
+:CommodityCode_FOOD_BVRG_TEA rdf:type owl:NamedIndividual ,
+                                      :CommodityCode ;
+                             rdfs:comment "Tea"@en ;
+                             rdfs:label "FOOD_BVRG_TEA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_BVRG_WINE
+:CommodityCode_FOOD_BVRG_WINE rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Wine"@en ;
+                              rdfs:label "FOOD_BVRG_WINE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_CERE
+:CommodityCode_FOOD_CERE rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Cereal foods"@en ;
+                         rdfs:label "FOOD_CERE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_CERE_BRED
+:CommodityCode_FOOD_CERE_BRED rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Bread"@en ;
+                              rdfs:label "FOOD_CERE_BRED"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_CERE_CAKE
+:CommodityCode_FOOD_CERE_CAKE rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Cakes and Pastries"@en ;
+                              rdfs:label "FOOD_CERE_CAKE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_DARY
+:CommodityCode_FOOD_DARY rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Dairy products"@en ;
+                         rdfs:label "FOOD_DARY"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_DARY_CHSE
+:CommodityCode_FOOD_DARY_CHSE rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Cheese"@en ;
+                              rdfs:label "FOOD_DARY_CHSE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_DARY_EGGS
+:CommodityCode_FOOD_DARY_EGGS rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Eggs"@en ;
+                              rdfs:label "FOOD_DARY_EGGS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_DARY_ICEC
+:CommodityCode_FOOD_DARY_ICEC rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Ice cream"@en ;
+                              rdfs:label "FOOD_DARY_ICEC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FISH
+:CommodityCode_FOOD_FISH rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Fish and Seafood"@en ;
+                         rdfs:label "FOOD_FISH"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FISH_ALBA
+:CommodityCode_FOOD_FISH_ALBA rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Albacora"@en ;
+                              rdfs:label "FOOD_FISH_ALBA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FISH_CAVR
+:CommodityCode_FOOD_FISH_CAVR rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Caviar"@en ;
+                              rdfs:label "FOOD_FISH_CAVR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FISH_FFSH
+:CommodityCode_FOOD_FISH_FFSH rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Fresh fish"@en ;
+                              rdfs:label "FOOD_FISH_FFSH"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FISH_FRZF
+:CommodityCode_FOOD_FISH_FRZF rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Frozen fish"@en ;
+                              rdfs:label "FOOD_FISH_FRZF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FISH_FRZS
+:CommodityCode_FOOD_FISH_FRZS rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Frozen seafood"@en ;
+                              rdfs:label "FOOD_FISH_FRZS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FISH_HAKE
+:CommodityCode_FOOD_FISH_HAKE rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Hake"@en ;
+                              rdfs:label "FOOD_FISH_HAKE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FISH_LOBS
+:CommodityCode_FOOD_FISH_LOBS rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Lobsters and Crabs"@en ;
+                              rdfs:label "FOOD_FISH_LOBS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FISH_REPA
+:CommodityCode_FOOD_FISH_REPA rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Reineta and Palometa"@en ;
+                              rdfs:label "FOOD_FISH_REPA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FISH_SFIN
+:CommodityCode_FOOD_FISH_SFIN rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Shark fin"@en ;
+                              rdfs:label "FOOD_FISH_SFIN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FISH_SFSH
+:CommodityCode_FOOD_FISH_SFSH rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Smoked fish"@en ;
+                              rdfs:label "FOOD_FISH_SFSH"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FISH_SHRI
+:CommodityCode_FOOD_FISH_SHRI rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Shrimps and Prawns"@en ;
+                              rdfs:label "FOOD_FISH_SHRI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FISH_SLMN
+:CommodityCode_FOOD_FISH_SLMN rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Salmon"@en ;
+                              rdfs:label "FOOD_FISH_SLMN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FISH_TUNA
+:CommodityCode_FOOD_FISH_TUNA rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Tuna"@en ;
+                              rdfs:label "FOOD_FISH_TUNA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FRTV
+:CommodityCode_FOOD_FRTV rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Fruits and Vegetables"@en ;
+                         rdfs:label "FOOD_FRTV"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FRTV_APPL
+:CommodityCode_FOOD_FRTV_APPL rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Apples"@en ;
+                              rdfs:label "FOOD_FRTV_APPL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FRTV_ASPA
+:CommodityCode_FOOD_FRTV_ASPA rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Asparagus"@en ;
+                              rdfs:label "FOOD_FRTV_ASPA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FRTV_AVOC
+:CommodityCode_FOOD_FRTV_AVOC rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Avocados"@en ;
+                              rdfs:label "FOOD_FRTV_AVOC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FRTV_BANA
+:CommodityCode_FOOD_FRTV_BANA rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Bananas"@en ;
+                              rdfs:label "FOOD_FRTV_BANA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FRTV_BEAN
+:CommodityCode_FOOD_FRTV_BEAN rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "String beans"@en ;
+                              rdfs:label "FOOD_FRTV_BEAN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FRTV_BERR
+:CommodityCode_FOOD_FRTV_BERR rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Berries"@en ;
+                              rdfs:label "FOOD_FRTV_BERR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FRTV_CHER
+:CommodityCode_FOOD_FRTV_CHER rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Cherries"@en ;
+                              rdfs:label "FOOD_FRTV_CHER"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FRTV_CMBR
+:CommodityCode_FOOD_FRTV_CMBR rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Cucumber"@en ;
+                              rdfs:label "FOOD_FRTV_CMBR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FRTV_DURI
+:CommodityCode_FOOD_FRTV_DURI rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Durian"@en ;
+                              rdfs:label "FOOD_FRTV_DURI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FRTV_GARL
+:CommodityCode_FOOD_FRTV_GARL rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Garlic"@en ;
+                              rdfs:label "FOOD_FRTV_GARL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FRTV_GRAP
+:CommodityCode_FOOD_FRTV_GRAP rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Grapes"@en ;
+                              rdfs:label "FOOD_FRTV_GRAP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FRTV_LITC
+:CommodityCode_FOOD_FRTV_LITC rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Litchies"@en ;
+                              rdfs:label "FOOD_FRTV_LITC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FRTV_MANG
+:CommodityCode_FOOD_FRTV_MANG rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Mangoes"@en ;
+                              rdfs:label "FOOD_FRTV_MANG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FRTV_MLNS
+:CommodityCode_FOOD_FRTV_MLNS rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Melons"@en ;
+                              rdfs:label "FOOD_FRTV_MLNS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FRTV_MUSH
+:CommodityCode_FOOD_FRTV_MUSH rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Mushrooms"@en ;
+                              rdfs:label "FOOD_FRTV_MUSH"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FRTV_PEPP
+:CommodityCode_FOOD_FRTV_PEPP rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Peppers"@en ;
+                              rdfs:label "FOOD_FRTV_PEPP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FRTV_PINE
+:CommodityCode_FOOD_FRTV_PINE rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Pineapple"@en ;
+                              rdfs:label "FOOD_FRTV_PINE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FRTV_PPYA
+:CommodityCode_FOOD_FRTV_PPYA rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Papaya"@en ;
+                              rdfs:label "FOOD_FRTV_PPYA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FRTV_PROD
+:CommodityCode_FOOD_FRTV_PROD rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Produce"@en ;
+                              rdfs:label "FOOD_FRTV_PROD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FRTV_STRW
+:CommodityCode_FOOD_FRTV_STRW rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Strawberries"@en ;
+                              rdfs:label "FOOD_FRTV_STRW"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_FRTV_TOMA
+:CommodityCode_FOOD_FRTV_TOMA rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Tomatoes"@en ;
+                              rdfs:label "FOOD_FRTV_TOMA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_MEAT
+:CommodityCode_FOOD_MEAT rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Meat products"@en ;
+                         rdfs:label "FOOD_MEAT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_MEAT_BEEF
+:CommodityCode_FOOD_MEAT_BEEF rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Beef products"@en ;
+                              rdfs:label "FOOD_MEAT_BEEF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_MEAT_DRIM
+:CommodityCode_FOOD_MEAT_DRIM rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Dried meat"@en ;
+                              rdfs:label "FOOD_MEAT_DRIM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_MEAT_FRZM
+:CommodityCode_FOOD_MEAT_FRZM rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Frozen meat"@en ;
+                              rdfs:label "FOOD_MEAT_FRZM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_MEAT_GOSL
+:CommodityCode_FOOD_MEAT_GOSL rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Goose liver"@en ;
+                              rdfs:label "FOOD_MEAT_GOSL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_MEAT_GUTS
+:CommodityCode_FOOD_MEAT_GUTS rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Guts"@en ;
+                              rdfs:label "FOOD_MEAT_GUTS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_MEAT_HRSP
+:CommodityCode_FOOD_MEAT_HRSP rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Horse products"@en ;
+                              rdfs:label "FOOD_MEAT_HRSP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_MEAT_MEAT
+:CommodityCode_FOOD_MEAT_MEAT rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Meat"@en ;
+                              rdfs:label "FOOD_MEAT_MEAT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_MEAT_PORK
+:CommodityCode_FOOD_MEAT_PORK rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Pork products"@en ;
+                              rdfs:label "FOOD_MEAT_PORK"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_MEAT_SAUS
+:CommodityCode_FOOD_MEAT_SAUS rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Sausages"@en ;
+                              rdfs:label "FOOD_MEAT_SAUS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_PERI
+:CommodityCode_FOOD_PERI rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Perhishables"@en ;
+                         rdfs:label "FOOD_PERI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_STUF
+:CommodityCode_FOOD_STUF rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Foodstuffs"@en ;
+                         rdfs:label "FOOD_STUF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_STUF_CATE
+:CommodityCode_FOOD_STUF_CATE rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Catering products"@en ;
+                              rdfs:label "FOOD_STUF_CATE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_STUF_CHOC
+:CommodityCode_FOOD_STUF_CHOC rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Chocolate"@en ;
+                              rdfs:label "FOOD_STUF_CHOC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_STUF_DFRU
+:CommodityCode_FOOD_STUF_DFRU rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Dried fruit"@en ;
+                              rdfs:label "FOOD_STUF_DFRU"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_STUF_MPWD
+:CommodityCode_FOOD_STUF_MPWD rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Milk powder"@en ;
+                              rdfs:label "FOOD_STUF_MPWD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_STUF_NUTS
+:CommodityCode_FOOD_STUF_NUTS rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Nuts"@en ;
+                              rdfs:label "FOOD_STUF_NUTS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_STUF_OOIL
+:CommodityCode_FOOD_STUF_OOIL rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Olive oil"@en ;
+                              rdfs:label "FOOD_STUF_OOIL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_STUF_SPCE
+:CommodityCode_FOOD_STUF_SPCE rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Spices and Roots"@en ;
+                              rdfs:label "FOOD_STUF_SPCE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_TBCO
+:CommodityCode_FOOD_TBCO rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Tobacco products"@en ;
+                         rdfs:label "FOOD_TBCO"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_TBCO_CGRT
+:CommodityCode_FOOD_TBCO_CGRT rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Cigarettes"@en ;
+                              rdfs:label "FOOD_TBCO_CGRT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_FOOD_TBCO_CIGA
+:CommodityCode_FOOD_TBCO_CIGA rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Cigars"@en ;
+                              rdfs:label "FOOD_TBCO_CIGA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_GENE
+:CommodityCode_GENE rdf:type owl:NamedIndividual ,
+                             :CommodityCode ;
+                    rdfs:comment "General Cargo"@en ;
+                    rdfs:label "GENE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_HUMR
+:CommodityCode_HUMR rdf:type owl:NamedIndividual ,
+                             :CommodityCode ;
+                    rdfs:comment "Human Remains"@en ;
+                    rdfs:label "HUMR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_HUMR_HUMB
+:CommodityCode_HUMR_HUMB rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Human remains not cremated"@en ;
+                         rdfs:label "HUMR_HUMB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_HUMR_HUMC
+:CommodityCode_HUMR_HUMC rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Human remains cremated"@en ;
+                         rdfs:label "HUMR_HUMC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE
+:CommodityCode_LIVE rdf:type owl:NamedIndividual ,
+                             :CommodityCode ;
+                    rdfs:comment "Live Animals"@en ;
+                    rdfs:label "LIVE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_BRDH
+:CommodityCode_LIVE_BRDH rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Birds & Hatching Eggs"@en ;
+                         rdfs:label "LIVE_BRDH"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_BRDH_BIRD
+:CommodityCode_LIVE_BRDH_BIRD rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Birds"@en ;
+                              rdfs:label "LIVE_BRDH_BIRD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_BRDH_CHIC
+:CommodityCode_LIVE_BRDH_CHIC rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Chicks"@en ;
+                              rdfs:label "LIVE_BRDH_CHIC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_BRDH_DUCK
+:CommodityCode_LIVE_BRDH_DUCK rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Ducks"@en ;
+                              rdfs:label "LIVE_BRDH_DUCK"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_BRDH_HEGG
+:CommodityCode_LIVE_BRDH_HEGG rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Hatching Eggs"@en ;
+                              rdfs:label "LIVE_BRDH_HEGG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_BRDH_OSTR
+:CommodityCode_LIVE_BRDH_OSTR rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Ostriches"@en ;
+                              rdfs:label "LIVE_BRDH_OSTR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_BRDH_PARR
+:CommodityCode_LIVE_BRDH_PARR rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Parrots"@en ;
+                              rdfs:label "LIVE_BRDH_PARR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_BRDH_TRKY
+:CommodityCode_LIVE_BRDH_TRKY rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Turkeys"@en ;
+                              rdfs:label "LIVE_BRDH_TRKY"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_INSC
+:CommodityCode_LIVE_INSC rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Insects"@en ;
+                         rdfs:label "LIVE_INSC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_INSC_BEES
+:CommodityCode_LIVE_INSC_BEES rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Bees"@en ;
+                              rdfs:label "LIVE_INSC_BEES"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_LFSH
+:CommodityCode_LIVE_LFSH rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Fish"@en ;
+                         rdfs:label "LIVE_LFSH"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_LFSH_EELS
+:CommodityCode_LIVE_LFSH_EELS rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Eels"@en ;
+                              rdfs:label "LIVE_LFSH_EELS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_LFSH_KOIF
+:CommodityCode_LIVE_LFSH_KOIF rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Koi fish"@en ;
+                              rdfs:label "LIVE_LFSH_KOIF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_LFSH_TRPF
+:CommodityCode_LIVE_LFSH_TRPF rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Tropical fish"@en ;
+                              rdfs:label "LIVE_LFSH_TRPF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MLKS
+:CommodityCode_LIVE_MLKS rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Mollusks"@en ;
+                         rdfs:label "LIVE_MLKS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MLKS_LUGW
+:CommodityCode_LIVE_MLKS_LUGW rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Lugworms"@en ;
+                              rdfs:label "LIVE_MLKS_LUGW"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MLKS_SNAI
+:CommodityCode_LIVE_MLKS_SNAI rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Snails"@en ;
+                              rdfs:label "LIVE_MLKS_SNAI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS
+:CommodityCode_LIVE_MMLS rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Mammals"@en ;
+                         rdfs:label "LIVE_MMLS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATL
+:CommodityCode_LIVE_MMLS_CATL rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Cattle"@en ;
+                              rdfs:label "LIVE_MMLS_CATL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS
+:CommodityCode_LIVE_MMLS_CATS rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Cats"@en ;
+                              rdfs:label "LIVE_MMLS_CATS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Abyssinian
+:CommodityCode_LIVE_MMLS_CATS_Abyssinian rdf:type owl:NamedIndividual ,
+                                                  :CommodityCode ;
+                                         rdfs:comment "Abyssinian"@en ;
+                                         rdfs:label "LIVE_MMLS_CATS_Abyssinian"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_American_Bobtail
+:CommodityCode_LIVE_MMLS_CATS_American_Bobtail rdf:type owl:NamedIndividual ,
+                                                        :CommodityCode ;
+                                               rdfs:comment "American Bobtail"@en ;
+                                               rdfs:label "LIVE_MMLS_CATS_American_Bobtail"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_American_Curl
+:CommodityCode_LIVE_MMLS_CATS_American_Curl rdf:type owl:NamedIndividual ,
+                                                     :CommodityCode ;
+                                            rdfs:comment "American Curl"@en ;
+                                            rdfs:label "LIVE_MMLS_CATS_American_Curl"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_American_Keuda
+:CommodityCode_LIVE_MMLS_CATS_American_Keuda rdf:type owl:NamedIndividual ,
+                                                      :CommodityCode ;
+                                             rdfs:comment "American Keuda"@en ;
+                                             rdfs:label "LIVE_MMLS_CATS_American_Keuda"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_American_Lynx
+:CommodityCode_LIVE_MMLS_CATS_American_Lynx rdf:type owl:NamedIndividual ,
+                                                     :CommodityCode ;
+                                            rdfs:comment "American Lynx"@en ;
+                                            rdfs:label "LIVE_MMLS_CATS_American_Lynx"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_American_Polydactyl
+:CommodityCode_LIVE_MMLS_CATS_American_Polydactyl rdf:type owl:NamedIndividual ,
+                                                           :CommodityCode ;
+                                                  rdfs:comment "American Polydactyl"@en ;
+                                                  rdfs:label "LIVE_MMLS_CATS_American_Polydactyl"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_American_Shorthair
+:CommodityCode_LIVE_MMLS_CATS_American_Shorthair rdf:type owl:NamedIndividual ,
+                                                          :CommodityCode ;
+                                                 rdfs:comment "American Shorthair"@en ;
+                                                 rdfs:label "LIVE_MMLS_CATS_American_Shorthair"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_American_Wirehair
+:CommodityCode_LIVE_MMLS_CATS_American_Wirehair rdf:type owl:NamedIndividual ,
+                                                         :CommodityCode ;
+                                                rdfs:comment "American Wirehair"@en ;
+                                                rdfs:label "LIVE_MMLS_CATS_American_Wirehair"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Asian
+:CommodityCode_LIVE_MMLS_CATS_Asian rdf:type owl:NamedIndividual ,
+                                             :CommodityCode ;
+                                    rdfs:comment "Asian"@en ;
+                                    rdfs:label "LIVE_MMLS_CATS_Asian"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Australian_Mist
+:CommodityCode_LIVE_MMLS_CATS_Australian_Mist rdf:type owl:NamedIndividual ,
+                                                       :CommodityCode ;
+                                              rdfs:comment "Australian Mist"@en ;
+                                              rdfs:label "LIVE_MMLS_CATS_Australian_Mist"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Balinese
+:CommodityCode_LIVE_MMLS_CATS_Balinese rdf:type owl:NamedIndividual ,
+                                                :CommodityCode ;
+                                       rdfs:comment "Balinese"@en ;
+                                       rdfs:label "LIVE_MMLS_CATS_Balinese"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Bengal
+:CommodityCode_LIVE_MMLS_CATS_Bengal rdf:type owl:NamedIndividual ,
+                                              :CommodityCode ;
+                                     rdfs:comment "Bengal"@en ;
+                                     rdfs:label "LIVE_MMLS_CATS_Bengal"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Birman
+:CommodityCode_LIVE_MMLS_CATS_Birman rdf:type owl:NamedIndividual ,
+                                              :CommodityCode ;
+                                     rdfs:comment "Birman"@en ;
+                                     rdfs:label "LIVE_MMLS_CATS_Birman"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Bombay
+:CommodityCode_LIVE_MMLS_CATS_Bombay rdf:type owl:NamedIndividual ,
+                                              :CommodityCode ;
+                                     rdfs:comment "Bombay"@en ;
+                                     rdfs:label "LIVE_MMLS_CATS_Bombay"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Bristol
+:CommodityCode_LIVE_MMLS_CATS_Bristol rdf:type owl:NamedIndividual ,
+                                               :CommodityCode ;
+                                      rdfs:comment "Bristol"@en ;
+                                      rdfs:label "LIVE_MMLS_CATS_Bristol"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_British_Shorthair
+:CommodityCode_LIVE_MMLS_CATS_British_Shorthair rdf:type owl:NamedIndividual ,
+                                                         :CommodityCode ;
+                                                rdfs:comment "British Shorthair"@en ;
+                                                rdfs:label "LIVE_MMLS_CATS_British_Shorthair"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Burmese
+:CommodityCode_LIVE_MMLS_CATS_Burmese rdf:type owl:NamedIndividual ,
+                                               :CommodityCode ;
+                                      rdfs:comment "Burmese"@en ;
+                                      rdfs:label "LIVE_MMLS_CATS_Burmese"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_California_Spangled
+:CommodityCode_LIVE_MMLS_CATS_California_Spangled rdf:type owl:NamedIndividual ,
+                                                           :CommodityCode ;
+                                                  rdfs:comment "California Spangled"@en ;
+                                                  rdfs:label "LIVE_MMLS_CATS_California_Spangled"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Chartreux
+:CommodityCode_LIVE_MMLS_CATS_Chartreux rdf:type owl:NamedIndividual ,
+                                                 :CommodityCode ;
+                                        rdfs:comment "Chartreux"@en ;
+                                        rdfs:label "LIVE_MMLS_CATS_Chartreux"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Chausie
+:CommodityCode_LIVE_MMLS_CATS_Chausie rdf:type owl:NamedIndividual ,
+                                               :CommodityCode ;
+                                      rdfs:comment "Chausie"@en ;
+                                      rdfs:label "LIVE_MMLS_CATS_Chausie"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Chinese_Harlequin
+:CommodityCode_LIVE_MMLS_CATS_Chinese_Harlequin rdf:type owl:NamedIndividual ,
+                                                         :CommodityCode ;
+                                                rdfs:comment "Chinese Harlequin"@en ;
+                                                rdfs:label "LIVE_MMLS_CATS_Chinese_Harlequin"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Color_Point_Shorthair
+:CommodityCode_LIVE_MMLS_CATS_Color_Point_Shorthair rdf:type owl:NamedIndividual ,
+                                                             :CommodityCode ;
+                                                    rdfs:comment "Color Point Shorthair"@en ;
+                                                    rdfs:label "LIVE_MMLS_CATS_Color_Point_Shorthair"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Copper
+:CommodityCode_LIVE_MMLS_CATS_Copper rdf:type owl:NamedIndividual ,
+                                              :CommodityCode ;
+                                     rdfs:comment "Copper"@en ;
+                                     rdfs:label "LIVE_MMLS_CATS_Copper"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Cornish_Rex
+:CommodityCode_LIVE_MMLS_CATS_Cornish_Rex rdf:type owl:NamedIndividual ,
+                                                   :CommodityCode ;
+                                          rdfs:comment "Cornish Rex"@en ;
+                                          rdfs:label "LIVE_MMLS_CATS_Cornish_Rex"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Cymric
+:CommodityCode_LIVE_MMLS_CATS_Cymric rdf:type owl:NamedIndividual ,
+                                              :CommodityCode ;
+                                     rdfs:comment "Cymric"@en ;
+                                     rdfs:label "LIVE_MMLS_CATS_Cymric"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Desert_Lynx
+:CommodityCode_LIVE_MMLS_CATS_Desert_Lynx rdf:type owl:NamedIndividual ,
+                                                   :CommodityCode ;
+                                          rdfs:comment "Desert Lynx"@en ;
+                                          rdfs:label "LIVE_MMLS_CATS_Desert_Lynx"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Devon_Rex
+:CommodityCode_LIVE_MMLS_CATS_Devon_Rex rdf:type owl:NamedIndividual ,
+                                                 :CommodityCode ;
+                                        rdfs:comment "Devon Rex"@en ;
+                                        rdfs:label "LIVE_MMLS_CATS_Devon_Rex"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Donskoy
+:CommodityCode_LIVE_MMLS_CATS_Donskoy rdf:type owl:NamedIndividual ,
+                                               :CommodityCode ;
+                                      rdfs:comment "Donskoy"@en ;
+                                      rdfs:label "LIVE_MMLS_CATS_Donskoy"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Egyptian_Mau
+:CommodityCode_LIVE_MMLS_CATS_Egyptian_Mau rdf:type owl:NamedIndividual ,
+                                                    :CommodityCode ;
+                                           rdfs:comment "Egyptian Mau"@en ;
+                                           rdfs:label "LIVE_MMLS_CATS_Egyptian_Mau"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Exotic_Shorthair
+:CommodityCode_LIVE_MMLS_CATS_Exotic_Shorthair rdf:type owl:NamedIndividual ,
+                                                        :CommodityCode ;
+                                               rdfs:comment "Exotic Shorthair"@en ;
+                                               rdfs:label "LIVE_MMLS_CATS_Exotic_Shorthair"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Havana
+:CommodityCode_LIVE_MMLS_CATS_Havana rdf:type owl:NamedIndividual ,
+                                              :CommodityCode ;
+                                     rdfs:comment "Havana"@en ;
+                                     rdfs:label "LIVE_MMLS_CATS_Havana"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Highland_Lynx
+:CommodityCode_LIVE_MMLS_CATS_Highland_Lynx rdf:type owl:NamedIndividual ,
+                                                     :CommodityCode ;
+                                            rdfs:comment "Highland Lynx"@en ;
+                                            rdfs:label "LIVE_MMLS_CATS_Highland_Lynx"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Himalayan
+:CommodityCode_LIVE_MMLS_CATS_Himalayan rdf:type owl:NamedIndividual ,
+                                                 :CommodityCode ;
+                                        rdfs:comment "Himalayan"@en ;
+                                        rdfs:label "LIVE_MMLS_CATS_Himalayan"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Japanese_Bobtail
+:CommodityCode_LIVE_MMLS_CATS_Japanese_Bobtail rdf:type owl:NamedIndividual ,
+                                                        :CommodityCode ;
+                                               rdfs:comment "Japanese Bobtail"@en ;
+                                               rdfs:label "LIVE_MMLS_CATS_Japanese_Bobtail"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Javanese
+:CommodityCode_LIVE_MMLS_CATS_Javanese rdf:type owl:NamedIndividual ,
+                                                :CommodityCode ;
+                                       rdfs:comment "Javanese"@en ;
+                                       rdfs:label "LIVE_MMLS_CATS_Javanese"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Korat
+:CommodityCode_LIVE_MMLS_CATS_Korat rdf:type owl:NamedIndividual ,
+                                             :CommodityCode ;
+                                    rdfs:comment "Korat"@en ;
+                                    rdfs:label "LIVE_MMLS_CATS_Korat"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_LaPerm
+:CommodityCode_LIVE_MMLS_CATS_LaPerm rdf:type owl:NamedIndividual ,
+                                              :CommodityCode ;
+                                     rdfs:comment "LaPerm"@en ;
+                                     rdfs:label "LIVE_MMLS_CATS_LaPerm"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Maine_Coon
+:CommodityCode_LIVE_MMLS_CATS_Maine_Coon rdf:type owl:NamedIndividual ,
+                                                  :CommodityCode ;
+                                         rdfs:comment "Maine Coon"@en ;
+                                         rdfs:label "LIVE_MMLS_CATS_Maine_Coon"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Manx
+:CommodityCode_LIVE_MMLS_CATS_Manx rdf:type owl:NamedIndividual ,
+                                            :CommodityCode ;
+                                   rdfs:comment "Manx"@en ;
+                                   rdfs:label "LIVE_MMLS_CATS_Manx"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Mojave_Spotted
+:CommodityCode_LIVE_MMLS_CATS_Mojave_Spotted rdf:type owl:NamedIndividual ,
+                                                      :CommodityCode ;
+                                             rdfs:comment "Mojave Spotted"@en ;
+                                             rdfs:label "LIVE_MMLS_CATS_Mojave_Spotted"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Munchkin
+:CommodityCode_LIVE_MMLS_CATS_Munchkin rdf:type owl:NamedIndividual ,
+                                                :CommodityCode ;
+                                       rdfs:comment "Munchkin"@en ;
+                                       rdfs:label "LIVE_MMLS_CATS_Munchkin"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Niebelung
+:CommodityCode_LIVE_MMLS_CATS_Niebelung rdf:type owl:NamedIndividual ,
+                                                 :CommodityCode ;
+                                        rdfs:comment "Niebelung"@en ;
+                                        rdfs:label "LIVE_MMLS_CATS_Niebelung"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Norwegian_Forest
+:CommodityCode_LIVE_MMLS_CATS_Norwegian_Forest rdf:type owl:NamedIndividual ,
+                                                        :CommodityCode ;
+                                               rdfs:comment "Norwegian Forest"@en ;
+                                               rdfs:label "LIVE_MMLS_CATS_Norwegian_Forest"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Ocicat
+:CommodityCode_LIVE_MMLS_CATS_Ocicat rdf:type owl:NamedIndividual ,
+                                              :CommodityCode ;
+                                     rdfs:comment "Ocicat"@en ;
+                                     rdfs:label "LIVE_MMLS_CATS_Ocicat"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Ojos_Azules
+:CommodityCode_LIVE_MMLS_CATS_Ojos_Azules rdf:type owl:NamedIndividual ,
+                                                   :CommodityCode ;
+                                          rdfs:comment "Ojos Azules"@en ;
+                                          rdfs:label "LIVE_MMLS_CATS_Ojos_Azules"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Oriental
+:CommodityCode_LIVE_MMLS_CATS_Oriental rdf:type owl:NamedIndividual ,
+                                                :CommodityCode ;
+                                       rdfs:comment "Oriental"@en ;
+                                       rdfs:label "LIVE_MMLS_CATS_Oriental"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Pantherette
+:CommodityCode_LIVE_MMLS_CATS_Pantherette rdf:type owl:NamedIndividual ,
+                                                   :CommodityCode ;
+                                          rdfs:comment "Pantherette"@en ;
+                                          rdfs:label "LIVE_MMLS_CATS_Pantherette"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Persian
+:CommodityCode_LIVE_MMLS_CATS_Persian rdf:type owl:NamedIndividual ,
+                                               :CommodityCode ;
+                                      rdfs:comment "Persian"@en ;
+                                      rdfs:label "LIVE_MMLS_CATS_Persian"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Peterbald
+:CommodityCode_LIVE_MMLS_CATS_Peterbald rdf:type owl:NamedIndividual ,
+                                                 :CommodityCode ;
+                                        rdfs:comment "Peterbald"@en ;
+                                        rdfs:label "LIVE_MMLS_CATS_Peterbald"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Pixiebob
+:CommodityCode_LIVE_MMLS_CATS_Pixiebob rdf:type owl:NamedIndividual ,
+                                                :CommodityCode ;
+                                       rdfs:comment "Pixiebob"@en ;
+                                       rdfs:label "LIVE_MMLS_CATS_Pixiebob"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Ragamuffin
+:CommodityCode_LIVE_MMLS_CATS_Ragamuffin rdf:type owl:NamedIndividual ,
+                                                  :CommodityCode ;
+                                         rdfs:comment "Ragamuffin"@en ;
+                                         rdfs:label "LIVE_MMLS_CATS_Ragamuffin"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Ragdoll
+:CommodityCode_LIVE_MMLS_CATS_Ragdoll rdf:type owl:NamedIndividual ,
+                                               :CommodityCode ;
+                                      rdfs:comment "Ragdoll"@en ;
+                                      rdfs:label "LIVE_MMLS_CATS_Ragdoll"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Russian_Blue
+:CommodityCode_LIVE_MMLS_CATS_Russian_Blue rdf:type owl:NamedIndividual ,
+                                                    :CommodityCode ;
+                                           rdfs:comment "Russian Blue"@en ;
+                                           rdfs:label "LIVE_MMLS_CATS_Russian_Blue"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Safari
+:CommodityCode_LIVE_MMLS_CATS_Safari rdf:type owl:NamedIndividual ,
+                                              :CommodityCode ;
+                                     rdfs:comment "Safari"@en ;
+                                     rdfs:label "LIVE_MMLS_CATS_Safari"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Savannah
+:CommodityCode_LIVE_MMLS_CATS_Savannah rdf:type owl:NamedIndividual ,
+                                                :CommodityCode ;
+                                       rdfs:comment "Savannah"@en ;
+                                       rdfs:label "LIVE_MMLS_CATS_Savannah"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Scottish_Fold
+:CommodityCode_LIVE_MMLS_CATS_Scottish_Fold rdf:type owl:NamedIndividual ,
+                                                     :CommodityCode ;
+                                            rdfs:comment "Scottish Fold"@en ;
+                                            rdfs:label "LIVE_MMLS_CATS_Scottish_Fold"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Selkirk_Rex
+:CommodityCode_LIVE_MMLS_CATS_Selkirk_Rex rdf:type owl:NamedIndividual ,
+                                                   :CommodityCode ;
+                                          rdfs:comment "Selkirk Rex"@en ;
+                                          rdfs:label "LIVE_MMLS_CATS_Selkirk_Rex"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Serengeti
+:CommodityCode_LIVE_MMLS_CATS_Serengeti rdf:type owl:NamedIndividual ,
+                                                 :CommodityCode ;
+                                        rdfs:comment "Serengeti"@en ;
+                                        rdfs:label "LIVE_MMLS_CATS_Serengeti"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Siamese
+:CommodityCode_LIVE_MMLS_CATS_Siamese rdf:type owl:NamedIndividual ,
+                                               :CommodityCode ;
+                                      rdfs:comment "Siamese"@en ;
+                                      rdfs:label "LIVE_MMLS_CATS_Siamese"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Siberian
+:CommodityCode_LIVE_MMLS_CATS_Siberian rdf:type owl:NamedIndividual ,
+                                                :CommodityCode ;
+                                       rdfs:comment "Siberian"@en ;
+                                       rdfs:label "LIVE_MMLS_CATS_Siberian"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Singapura
+:CommodityCode_LIVE_MMLS_CATS_Singapura rdf:type owl:NamedIndividual ,
+                                                 :CommodityCode ;
+                                        rdfs:comment "Singapura"@en ;
+                                        rdfs:label "LIVE_MMLS_CATS_Singapura"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Snowshoe
+:CommodityCode_LIVE_MMLS_CATS_Snowshoe rdf:type owl:NamedIndividual ,
+                                                :CommodityCode ;
+                                       rdfs:comment "Snowshoe"@en ;
+                                       rdfs:label "LIVE_MMLS_CATS_Snowshoe"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Somali
+:CommodityCode_LIVE_MMLS_CATS_Somali rdf:type owl:NamedIndividual ,
+                                              :CommodityCode ;
+                                     rdfs:comment "Somali"@en ;
+                                     rdfs:label "LIVE_MMLS_CATS_Somali"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Sphynx
+:CommodityCode_LIVE_MMLS_CATS_Sphynx rdf:type owl:NamedIndividual ,
+                                              :CommodityCode ;
+                                     rdfs:comment "Sphynx"@en ;
+                                     rdfs:label "LIVE_MMLS_CATS_Sphynx"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Tiffany
+:CommodityCode_LIVE_MMLS_CATS_Tiffany rdf:type owl:NamedIndividual ,
+                                               :CommodityCode ;
+                                      rdfs:comment "Tiffany"@en ;
+                                      rdfs:label "LIVE_MMLS_CATS_Tiffany"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Tonkinese
+:CommodityCode_LIVE_MMLS_CATS_Tonkinese rdf:type owl:NamedIndividual ,
+                                                 :CommodityCode ;
+                                        rdfs:comment "Tonkinese"@en ;
+                                        rdfs:label "LIVE_MMLS_CATS_Tonkinese"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Traditional_Siamese
+:CommodityCode_LIVE_MMLS_CATS_Traditional_Siamese rdf:type owl:NamedIndividual ,
+                                                           :CommodityCode ;
+                                                  rdfs:comment "Traditional Siamese"@en ;
+                                                  rdfs:label "LIVE_MMLS_CATS_Traditional_Siamese"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Turkish_Angora
+:CommodityCode_LIVE_MMLS_CATS_Turkish_Angora rdf:type owl:NamedIndividual ,
+                                                      :CommodityCode ;
+                                             rdfs:comment "Turkish Angora"@en ;
+                                             rdfs:label "LIVE_MMLS_CATS_Turkish_Angora"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Turkish_Van
+:CommodityCode_LIVE_MMLS_CATS_Turkish_Van rdf:type owl:NamedIndividual ,
+                                                   :CommodityCode ;
+                                          rdfs:comment "Turkish Van"@en ;
+                                          rdfs:label "LIVE_MMLS_CATS_Turkish_Van"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Vienna_Woods
+:CommodityCode_LIVE_MMLS_CATS_Vienna_Woods rdf:type owl:NamedIndividual ,
+                                                    :CommodityCode ;
+                                           rdfs:comment "Vienna Woods"@en ;
+                                           rdfs:label "LIVE_MMLS_CATS_Vienna_Woods"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_Viverral_Hybrid_Cat
+:CommodityCode_LIVE_MMLS_CATS_Viverral_Hybrid_Cat rdf:type owl:NamedIndividual ,
+                                                           :CommodityCode ;
+                                                  rdfs:comment "Viverral-Hybrid Cat"@en ;
+                                                  rdfs:label "LIVE_MMLS_CATS_Viverral_Hybrid_Cat"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_CATS_York_Chocolate
+:CommodityCode_LIVE_MMLS_CATS_York_Chocolate rdf:type owl:NamedIndividual ,
+                                                      :CommodityCode ;
+                                             rdfs:comment "York Chocolate"@en ;
+                                             rdfs:label "LIVE_MMLS_CATS_York_Chocolate"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS
+:CommodityCode_LIVE_MMLS_DOGS rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Dogs"@en ;
+                              rdfs:label "LIVE_MMLS_DOGS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Affenpinscher
+:CommodityCode_LIVE_MMLS_DOGS_Affenpinscher rdf:type owl:NamedIndividual ,
+                                                     :CommodityCode ;
+                                            rdfs:comment "Affenpinscher"@en ;
+                                            rdfs:label "LIVE_MMLS_DOGS_Affenpinscher"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Afghan_Hound
+:CommodityCode_LIVE_MMLS_DOGS_Afghan_Hound rdf:type owl:NamedIndividual ,
+                                                    :CommodityCode ;
+                                           rdfs:comment "Afghan Hound"@en ;
+                                           rdfs:label "LIVE_MMLS_DOGS_Afghan_Hound"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Airedale_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Airedale_Terrier rdf:type owl:NamedIndividual ,
+                                                        :CommodityCode ;
+                                               rdfs:comment "Airedale Terrier"@en ;
+                                               rdfs:label "LIVE_MMLS_DOGS_Airedale_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Akita
+:CommodityCode_LIVE_MMLS_DOGS_Akita rdf:type owl:NamedIndividual ,
+                                             :CommodityCode ;
+                                    rdfs:comment "Akita"@en ;
+                                    rdfs:label "LIVE_MMLS_DOGS_Akita"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Alangu_Mastiff
+:CommodityCode_LIVE_MMLS_DOGS_Alangu_Mastiff rdf:type owl:NamedIndividual ,
+                                                      :CommodityCode ;
+                                             rdfs:comment "Alangu Mastiff"@en ;
+                                             rdfs:label "LIVE_MMLS_DOGS_Alangu_Mastiff"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Alano
+:CommodityCode_LIVE_MMLS_DOGS_Alano rdf:type owl:NamedIndividual ,
+                                             :CommodityCode ;
+                                    rdfs:comment "Alano"@en ;
+                                    rdfs:label "LIVE_MMLS_DOGS_Alano"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Alaskan_Malamute
+:CommodityCode_LIVE_MMLS_DOGS_Alaskan_Malamute rdf:type owl:NamedIndividual ,
+                                                        :CommodityCode ;
+                                               rdfs:comment "Alaskan Malamute"@en ;
+                                               rdfs:label "LIVE_MMLS_DOGS_Alaskan_Malamute"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_American_Bulldog
+:CommodityCode_LIVE_MMLS_DOGS_American_Bulldog rdf:type owl:NamedIndividual ,
+                                                        :CommodityCode ;
+                                               rdfs:comment "American Bulldog"@en ;
+                                               rdfs:label "LIVE_MMLS_DOGS_American_Bulldog"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_American_Bully
+:CommodityCode_LIVE_MMLS_DOGS_American_Bully rdf:type owl:NamedIndividual ,
+                                                      :CommodityCode ;
+                                             rdfs:comment "American Bully"@en ;
+                                             rdfs:label "LIVE_MMLS_DOGS_American_Bully"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_American_Cocker_Spaniel
+:CommodityCode_LIVE_MMLS_DOGS_American_Cocker_Spaniel rdf:type owl:NamedIndividual ,
+                                                               :CommodityCode ;
+                                                      rdfs:comment "American Cocker Spaniel"@en ;
+                                                      rdfs:label "LIVE_MMLS_DOGS_American_Cocker_Spaniel"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_American_English_Coonhound
+:CommodityCode_LIVE_MMLS_DOGS_American_English_Coonhound rdf:type owl:NamedIndividual ,
+                                                                  :CommodityCode ;
+                                                         rdfs:comment "American English Coonhound"@en ;
+                                                         rdfs:label "LIVE_MMLS_DOGS_American_English_Coonhound"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_American_Eskimo_Dog_Miniature
+:CommodityCode_LIVE_MMLS_DOGS_American_Eskimo_Dog_Miniature rdf:type owl:NamedIndividual ,
+                                                                     :CommodityCode ;
+                                                            rdfs:comment "American Eskimo Dog-Miniature"@en ;
+                                                            rdfs:label "LIVE_MMLS_DOGS_American_Eskimo_Dog_Miniature"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_American_Eskimo_Dog_Standard
+:CommodityCode_LIVE_MMLS_DOGS_American_Eskimo_Dog_Standard rdf:type owl:NamedIndividual ,
+                                                                    :CommodityCode ;
+                                                           rdfs:comment "American Eskimo Dog-Standard"@en ;
+                                                           rdfs:label "LIVE_MMLS_DOGS_American_Eskimo_Dog_Standard"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_American_Eskimo_Dog_Toy
+:CommodityCode_LIVE_MMLS_DOGS_American_Eskimo_Dog_Toy rdf:type owl:NamedIndividual ,
+                                                               :CommodityCode ;
+                                                      rdfs:comment "American Eskimo Dog-Toy"@en ;
+                                                      rdfs:label "LIVE_MMLS_DOGS_American_Eskimo_Dog_Toy"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_American_Foxhound
+:CommodityCode_LIVE_MMLS_DOGS_American_Foxhound rdf:type owl:NamedIndividual ,
+                                                         :CommodityCode ;
+                                                rdfs:comment "American Foxhound"@en ;
+                                                rdfs:label "LIVE_MMLS_DOGS_American_Foxhound"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_American_Hairless_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_American_Hairless_Terrier rdf:type owl:NamedIndividual ,
+                                                                 :CommodityCode ;
+                                                        rdfs:comment "American Hairless Terrier"@en ;
+                                                        rdfs:label "LIVE_MMLS_DOGS_American_Hairless_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_American_Pit_Bull_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_American_Pit_Bull_Terrier rdf:type owl:NamedIndividual ,
+                                                                 :CommodityCode ;
+                                                        rdfs:comment "American Pit Bull Terrier"@en ;
+                                                        rdfs:label "LIVE_MMLS_DOGS_American_Pit_Bull_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_American_Staffordshire_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_American_Staffordshire_Terrier rdf:type owl:NamedIndividual ,
+                                                                      :CommodityCode ;
+                                                             rdfs:comment "American Staffordshire Terrier"@en ;
+                                                             rdfs:label "LIVE_MMLS_DOGS_American_Staffordshire_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_American_Water_Spaniel
+:CommodityCode_LIVE_MMLS_DOGS_American_Water_Spaniel rdf:type owl:NamedIndividual ,
+                                                              :CommodityCode ;
+                                                     rdfs:comment "American Water Spaniel"@en ;
+                                                     rdfs:label "LIVE_MMLS_DOGS_American_Water_Spaniel"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Anatolian_Shepherd_Dog
+:CommodityCode_LIVE_MMLS_DOGS_Anatolian_Shepherd_Dog rdf:type owl:NamedIndividual ,
+                                                              :CommodityCode ;
+                                                     rdfs:comment "Anatolian Shepherd Dog"@en ;
+                                                     rdfs:label "LIVE_MMLS_DOGS_Anatolian_Shepherd_Dog"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Argentinian_Mastiff
+:CommodityCode_LIVE_MMLS_DOGS_Argentinian_Mastiff rdf:type owl:NamedIndividual ,
+                                                           :CommodityCode ;
+                                                  rdfs:comment "Argentinian Mastiff"@en ;
+                                                  rdfs:label "LIVE_MMLS_DOGS_Argentinian_Mastiff"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Aussiedoodle
+:CommodityCode_LIVE_MMLS_DOGS_Aussiedoodle rdf:type owl:NamedIndividual ,
+                                                    :CommodityCode ;
+                                           rdfs:comment "Aussiedoodle"@en ;
+                                           rdfs:label "LIVE_MMLS_DOGS_Aussiedoodle"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Australian_Cattle_Dog
+:CommodityCode_LIVE_MMLS_DOGS_Australian_Cattle_Dog rdf:type owl:NamedIndividual ,
+                                                             :CommodityCode ;
+                                                    rdfs:comment "Australian Cattle Dog"@en ;
+                                                    rdfs:label "LIVE_MMLS_DOGS_Australian_Cattle_Dog"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Australian_Shepherd
+:CommodityCode_LIVE_MMLS_DOGS_Australian_Shepherd rdf:type owl:NamedIndividual ,
+                                                           :CommodityCode ;
+                                                  rdfs:comment "Australian Shepherd"@en ;
+                                                  rdfs:label "LIVE_MMLS_DOGS_Australian_Shepherd"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Australian_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Australian_Terrier rdf:type owl:NamedIndividual ,
+                                                          :CommodityCode ;
+                                                 rdfs:comment "Australian Terrier"@en ;
+                                                 rdfs:label "LIVE_MMLS_DOGS_Australian_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Ba_Shar_Basset_Hound_Shar_pei_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Ba_Shar_Basset_Hound_Shar_pei_Mix rdf:type owl:NamedIndividual ,
+                                                                         :CommodityCode ;
+                                                                rdfs:comment "Ba Shar-Basset Hound Shar pei Mix"@en ;
+                                                                rdfs:label "LIVE_MMLS_DOGS_Ba_Shar_Basset_Hound_Shar_pei_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Basenji
+:CommodityCode_LIVE_MMLS_DOGS_Basenji rdf:type owl:NamedIndividual ,
+                                               :CommodityCode ;
+                                      rdfs:comment "Basenji"@en ;
+                                      rdfs:label "LIVE_MMLS_DOGS_Basenji"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Basset_Hound
+:CommodityCode_LIVE_MMLS_DOGS_Basset_Hound rdf:type owl:NamedIndividual ,
+                                                    :CommodityCode ;
+                                           rdfs:comment "Basset Hound"@en ;
+                                           rdfs:label "LIVE_MMLS_DOGS_Basset_Hound"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Beagle
+:CommodityCode_LIVE_MMLS_DOGS_Beagle rdf:type owl:NamedIndividual ,
+                                              :CommodityCode ;
+                                     rdfs:comment "Beagle"@en ;
+                                     rdfs:label "LIVE_MMLS_DOGS_Beagle"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Bearded_Collie
+:CommodityCode_LIVE_MMLS_DOGS_Bearded_Collie rdf:type owl:NamedIndividual ,
+                                                      :CommodityCode ;
+                                             rdfs:comment "Bearded Collie"@en ;
+                                             rdfs:label "LIVE_MMLS_DOGS_Bearded_Collie"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Beauceron
+:CommodityCode_LIVE_MMLS_DOGS_Beauceron rdf:type owl:NamedIndividual ,
+                                                 :CommodityCode ;
+                                        rdfs:comment "Beauceron"@en ;
+                                        rdfs:label "LIVE_MMLS_DOGS_Beauceron"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Bedlington_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Bedlington_Terrier rdf:type owl:NamedIndividual ,
+                                                          :CommodityCode ;
+                                                 rdfs:comment "Bedlington Terrier"@en ;
+                                                 rdfs:label "LIVE_MMLS_DOGS_Bedlington_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Belgian_Malinois
+:CommodityCode_LIVE_MMLS_DOGS_Belgian_Malinois rdf:type owl:NamedIndividual ,
+                                                        :CommodityCode ;
+                                               rdfs:comment "Belgian Malinois"@en ;
+                                               rdfs:label "LIVE_MMLS_DOGS_Belgian_Malinois"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Belgian_Sheepdog
+:CommodityCode_LIVE_MMLS_DOGS_Belgian_Sheepdog rdf:type owl:NamedIndividual ,
+                                                        :CommodityCode ;
+                                               rdfs:comment "Belgian Sheepdog"@en ;
+                                               rdfs:label "LIVE_MMLS_DOGS_Belgian_Sheepdog"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Belgian_Tervuren
+:CommodityCode_LIVE_MMLS_DOGS_Belgian_Tervuren rdf:type owl:NamedIndividual ,
+                                                        :CommodityCode ;
+                                               rdfs:comment "Belgian Tervuren"@en ;
+                                               rdfs:label "LIVE_MMLS_DOGS_Belgian_Tervuren"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Bergamasco
+:CommodityCode_LIVE_MMLS_DOGS_Bergamasco rdf:type owl:NamedIndividual ,
+                                                  :CommodityCode ;
+                                         rdfs:comment "Bergamasco"@en ;
+                                         rdfs:label "LIVE_MMLS_DOGS_Bergamasco"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Berger_Picard
+:CommodityCode_LIVE_MMLS_DOGS_Berger_Picard rdf:type owl:NamedIndividual ,
+                                                     :CommodityCode ;
+                                            rdfs:comment "Berger Picard"@en ;
+                                            rdfs:label "LIVE_MMLS_DOGS_Berger_Picard"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Bernedoodle
+:CommodityCode_LIVE_MMLS_DOGS_Bernedoodle rdf:type owl:NamedIndividual ,
+                                                   :CommodityCode ;
+                                          rdfs:comment "Bernedoodle"@en ;
+                                          rdfs:label "LIVE_MMLS_DOGS_Bernedoodle"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Bernese_Mountain_Dog
+:CommodityCode_LIVE_MMLS_DOGS_Bernese_Mountain_Dog rdf:type owl:NamedIndividual ,
+                                                            :CommodityCode ;
+                                                   rdfs:comment "Bernese Mountain Dog"@en ;
+                                                   rdfs:label "LIVE_MMLS_DOGS_Bernese_Mountain_Dog"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Bichon_Frise
+:CommodityCode_LIVE_MMLS_DOGS_Bichon_Frise rdf:type owl:NamedIndividual ,
+                                                    :CommodityCode ;
+                                           rdfs:comment "Bichon Frise"@en ;
+                                           rdfs:label "LIVE_MMLS_DOGS_Bichon_Frise"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Black_Russian_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Black_Russian_Terrier rdf:type owl:NamedIndividual ,
+                                                             :CommodityCode ;
+                                                    rdfs:comment "Black Russian Terrier"@en ;
+                                                    rdfs:label "LIVE_MMLS_DOGS_Black_Russian_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Black_and_Tan_Coonhound
+:CommodityCode_LIVE_MMLS_DOGS_Black_and_Tan_Coonhound rdf:type owl:NamedIndividual ,
+                                                               :CommodityCode ;
+                                                      rdfs:comment "Black and Tan Coonhound"@en ;
+                                                      rdfs:label "LIVE_MMLS_DOGS_Black_and_Tan_Coonhound"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Bloodhound
+:CommodityCode_LIVE_MMLS_DOGS_Bloodhound rdf:type owl:NamedIndividual ,
+                                                  :CommodityCode ;
+                                         rdfs:comment "Bloodhound"@en ;
+                                         rdfs:label "LIVE_MMLS_DOGS_Bloodhound"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Bluetick_Coonhound
+:CommodityCode_LIVE_MMLS_DOGS_Bluetick_Coonhound rdf:type owl:NamedIndividual ,
+                                                          :CommodityCode ;
+                                                 rdfs:comment "Bluetick Coonhound"@en ;
+                                                 rdfs:label "LIVE_MMLS_DOGS_Bluetick_Coonhound"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Boerboel
+:CommodityCode_LIVE_MMLS_DOGS_Boerboel rdf:type owl:NamedIndividual ,
+                                                :CommodityCode ;
+                                       rdfs:comment "Boerboel"@en ;
+                                       rdfs:label "LIVE_MMLS_DOGS_Boerboel"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Border_Collie
+:CommodityCode_LIVE_MMLS_DOGS_Border_Collie rdf:type owl:NamedIndividual ,
+                                                     :CommodityCode ;
+                                            rdfs:comment "Border Collie"@en ;
+                                            rdfs:label "LIVE_MMLS_DOGS_Border_Collie"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Border_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Border_Terrier rdf:type owl:NamedIndividual ,
+                                                      :CommodityCode ;
+                                             rdfs:comment "Border Terrier"@en ;
+                                             rdfs:label "LIVE_MMLS_DOGS_Border_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Borzoi
+:CommodityCode_LIVE_MMLS_DOGS_Borzoi rdf:type owl:NamedIndividual ,
+                                              :CommodityCode ;
+                                     rdfs:comment "Borzoi"@en ;
+                                     rdfs:label "LIVE_MMLS_DOGS_Borzoi"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Boston_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Boston_Terrier rdf:type owl:NamedIndividual ,
+                                                      :CommodityCode ;
+                                             rdfs:comment "Boston Terrier"@en ;
+                                             rdfs:label "LIVE_MMLS_DOGS_Boston_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Bouvier_des_Flandres
+:CommodityCode_LIVE_MMLS_DOGS_Bouvier_des_Flandres rdf:type owl:NamedIndividual ,
+                                                            :CommodityCode ;
+                                                   rdfs:comment "Bouvier des Flandres"@en ;
+                                                   rdfs:label "LIVE_MMLS_DOGS_Bouvier_des_Flandres"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Boweimar_Boxer_Weimaraner_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Boweimar_Boxer_Weimaraner_Mix rdf:type owl:NamedIndividual ,
+                                                                     :CommodityCode ;
+                                                            rdfs:comment "Boweimar-Boxer Weimaraner Mix"@en ;
+                                                            rdfs:label "LIVE_MMLS_DOGS_Boweimar_Boxer_Weimaraner_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Boxer
+:CommodityCode_LIVE_MMLS_DOGS_Boxer rdf:type owl:NamedIndividual ,
+                                             :CommodityCode ;
+                                    rdfs:comment "Boxer"@en ;
+                                    rdfs:label "LIVE_MMLS_DOGS_Boxer"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Boykin_Spaniel
+:CommodityCode_LIVE_MMLS_DOGS_Boykin_Spaniel rdf:type owl:NamedIndividual ,
+                                                      :CommodityCode ;
+                                             rdfs:comment "Boykin Spaniel"@en ;
+                                             rdfs:label "LIVE_MMLS_DOGS_Boykin_Spaniel"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Brazilian_Mastiff
+:CommodityCode_LIVE_MMLS_DOGS_Brazilian_Mastiff rdf:type owl:NamedIndividual ,
+                                                         :CommodityCode ;
+                                                rdfs:comment "Brazilian Mastiff"@en ;
+                                                rdfs:label "LIVE_MMLS_DOGS_Brazilian_Mastiff"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Briard
+:CommodityCode_LIVE_MMLS_DOGS_Briard rdf:type owl:NamedIndividual ,
+                                              :CommodityCode ;
+                                     rdfs:comment "Briard"@en ;
+                                     rdfs:label "LIVE_MMLS_DOGS_Briard"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Brittany
+:CommodityCode_LIVE_MMLS_DOGS_Brittany rdf:type owl:NamedIndividual ,
+                                                :CommodityCode ;
+                                       rdfs:comment "Brittany"@en ;
+                                       rdfs:label "LIVE_MMLS_DOGS_Brittany"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Brussels_Griffon
+:CommodityCode_LIVE_MMLS_DOGS_Brussels_Griffon rdf:type owl:NamedIndividual ,
+                                                        :CommodityCode ;
+                                               rdfs:comment "Brussels Griffon"@en ;
+                                               rdfs:label "LIVE_MMLS_DOGS_Brussels_Griffon"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Bull_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Bull_Terrier rdf:type owl:NamedIndividual ,
+                                                    :CommodityCode ;
+                                           rdfs:comment "Bull Terrier"@en ;
+                                           rdfs:label "LIVE_MMLS_DOGS_Bull_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Bull_Terrier_Miniature
+:CommodityCode_LIVE_MMLS_DOGS_Bull_Terrier_Miniature rdf:type owl:NamedIndividual ,
+                                                              :CommodityCode ;
+                                                     rdfs:comment "Bull Terrier-Miniature"@en ;
+                                                     rdfs:label "LIVE_MMLS_DOGS_Bull_Terrier_Miniature"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Bulldog
+:CommodityCode_LIVE_MMLS_DOGS_Bulldog rdf:type owl:NamedIndividual ,
+                                               :CommodityCode ;
+                                      rdfs:comment "Bulldog"@en ;
+                                      rdfs:label "LIVE_MMLS_DOGS_Bulldog"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Bulli_Kutta
+:CommodityCode_LIVE_MMLS_DOGS_Bulli_Kutta rdf:type owl:NamedIndividual ,
+                                                   :CommodityCode ;
+                                          rdfs:comment "Bulli Kutta"@en ;
+                                          rdfs:label "LIVE_MMLS_DOGS_Bulli_Kutta"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Bullmastiff
+:CommodityCode_LIVE_MMLS_DOGS_Bullmastiff rdf:type owl:NamedIndividual ,
+                                                   :CommodityCode ;
+                                          rdfs:comment "Bullmastiff"@en ;
+                                          rdfs:label "LIVE_MMLS_DOGS_Bullmastiff"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Bully_Kutta_Mastiff_breed
+:CommodityCode_LIVE_MMLS_DOGS_Bully_Kutta_Mastiff_breed rdf:type owl:NamedIndividual ,
+                                                                 :CommodityCode ;
+                                                        rdfs:comment "Bully Kutta-Mastiff breed"@en ;
+                                                        rdfs:label "LIVE_MMLS_DOGS_Bully_Kutta_Mastiff_breed"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Cairn_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Cairn_Terrier rdf:type owl:NamedIndividual ,
+                                                     :CommodityCode ;
+                                            rdfs:comment "Cairn Terrier"@en ;
+                                            rdfs:label "LIVE_MMLS_DOGS_Cairn_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Campeiro_Bulldog_Brazilian_Bulldog
+:CommodityCode_LIVE_MMLS_DOGS_Campeiro_Bulldog_Brazilian_Bulldog rdf:type owl:NamedIndividual ,
+                                                                          :CommodityCode ;
+                                                                 rdfs:comment "Campeiro Bulldog-Brazilian Bulldog"@en ;
+                                                                 rdfs:label "LIVE_MMLS_DOGS_Campeiro_Bulldog_Brazilian_Bulldog"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Canaan_Dog
+:CommodityCode_LIVE_MMLS_DOGS_Canaan_Dog rdf:type owl:NamedIndividual ,
+                                                  :CommodityCode ;
+                                         rdfs:comment "Canaan Dog"@en ;
+                                         rdfs:label "LIVE_MMLS_DOGS_Canaan_Dog"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Canary_Mastiff
+:CommodityCode_LIVE_MMLS_DOGS_Canary_Mastiff rdf:type owl:NamedIndividual ,
+                                                      :CommodityCode ;
+                                             rdfs:comment "Canary Mastiff"@en ;
+                                             rdfs:label "LIVE_MMLS_DOGS_Canary_Mastiff"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Cane_Corso
+:CommodityCode_LIVE_MMLS_DOGS_Cane_Corso rdf:type owl:NamedIndividual ,
+                                                  :CommodityCode ;
+                                         rdfs:comment "Cane Corso"@en ;
+                                         rdfs:label "LIVE_MMLS_DOGS_Cane_Corso"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Cardigan_Welsh_Corgi
+:CommodityCode_LIVE_MMLS_DOGS_Cardigan_Welsh_Corgi rdf:type owl:NamedIndividual ,
+                                                            :CommodityCode ;
+                                                   rdfs:comment "Cardigan Welsh Corgi"@en ;
+                                                   rdfs:label "LIVE_MMLS_DOGS_Cardigan_Welsh_Corgi"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Catahoula_Bulldog_Catahoula_Leopard_Bulldog
+:CommodityCode_LIVE_MMLS_DOGS_Catahoula_Bulldog_Catahoula_Leopard_Bulldog rdf:type owl:NamedIndividual ,
+                                                                                   :CommodityCode ;
+                                                                          rdfs:comment "Catahoula Bulldog-Catahoula Leopard Bulldog"@en ;
+                                                                          rdfs:label "LIVE_MMLS_DOGS_Catahoula_Bulldog_Catahoula_Leopard_Bulldog"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Cavachon_King_Charles_Spaniel_Bichon_Frise
+:CommodityCode_LIVE_MMLS_DOGS_Cavachon_King_Charles_Spaniel_Bichon_Frise rdf:type owl:NamedIndividual ,
+                                                                                  :CommodityCode ;
+                                                                         rdfs:comment "Cavachon-King Charles Spaniel Bichon Frise"@en ;
+                                                                         rdfs:label "LIVE_MMLS_DOGS_Cavachon_King_Charles_Spaniel_Bichon_Frise"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Cavalier_King_Charles_Spaniel
+:CommodityCode_LIVE_MMLS_DOGS_Cavalier_King_Charles_Spaniel rdf:type owl:NamedIndividual ,
+                                                                     :CommodityCode ;
+                                                            rdfs:comment "Cavalier King Charles Spaniel"@en ;
+                                                            rdfs:label "LIVE_MMLS_DOGS_Cavalier_King_Charles_Spaniel"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Cavapoo_Cavalier_King_Charles_Spaniel_Poodle
+:CommodityCode_LIVE_MMLS_DOGS_Cavapoo_Cavalier_King_Charles_Spaniel_Poodle rdf:type owl:NamedIndividual ,
+                                                                                    :CommodityCode ;
+                                                                           rdfs:comment "Cavapoo-Cavalier King Charles Spaniel Poodle"@en ;
+                                                                           rdfs:label "LIVE_MMLS_DOGS_Cavapoo_Cavalier_King_Charles_Spaniel_Poodle"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Cesky_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Cesky_Terrier rdf:type owl:NamedIndividual ,
+                                                     :CommodityCode ;
+                                            rdfs:comment "Cesky Terrier"@en ;
+                                            rdfs:label "LIVE_MMLS_DOGS_Cesky_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Chesapeake_Bay_Retriever
+:CommodityCode_LIVE_MMLS_DOGS_Chesapeake_Bay_Retriever rdf:type owl:NamedIndividual ,
+                                                                :CommodityCode ;
+                                                       rdfs:comment "Chesapeake Bay Retriever"@en ;
+                                                       rdfs:label "LIVE_MMLS_DOGS_Chesapeake_Bay_Retriever"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Chihuahua
+:CommodityCode_LIVE_MMLS_DOGS_Chihuahua rdf:type owl:NamedIndividual ,
+                                                 :CommodityCode ;
+                                        rdfs:comment "Chihuahua"@en ;
+                                        rdfs:label "LIVE_MMLS_DOGS_Chihuahua"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Chinese_Crested_Dog
+:CommodityCode_LIVE_MMLS_DOGS_Chinese_Crested_Dog rdf:type owl:NamedIndividual ,
+                                                           :CommodityCode ;
+                                                  rdfs:comment "Chinese Crested Dog"@en ;
+                                                  rdfs:label "LIVE_MMLS_DOGS_Chinese_Crested_Dog"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Chinese_Pug
+:CommodityCode_LIVE_MMLS_DOGS_Chinese_Pug rdf:type owl:NamedIndividual ,
+                                                   :CommodityCode ;
+                                          rdfs:comment "Chinese Pug"@en ;
+                                          rdfs:label "LIVE_MMLS_DOGS_Chinese_Pug"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Chinese_Shar_Pei
+:CommodityCode_LIVE_MMLS_DOGS_Chinese_Shar_Pei rdf:type owl:NamedIndividual ,
+                                                        :CommodityCode ;
+                                               rdfs:comment "Chinese Shar Pei"@en ;
+                                               rdfs:label "LIVE_MMLS_DOGS_Chinese_Shar_Pei"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Chinook
+:CommodityCode_LIVE_MMLS_DOGS_Chinook rdf:type owl:NamedIndividual ,
+                                               :CommodityCode ;
+                                      rdfs:comment "Chinook"@en ;
+                                      rdfs:label "LIVE_MMLS_DOGS_Chinook"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Chipin_Chihuahua_Minature_Pinscher_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Chipin_Chihuahua_Minature_Pinscher_Mix rdf:type owl:NamedIndividual ,
+                                                                              :CommodityCode ;
+                                                                     rdfs:comment "Chipin-Chihuahua Minature Pinscher Mix"@en ;
+                                                                     rdfs:label "LIVE_MMLS_DOGS_Chipin_Chihuahua_Minature_Pinscher_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Chiweenie_Chihuahua_Dachshund_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Chiweenie_Chihuahua_Dachshund_Mix rdf:type owl:NamedIndividual ,
+                                                                         :CommodityCode ;
+                                                                rdfs:comment "Chiweenie-Chihuahua Dachshund Mix"@en ;
+                                                                rdfs:label "LIVE_MMLS_DOGS_Chiweenie_Chihuahua_Dachshund_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Chorkie_Chihuahua_Yorkshire_Terrier_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Chorkie_Chihuahua_Yorkshire_Terrier_Mix rdf:type owl:NamedIndividual ,
+                                                                               :CommodityCode ;
+                                                                      rdfs:comment "Chorkie-Chihuahua Yorkshire Terrier Mix"@en ;
+                                                                      rdfs:label "LIVE_MMLS_DOGS_Chorkie_Chihuahua_Yorkshire_Terrier_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Chow_Chow
+:CommodityCode_LIVE_MMLS_DOGS_Chow_Chow rdf:type owl:NamedIndividual ,
+                                                 :CommodityCode ;
+                                        rdfs:comment "Chow Chow"@en ;
+                                        rdfs:label "LIVE_MMLS_DOGS_Chow_Chow"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Chow_Pei_Chow_Chow_Shar_Pei_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Chow_Pei_Chow_Chow_Shar_Pei_Mix rdf:type owl:NamedIndividual ,
+                                                                       :CommodityCode ;
+                                                              rdfs:comment "Chow Pei-Chow Chow Shar Pei Mix"@en ;
+                                                              rdfs:label "LIVE_MMLS_DOGS_Chow_Pei_Chow_Chow_Shar_Pei_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Cirneco_dell_Etna
+:CommodityCode_LIVE_MMLS_DOGS_Cirneco_dell_Etna rdf:type owl:NamedIndividual ,
+                                                         :CommodityCode ;
+                                                rdfs:comment "Cirneco dell Etna"@en ;
+                                                rdfs:label "LIVE_MMLS_DOGS_Cirneco_dell_Etna"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Clumber_Spaniel
+:CommodityCode_LIVE_MMLS_DOGS_Clumber_Spaniel rdf:type owl:NamedIndividual ,
+                                                       :CommodityCode ;
+                                              rdfs:comment "Clumber Spaniel"@en ;
+                                              rdfs:label "LIVE_MMLS_DOGS_Clumber_Spaniel"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Cockapoo_Cocker_Spaniel_Poodle_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Cockapoo_Cocker_Spaniel_Poodle_Mix rdf:type owl:NamedIndividual ,
+                                                                          :CommodityCode ;
+                                                                 rdfs:comment "Cockapoo-Cocker Spaniel Poodle Mix"@en ;
+                                                                 rdfs:label "LIVE_MMLS_DOGS_Cockapoo_Cocker_Spaniel_Poodle_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Cocker_Spaniel
+:CommodityCode_LIVE_MMLS_DOGS_Cocker_Spaniel rdf:type owl:NamedIndividual ,
+                                                      :CommodityCode ;
+                                             rdfs:comment "Cocker Spaniel"@en ;
+                                             rdfs:label "LIVE_MMLS_DOGS_Cocker_Spaniel"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Collie
+:CommodityCode_LIVE_MMLS_DOGS_Collie rdf:type owl:NamedIndividual ,
+                                              :CommodityCode ;
+                                     rdfs:comment "Collie"@en ;
+                                     rdfs:label "LIVE_MMLS_DOGS_Collie"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Coton_de_Tulear
+:CommodityCode_LIVE_MMLS_DOGS_Coton_de_Tulear rdf:type owl:NamedIndividual ,
+                                                       :CommodityCode ;
+                                              rdfs:comment "Coton de Tulear"@en ;
+                                              rdfs:label "LIVE_MMLS_DOGS_Coton_de_Tulear"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Curly_Coated_Retriever
+:CommodityCode_LIVE_MMLS_DOGS_Curly_Coated_Retriever rdf:type owl:NamedIndividual ,
+                                                              :CommodityCode ;
+                                                     rdfs:comment "Curly-Coated Retriever"@en ;
+                                                     rdfs:label "LIVE_MMLS_DOGS_Curly_Coated_Retriever"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Dachshund
+:CommodityCode_LIVE_MMLS_DOGS_Dachshund rdf:type owl:NamedIndividual ,
+                                                 :CommodityCode ;
+                                        rdfs:comment "Dachshund"@en ;
+                                        rdfs:label "LIVE_MMLS_DOGS_Dachshund"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Dalmatian
+:CommodityCode_LIVE_MMLS_DOGS_Dalmatian rdf:type owl:NamedIndividual ,
+                                                 :CommodityCode ;
+                                        rdfs:comment "Dalmatian"@en ;
+                                        rdfs:label "LIVE_MMLS_DOGS_Dalmatian"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Dandie_Dinmont_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Dandie_Dinmont_Terrier rdf:type owl:NamedIndividual ,
+                                                              :CommodityCode ;
+                                                     rdfs:comment "Dandie Dinmont Terrier"@en ;
+                                                     rdfs:label "LIVE_MMLS_DOGS_Dandie_Dinmont_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Doberman_Pinscher
+:CommodityCode_LIVE_MMLS_DOGS_Doberman_Pinscher rdf:type owl:NamedIndividual ,
+                                                         :CommodityCode ;
+                                                rdfs:comment "Doberman Pinscher"@en ;
+                                                rdfs:label "LIVE_MMLS_DOGS_Doberman_Pinscher"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Dogo_Argentino
+:CommodityCode_LIVE_MMLS_DOGS_Dogo_Argentino rdf:type owl:NamedIndividual ,
+                                                      :CommodityCode ;
+                                             rdfs:comment "Dogo Argentino"@en ;
+                                             rdfs:label "LIVE_MMLS_DOGS_Dogo_Argentino"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Dogue_de_Bordeaux
+:CommodityCode_LIVE_MMLS_DOGS_Dogue_de_Bordeaux rdf:type owl:NamedIndividual ,
+                                                         :CommodityCode ;
+                                                rdfs:comment "Dogue de Bordeaux"@en ;
+                                                rdfs:label "LIVE_MMLS_DOGS_Dogue_de_Bordeaux"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Doxiepoo_Dachshund_Poodle_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Doxiepoo_Dachshund_Poodle_Mix rdf:type owl:NamedIndividual ,
+                                                                     :CommodityCode ;
+                                                            rdfs:comment "Doxiepoo-Dachshund Poodle Mix"@en ;
+                                                            rdfs:label "LIVE_MMLS_DOGS_Doxiepoo_Dachshund_Poodle_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Dutch_Pug
+:CommodityCode_LIVE_MMLS_DOGS_Dutch_Pug rdf:type owl:NamedIndividual ,
+                                                 :CommodityCode ;
+                                        rdfs:comment "Dutch Pug"@en ;
+                                        rdfs:label "LIVE_MMLS_DOGS_Dutch_Pug"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_English_Bulldog
+:CommodityCode_LIVE_MMLS_DOGS_English_Bulldog rdf:type owl:NamedIndividual ,
+                                                       :CommodityCode ;
+                                              rdfs:comment "English Bulldog"@en ;
+                                              rdfs:label "LIVE_MMLS_DOGS_English_Bulldog"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_English_Cocker_Spaniel
+:CommodityCode_LIVE_MMLS_DOGS_English_Cocker_Spaniel rdf:type owl:NamedIndividual ,
+                                                              :CommodityCode ;
+                                                     rdfs:comment "English Cocker Spaniel"@en ;
+                                                     rdfs:label "LIVE_MMLS_DOGS_English_Cocker_Spaniel"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_English_Foxhound
+:CommodityCode_LIVE_MMLS_DOGS_English_Foxhound rdf:type owl:NamedIndividual ,
+                                                        :CommodityCode ;
+                                               rdfs:comment "English Foxhound"@en ;
+                                               rdfs:label "LIVE_MMLS_DOGS_English_Foxhound"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_English_Mastiff
+:CommodityCode_LIVE_MMLS_DOGS_English_Mastiff rdf:type owl:NamedIndividual ,
+                                                       :CommodityCode ;
+                                              rdfs:comment "English Mastiff"@en ;
+                                              rdfs:label "LIVE_MMLS_DOGS_English_Mastiff"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_English_Setter
+:CommodityCode_LIVE_MMLS_DOGS_English_Setter rdf:type owl:NamedIndividual ,
+                                                      :CommodityCode ;
+                                             rdfs:comment "English Setter"@en ;
+                                             rdfs:label "LIVE_MMLS_DOGS_English_Setter"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_English_Springer_Spaniel
+:CommodityCode_LIVE_MMLS_DOGS_English_Springer_Spaniel rdf:type owl:NamedIndividual ,
+                                                                :CommodityCode ;
+                                                       rdfs:comment "English Springer Spaniel"@en ;
+                                                       rdfs:label "LIVE_MMLS_DOGS_English_Springer_Spaniel"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_English_Toy_Spaniel
+:CommodityCode_LIVE_MMLS_DOGS_English_Toy_Spaniel rdf:type owl:NamedIndividual ,
+                                                           :CommodityCode ;
+                                                  rdfs:comment "English Toy Spaniel"@en ;
+                                                  rdfs:label "LIVE_MMLS_DOGS_English_Toy_Spaniel"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Entlebucher_Mountain_Dog
+:CommodityCode_LIVE_MMLS_DOGS_Entlebucher_Mountain_Dog rdf:type owl:NamedIndividual ,
+                                                                :CommodityCode ;
+                                                       rdfs:comment "Entlebucher Mountain Dog"@en ;
+                                                       rdfs:label "LIVE_MMLS_DOGS_Entlebucher_Mountain_Dog"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Eurasier
+:CommodityCode_LIVE_MMLS_DOGS_Eurasier rdf:type owl:NamedIndividual ,
+                                                :CommodityCode ;
+                                       rdfs:comment "Eurasier"@en ;
+                                       rdfs:label "LIVE_MMLS_DOGS_Eurasier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Field_Spaniel
+:CommodityCode_LIVE_MMLS_DOGS_Field_Spaniel rdf:type owl:NamedIndividual ,
+                                                     :CommodityCode ;
+                                            rdfs:comment "Field Spaniel"@en ;
+                                            rdfs:label "LIVE_MMLS_DOGS_Field_Spaniel"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Fila_Brasileiro_Brazilian_Mastiff
+:CommodityCode_LIVE_MMLS_DOGS_Fila_Brasileiro_Brazilian_Mastiff rdf:type owl:NamedIndividual ,
+                                                                         :CommodityCode ;
+                                                                rdfs:comment "Fila Brasileiro-Brazilian Mastiff"@en ;
+                                                                rdfs:label "LIVE_MMLS_DOGS_Fila_Brasileiro_Brazilian_Mastiff"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Finnish_Lapphund
+:CommodityCode_LIVE_MMLS_DOGS_Finnish_Lapphund rdf:type owl:NamedIndividual ,
+                                                        :CommodityCode ;
+                                               rdfs:comment "Finnish Lapphund"@en ;
+                                               rdfs:label "LIVE_MMLS_DOGS_Finnish_Lapphund"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Finnish_Spitz
+:CommodityCode_LIVE_MMLS_DOGS_Finnish_Spitz rdf:type owl:NamedIndividual ,
+                                                     :CommodityCode ;
+                                            rdfs:comment "Finnish Spitz"@en ;
+                                            rdfs:label "LIVE_MMLS_DOGS_Finnish_Spitz"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Flat_Coated_Retriever
+:CommodityCode_LIVE_MMLS_DOGS_Flat_Coated_Retriever rdf:type owl:NamedIndividual ,
+                                                             :CommodityCode ;
+                                                    rdfs:comment "Flat-Coated Retriever"@en ;
+                                                    rdfs:label "LIVE_MMLS_DOGS_Flat_Coated_Retriever"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_French_Bulldog
+:CommodityCode_LIVE_MMLS_DOGS_French_Bulldog rdf:type owl:NamedIndividual ,
+                                                      :CommodityCode ;
+                                             rdfs:comment "French Bulldog"@en ;
+                                             rdfs:label "LIVE_MMLS_DOGS_French_Bulldog"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_French_Mastiff
+:CommodityCode_LIVE_MMLS_DOGS_French_Mastiff rdf:type owl:NamedIndividual ,
+                                                      :CommodityCode ;
+                                             rdfs:comment "French Mastiff"@en ;
+                                             rdfs:label "LIVE_MMLS_DOGS_French_Mastiff"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_German_Mastiff_Great_Dane
+:CommodityCode_LIVE_MMLS_DOGS_German_Mastiff_Great_Dane rdf:type owl:NamedIndividual ,
+                                                                 :CommodityCode ;
+                                                        rdfs:comment "German Mastiff-Great Dane"@en ;
+                                                        rdfs:label "LIVE_MMLS_DOGS_German_Mastiff_Great_Dane"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_German_Pinscher
+:CommodityCode_LIVE_MMLS_DOGS_German_Pinscher rdf:type owl:NamedIndividual ,
+                                                       :CommodityCode ;
+                                              rdfs:comment "German Pinscher"@en ;
+                                              rdfs:label "LIVE_MMLS_DOGS_German_Pinscher"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_German_Shepherd_Dog
+:CommodityCode_LIVE_MMLS_DOGS_German_Shepherd_Dog rdf:type owl:NamedIndividual ,
+                                                           :CommodityCode ;
+                                                  rdfs:comment "German Shepherd Dog"@en ;
+                                                  rdfs:label "LIVE_MMLS_DOGS_German_Shepherd_Dog"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_German_Shorthaired_Pointer
+:CommodityCode_LIVE_MMLS_DOGS_German_Shorthaired_Pointer rdf:type owl:NamedIndividual ,
+                                                                  :CommodityCode ;
+                                                         rdfs:comment "German Shorthaired Pointer"@en ;
+                                                         rdfs:label "LIVE_MMLS_DOGS_German_Shorthaired_Pointer"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_German_Wirehaired_Pointer
+:CommodityCode_LIVE_MMLS_DOGS_German_Wirehaired_Pointer rdf:type owl:NamedIndividual ,
+                                                                 :CommodityCode ;
+                                                        rdfs:comment "German Wirehaired Pointer"@en ;
+                                                        rdfs:label "LIVE_MMLS_DOGS_German_Wirehaired_Pointer"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Giant_Schnauzer
+:CommodityCode_LIVE_MMLS_DOGS_Giant_Schnauzer rdf:type owl:NamedIndividual ,
+                                                       :CommodityCode ;
+                                              rdfs:comment "Giant Schnauzer"@en ;
+                                              rdfs:label "LIVE_MMLS_DOGS_Giant_Schnauzer"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Glen_of_Imaal_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Glen_of_Imaal_Terrier rdf:type owl:NamedIndividual ,
+                                                             :CommodityCode ;
+                                                    rdfs:comment "Glen of Imaal Terrier"@en ;
+                                                    rdfs:label "LIVE_MMLS_DOGS_Glen_of_Imaal_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Goldador_Golden_Retriever_Labrador_Retriever
+:CommodityCode_LIVE_MMLS_DOGS_Goldador_Golden_Retriever_Labrador_Retriever rdf:type owl:NamedIndividual ,
+                                                                                    :CommodityCode ;
+                                                                           rdfs:comment "Goldador-Golden Retriever Labrador Retriever"@en ;
+                                                                           rdfs:label "LIVE_MMLS_DOGS_Goldador_Golden_Retriever_Labrador_Retriever"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Golden_Retriever
+:CommodityCode_LIVE_MMLS_DOGS_Golden_Retriever rdf:type owl:NamedIndividual ,
+                                                        :CommodityCode ;
+                                               rdfs:comment "Golden Retriever"@en ;
+                                               rdfs:label "LIVE_MMLS_DOGS_Golden_Retriever"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Goldendoodle_Golden_Retriever_Poodle_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Goldendoodle_Golden_Retriever_Poodle_Mix rdf:type owl:NamedIndividual ,
+                                                                                :CommodityCode ;
+                                                                       rdfs:comment "Goldendoodle-Golden Retriever Poodle Mix"@en ;
+                                                                       rdfs:label "LIVE_MMLS_DOGS_Goldendoodle_Golden_Retriever_Poodle_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Gordon_Setter
+:CommodityCode_LIVE_MMLS_DOGS_Gordon_Setter rdf:type owl:NamedIndividual ,
+                                                     :CommodityCode ;
+                                            rdfs:comment "Gordon Setter"@en ;
+                                            rdfs:label "LIVE_MMLS_DOGS_Gordon_Setter"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Great_Dane
+:CommodityCode_LIVE_MMLS_DOGS_Great_Dane rdf:type owl:NamedIndividual ,
+                                                  :CommodityCode ;
+                                         rdfs:comment "Great Dane"@en ;
+                                         rdfs:label "LIVE_MMLS_DOGS_Great_Dane"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Great_Pyrenees
+:CommodityCode_LIVE_MMLS_DOGS_Great_Pyrenees rdf:type owl:NamedIndividual ,
+                                                      :CommodityCode ;
+                                             rdfs:comment "Great Pyrenees"@en ;
+                                             rdfs:label "LIVE_MMLS_DOGS_Great_Pyrenees"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Greater_Swiss_Mountain_Dog
+:CommodityCode_LIVE_MMLS_DOGS_Greater_Swiss_Mountain_Dog rdf:type owl:NamedIndividual ,
+                                                                  :CommodityCode ;
+                                                         rdfs:comment "Greater Swiss Mountain Dog"@en ;
+                                                         rdfs:label "LIVE_MMLS_DOGS_Greater_Swiss_Mountain_Dog"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Greyhound
+:CommodityCode_LIVE_MMLS_DOGS_Greyhound rdf:type owl:NamedIndividual ,
+                                                 :CommodityCode ;
+                                        rdfs:comment "Greyhound"@en ;
+                                        rdfs:label "LIVE_MMLS_DOGS_Greyhound"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Harrier
+:CommodityCode_LIVE_MMLS_DOGS_Harrier rdf:type owl:NamedIndividual ,
+                                               :CommodityCode ;
+                                      rdfs:comment "Harrier"@en ;
+                                      rdfs:label "LIVE_MMLS_DOGS_Harrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Havanese
+:CommodityCode_LIVE_MMLS_DOGS_Havanese rdf:type owl:NamedIndividual ,
+                                                :CommodityCode ;
+                                       rdfs:comment "Havanese"@en ;
+                                       rdfs:label "LIVE_MMLS_DOGS_Havanese"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Ibizan_Hound
+:CommodityCode_LIVE_MMLS_DOGS_Ibizan_Hound rdf:type owl:NamedIndividual ,
+                                                    :CommodityCode ;
+                                           rdfs:comment "Ibizan Hound"@en ;
+                                           rdfs:label "LIVE_MMLS_DOGS_Ibizan_Hound"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Icelandic_Sheepdog
+:CommodityCode_LIVE_MMLS_DOGS_Icelandic_Sheepdog rdf:type owl:NamedIndividual ,
+                                                          :CommodityCode ;
+                                                 rdfs:comment "Icelandic Sheepdog"@en ;
+                                                 rdfs:label "LIVE_MMLS_DOGS_Icelandic_Sheepdog"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Irish_Red_and_White_Setter
+:CommodityCode_LIVE_MMLS_DOGS_Irish_Red_and_White_Setter rdf:type owl:NamedIndividual ,
+                                                                  :CommodityCode ;
+                                                         rdfs:comment "Irish Red and White Setter"@en ;
+                                                         rdfs:label "LIVE_MMLS_DOGS_Irish_Red_and_White_Setter"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Irish_Setter
+:CommodityCode_LIVE_MMLS_DOGS_Irish_Setter rdf:type owl:NamedIndividual ,
+                                                    :CommodityCode ;
+                                           rdfs:comment "Irish Setter"@en ;
+                                           rdfs:label "LIVE_MMLS_DOGS_Irish_Setter"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Irish_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Irish_Terrier rdf:type owl:NamedIndividual ,
+                                                     :CommodityCode ;
+                                            rdfs:comment "Irish Terrier"@en ;
+                                            rdfs:label "LIVE_MMLS_DOGS_Irish_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Irish_Water_Spaniel
+:CommodityCode_LIVE_MMLS_DOGS_Irish_Water_Spaniel rdf:type owl:NamedIndividual ,
+                                                           :CommodityCode ;
+                                                  rdfs:comment "Irish Water Spaniel"@en ;
+                                                  rdfs:label "LIVE_MMLS_DOGS_Irish_Water_Spaniel"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Irish_Wolfhound
+:CommodityCode_LIVE_MMLS_DOGS_Irish_Wolfhound rdf:type owl:NamedIndividual ,
+                                                       :CommodityCode ;
+                                              rdfs:comment "Irish Wolfhound"@en ;
+                                              rdfs:label "LIVE_MMLS_DOGS_Irish_Wolfhound"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Italian_Greyhound
+:CommodityCode_LIVE_MMLS_DOGS_Italian_Greyhound rdf:type owl:NamedIndividual ,
+                                                         :CommodityCode ;
+                                                rdfs:comment "Italian Greyhound"@en ;
+                                                rdfs:label "LIVE_MMLS_DOGS_Italian_Greyhound"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Italian_Mastiff
+:CommodityCode_LIVE_MMLS_DOGS_Italian_Mastiff rdf:type owl:NamedIndividual ,
+                                                       :CommodityCode ;
+                                              rdfs:comment "Italian Mastiff"@en ;
+                                              rdfs:label "LIVE_MMLS_DOGS_Italian_Mastiff"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Jack_Chi_Chihuahua_Jack_Russell_Terrier_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Jack_Chi_Chihuahua_Jack_Russell_Terrier_Mix rdf:type owl:NamedIndividual ,
+                                                                                   :CommodityCode ;
+                                                                          rdfs:comment "Jack Chi-Chihuahua Jack Russell Terrier Mix"@en ;
+                                                                          rdfs:label "LIVE_MMLS_DOGS_Jack_Chi_Chihuahua_Jack_Russell_Terrier_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Jack_Russell_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Jack_Russell_Terrier rdf:type owl:NamedIndividual ,
+                                                            :CommodityCode ;
+                                                   rdfs:comment "Jack Russell Terrier"@en ;
+                                                   rdfs:label "LIVE_MMLS_DOGS_Jack_Russell_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Japanese_Boxer
+:CommodityCode_LIVE_MMLS_DOGS_Japanese_Boxer rdf:type owl:NamedIndividual ,
+                                                      :CommodityCode ;
+                                             rdfs:comment "Japanese Boxer"@en ;
+                                             rdfs:label "LIVE_MMLS_DOGS_Japanese_Boxer"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Japanese_Chin
+:CommodityCode_LIVE_MMLS_DOGS_Japanese_Chin rdf:type owl:NamedIndividual ,
+                                                     :CommodityCode ;
+                                            rdfs:comment "Japanese Chin"@en ;
+                                            rdfs:label "LIVE_MMLS_DOGS_Japanese_Chin"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Japanese_Mastiff
+:CommodityCode_LIVE_MMLS_DOGS_Japanese_Mastiff rdf:type owl:NamedIndividual ,
+                                                        :CommodityCode ;
+                                               rdfs:comment "Japanese Mastiff"@en ;
+                                               rdfs:label "LIVE_MMLS_DOGS_Japanese_Mastiff"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Japanese_Pug
+:CommodityCode_LIVE_MMLS_DOGS_Japanese_Pug rdf:type owl:NamedIndividual ,
+                                                    :CommodityCode ;
+                                           rdfs:comment "Japanese Pug"@en ;
+                                           rdfs:label "LIVE_MMLS_DOGS_Japanese_Pug"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Japanese_Spaniel
+:CommodityCode_LIVE_MMLS_DOGS_Japanese_Spaniel rdf:type owl:NamedIndividual ,
+                                                        :CommodityCode ;
+                                               rdfs:comment "Japanese Spaniel"@en ;
+                                               rdfs:label "LIVE_MMLS_DOGS_Japanese_Spaniel"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Kangal_Shepherd_Dog
+:CommodityCode_LIVE_MMLS_DOGS_Kangal_Shepherd_Dog rdf:type owl:NamedIndividual ,
+                                                           :CommodityCode ;
+                                                  rdfs:comment "Kangal Shepherd Dog"@en ;
+                                                  rdfs:label "LIVE_MMLS_DOGS_Kangal_Shepherd_Dog"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Keeshond
+:CommodityCode_LIVE_MMLS_DOGS_Keeshond rdf:type owl:NamedIndividual ,
+                                                :CommodityCode ;
+                                       rdfs:comment "Keeshond"@en ;
+                                       rdfs:label "LIVE_MMLS_DOGS_Keeshond"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Kerry_Blue_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Kerry_Blue_Terrier rdf:type owl:NamedIndividual ,
+                                                          :CommodityCode ;
+                                                 rdfs:comment "Kerry Blue Terrier"@en ;
+                                                 rdfs:label "LIVE_MMLS_DOGS_Kerry_Blue_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_King_Charles_Spaniel
+:CommodityCode_LIVE_MMLS_DOGS_King_Charles_Spaniel rdf:type owl:NamedIndividual ,
+                                                            :CommodityCode ;
+                                                   rdfs:comment "King Charles Spaniel"@en ;
+                                                   rdfs:label "LIVE_MMLS_DOGS_King_Charles_Spaniel"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Komondor
+:CommodityCode_LIVE_MMLS_DOGS_Komondor rdf:type owl:NamedIndividual ,
+                                                :CommodityCode ;
+                                       rdfs:comment "Komondor"@en ;
+                                       rdfs:label "LIVE_MMLS_DOGS_Komondor"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Kuvasz
+:CommodityCode_LIVE_MMLS_DOGS_Kuvasz rdf:type owl:NamedIndividual ,
+                                              :CommodityCode ;
+                                     rdfs:comment "Kuvasz"@en ;
+                                     rdfs:label "LIVE_MMLS_DOGS_Kuvasz"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Kyi_Leo_Maltese_Lhasa_Apso_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Kyi_Leo_Maltese_Lhasa_Apso_Mix rdf:type owl:NamedIndividual ,
+                                                                      :CommodityCode ;
+                                                             rdfs:comment "Kyi-Leo-Maltese Lhasa Apso Mix"@en ;
+                                                             rdfs:label "LIVE_MMLS_DOGS_Kyi_Leo_Maltese_Lhasa_Apso_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Labrabull_Labrador_Retriever_American_Pit_Bull
+:CommodityCode_LIVE_MMLS_DOGS_Labrabull_Labrador_Retriever_American_Pit_Bull rdf:type owl:NamedIndividual ,
+                                                                                      :CommodityCode ;
+                                                                             rdfs:comment "Labrabull-Labrador Retriever American Pit Bull"@en ;
+                                                                             rdfs:label "LIVE_MMLS_DOGS_Labrabull_Labrador_Retriever_American_Pit_Bull"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Labradane_Labrador_Retriever_Great_Dane_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Labradane_Labrador_Retriever_Great_Dane_Mix rdf:type owl:NamedIndividual ,
+                                                                                   :CommodityCode ;
+                                                                          rdfs:comment "Labradane-Labrador Retriever Great Dane Mix"@en ;
+                                                                          rdfs:label "LIVE_MMLS_DOGS_Labradane_Labrador_Retriever_Great_Dane_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Labradoodle_Labrador_Retriever_Poodle_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Labradoodle_Labrador_Retriever_Poodle_Mix rdf:type owl:NamedIndividual ,
+                                                                                 :CommodityCode ;
+                                                                        rdfs:comment "Labradoodle Labrador Retriever Poodle Mix"@en ;
+                                                                        rdfs:label "LIVE_MMLS_DOGS_Labradoodle_Labrador_Retriever_Poodle_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Labrador_Retriever
+:CommodityCode_LIVE_MMLS_DOGS_Labrador_Retriever rdf:type owl:NamedIndividual ,
+                                                          :CommodityCode ;
+                                                 rdfs:comment "Labrador Retriever"@en ;
+                                                 rdfs:label "LIVE_MMLS_DOGS_Labrador_Retriever"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Lagotto_Romagnolo
+:CommodityCode_LIVE_MMLS_DOGS_Lagotto_Romagnolo rdf:type owl:NamedIndividual ,
+                                                         :CommodityCode ;
+                                                rdfs:comment "Lagotto Romagnolo"@en ;
+                                                rdfs:label "LIVE_MMLS_DOGS_Lagotto_Romagnolo"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Lakeland_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Lakeland_Terrier rdf:type owl:NamedIndividual ,
+                                                        :CommodityCode ;
+                                               rdfs:comment "Lakeland Terrier"@en ;
+                                               rdfs:label "LIVE_MMLS_DOGS_Lakeland_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Leonberger
+:CommodityCode_LIVE_MMLS_DOGS_Leonberger rdf:type owl:NamedIndividual ,
+                                                  :CommodityCode ;
+                                         rdfs:comment "Leonberger"@en ;
+                                         rdfs:label "LIVE_MMLS_DOGS_Leonberger"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Lhasa_Apso
+:CommodityCode_LIVE_MMLS_DOGS_Lhasa_Apso rdf:type owl:NamedIndividual ,
+                                                  :CommodityCode ;
+                                         rdfs:comment "Lhasa Apso"@en ;
+                                         rdfs:label "LIVE_MMLS_DOGS_Lhasa_Apso"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Löwchen
+:CommodityCode_LIVE_MMLS_DOGS_Löwchen rdf:type owl:NamedIndividual ,
+                                               :CommodityCode ;
+                                      rdfs:comment "Löwchen"@en ;
+                                      rdfs:label "LIVE_MMLS_DOGS_Löwchen"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Mal_Shi_Maltese_Shih_Tzu_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Mal_Shi_Maltese_Shih_Tzu_Mix rdf:type owl:NamedIndividual ,
+                                                                    :CommodityCode ;
+                                                           rdfs:comment "Mal-Shi-Maltese Shih Tzu Mix"@en ;
+                                                           rdfs:label "LIVE_MMLS_DOGS_Mal_Shi_Maltese_Shih_Tzu_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Malt_Tzu_Maltese_Shih_Tzu_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Malt_Tzu_Maltese_Shih_Tzu_Mix rdf:type owl:NamedIndividual ,
+                                                                     :CommodityCode ;
+                                                            rdfs:comment "Malt-Tzu-Maltese Shih Tzu Mix"@en ;
+                                                            rdfs:label "LIVE_MMLS_DOGS_Malt_Tzu_Maltese_Shih_Tzu_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Maltese
+:CommodityCode_LIVE_MMLS_DOGS_Maltese rdf:type owl:NamedIndividual ,
+                                               :CommodityCode ;
+                                      rdfs:comment "Maltese"@en ;
+                                      rdfs:label "LIVE_MMLS_DOGS_Maltese"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Maltese_Shih_Tzu
+:CommodityCode_LIVE_MMLS_DOGS_Maltese_Shih_Tzu rdf:type owl:NamedIndividual ,
+                                                        :CommodityCode ;
+                                               rdfs:comment "Maltese Shih Tzu"@en ;
+                                               rdfs:label "LIVE_MMLS_DOGS_Maltese_Shih_Tzu"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Malti_Zu_Maltese_Shih_Tzu_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Malti_Zu_Maltese_Shih_Tzu_Mix rdf:type owl:NamedIndividual ,
+                                                                     :CommodityCode ;
+                                                            rdfs:comment "Malti Zu-Maltese Shih Tzu Mix"@en ;
+                                                            rdfs:label "LIVE_MMLS_DOGS_Malti_Zu_Maltese_Shih_Tzu_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Maltipoo_Maltese_Poodle_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Maltipoo_Maltese_Poodle_Mix rdf:type owl:NamedIndividual ,
+                                                                   :CommodityCode ;
+                                                          rdfs:comment "Maltipoo-Maltese Poodle Mix"@en ;
+                                                          rdfs:label "LIVE_MMLS_DOGS_Maltipoo_Maltese_Poodle_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Manchester_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Manchester_Terrier rdf:type owl:NamedIndividual ,
+                                                          :CommodityCode ;
+                                                 rdfs:comment "Manchester Terrier"@en ;
+                                                 rdfs:label "LIVE_MMLS_DOGS_Manchester_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Mastador_Bullmastiff_Labrador_Retriever_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Mastador_Bullmastiff_Labrador_Retriever_Mix rdf:type owl:NamedIndividual ,
+                                                                                   :CommodityCode ;
+                                                                          rdfs:comment "Mastador-Bullmastiff Labrador Retriever Mix"@en ;
+                                                                          rdfs:label "LIVE_MMLS_DOGS_Mastador_Bullmastiff_Labrador_Retriever_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Mastiff
+:CommodityCode_LIVE_MMLS_DOGS_Mastiff rdf:type owl:NamedIndividual ,
+                                               :CommodityCode ;
+                                      rdfs:comment "Mastiff"@en ;
+                                      rdfs:label "LIVE_MMLS_DOGS_Mastiff"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Mastin_Espanol_Spanish_Mastiff
+:CommodityCode_LIVE_MMLS_DOGS_Mastin_Espanol_Spanish_Mastiff rdf:type owl:NamedIndividual ,
+                                                                      :CommodityCode ;
+                                                             rdfs:comment "Mastin Espanol-Spanish Mastiff"@en ;
+                                                             rdfs:label "LIVE_MMLS_DOGS_Mastin_Espanol_Spanish_Mastiff"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Mastino_Napoletano_Neopolitan_Mastiff
+:CommodityCode_LIVE_MMLS_DOGS_Mastino_Napoletano_Neopolitan_Mastiff rdf:type owl:NamedIndividual ,
+                                                                             :CommodityCode ;
+                                                                    rdfs:comment "Mastino Napoletano-Neopolitan Mastiff"@en ;
+                                                                    rdfs:label "LIVE_MMLS_DOGS_Mastino_Napoletano_Neopolitan_Mastiff"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Miniature_American_Shepherd
+:CommodityCode_LIVE_MMLS_DOGS_Miniature_American_Shepherd rdf:type owl:NamedIndividual ,
+                                                                   :CommodityCode ;
+                                                          rdfs:comment "Miniature American Shepherd"@en ;
+                                                          rdfs:label "LIVE_MMLS_DOGS_Miniature_American_Shepherd"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Miniature_Bull_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Miniature_Bull_Terrier rdf:type owl:NamedIndividual ,
+                                                              :CommodityCode ;
+                                                     rdfs:comment "Miniature Bull Terrier"@en ;
+                                                     rdfs:label "LIVE_MMLS_DOGS_Miniature_Bull_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Miniature_Pinscher
+:CommodityCode_LIVE_MMLS_DOGS_Miniature_Pinscher rdf:type owl:NamedIndividual ,
+                                                          :CommodityCode ;
+                                                 rdfs:comment "Miniature Pinscher"@en ;
+                                                 rdfs:label "LIVE_MMLS_DOGS_Miniature_Pinscher"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Miniature_Schnauzer
+:CommodityCode_LIVE_MMLS_DOGS_Miniature_Schnauzer rdf:type owl:NamedIndividual ,
+                                                           :CommodityCode ;
+                                                  rdfs:comment "Miniature Schnauzer"@en ;
+                                                  rdfs:label "LIVE_MMLS_DOGS_Miniature_Schnauzer"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Mixed_Invalid_Breed_Type
+:CommodityCode_LIVE_MMLS_DOGS_Mixed_Invalid_Breed_Type rdf:type owl:NamedIndividual ,
+                                                                :CommodityCode ;
+                                                       rdfs:comment "Mixed-Invalid Breed Type"@en ;
+                                                       rdfs:label "LIVE_MMLS_DOGS_Mixed_Invalid_Breed_Type"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Neapolitan_Mastiff
+:CommodityCode_LIVE_MMLS_DOGS_Neapolitan_Mastiff rdf:type owl:NamedIndividual ,
+                                                          :CommodityCode ;
+                                                 rdfs:comment "Neapolitan Mastiff"@en ;
+                                                 rdfs:label "LIVE_MMLS_DOGS_Neapolitan_Mastiff"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Newfoundland
+:CommodityCode_LIVE_MMLS_DOGS_Newfoundland rdf:type owl:NamedIndividual ,
+                                                    :CommodityCode ;
+                                           rdfs:comment "Newfoundland"@en ;
+                                           rdfs:label "LIVE_MMLS_DOGS_Newfoundland"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Norfolk_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Norfolk_Terrier rdf:type owl:NamedIndividual ,
+                                                       :CommodityCode ;
+                                              rdfs:comment "Norfolk Terrier"@en ;
+                                              rdfs:label "LIVE_MMLS_DOGS_Norfolk_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Norwegian_Buhund
+:CommodityCode_LIVE_MMLS_DOGS_Norwegian_Buhund rdf:type owl:NamedIndividual ,
+                                                        :CommodityCode ;
+                                               rdfs:comment "Norwegian Buhund"@en ;
+                                               rdfs:label "LIVE_MMLS_DOGS_Norwegian_Buhund"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Norwegian_Elkhound
+:CommodityCode_LIVE_MMLS_DOGS_Norwegian_Elkhound rdf:type owl:NamedIndividual ,
+                                                          :CommodityCode ;
+                                                 rdfs:comment "Norwegian Elkhound"@en ;
+                                                 rdfs:label "LIVE_MMLS_DOGS_Norwegian_Elkhound"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Norwegian_Lundehund
+:CommodityCode_LIVE_MMLS_DOGS_Norwegian_Lundehund rdf:type owl:NamedIndividual ,
+                                                           :CommodityCode ;
+                                                  rdfs:comment "Norwegian Lundehund"@en ;
+                                                  rdfs:label "LIVE_MMLS_DOGS_Norwegian_Lundehund"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Norwich_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Norwich_Terrier rdf:type owl:NamedIndividual ,
+                                                       :CommodityCode ;
+                                              rdfs:comment "Norwich Terrier"@en ;
+                                              rdfs:label "LIVE_MMLS_DOGS_Norwich_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Nova_Scotia_Duck_Tolling_Retriever
+:CommodityCode_LIVE_MMLS_DOGS_Nova_Scotia_Duck_Tolling_Retriever rdf:type owl:NamedIndividual ,
+                                                                          :CommodityCode ;
+                                                                 rdfs:comment "Nova Scotia Duck-Tolling Retriever"@en ;
+                                                                 rdfs:label "LIVE_MMLS_DOGS_Nova_Scotia_Duck_Tolling_Retriever"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Old_English_Bulldog
+:CommodityCode_LIVE_MMLS_DOGS_Old_English_Bulldog rdf:type owl:NamedIndividual ,
+                                                           :CommodityCode ;
+                                                  rdfs:comment "Old English Bulldog"@en ;
+                                                  rdfs:label "LIVE_MMLS_DOGS_Old_English_Bulldog"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Old_English_Sheepdog
+:CommodityCode_LIVE_MMLS_DOGS_Old_English_Sheepdog rdf:type owl:NamedIndividual ,
+                                                            :CommodityCode ;
+                                                   rdfs:comment "Old English Sheepdog"@en ;
+                                                   rdfs:label "LIVE_MMLS_DOGS_Old_English_Sheepdog"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Olde_English_Bulldog
+:CommodityCode_LIVE_MMLS_DOGS_Olde_English_Bulldog rdf:type owl:NamedIndividual ,
+                                                            :CommodityCode ;
+                                                   rdfs:comment "Olde English Bulldog"@en ;
+                                                   rdfs:label "LIVE_MMLS_DOGS_Olde_English_Bulldog"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Otterhound
+:CommodityCode_LIVE_MMLS_DOGS_Otterhound rdf:type owl:NamedIndividual ,
+                                                  :CommodityCode ;
+                                         rdfs:comment "Otterhound"@en ;
+                                         rdfs:label "LIVE_MMLS_DOGS_Otterhound"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Papillon
+:CommodityCode_LIVE_MMLS_DOGS_Papillon rdf:type owl:NamedIndividual ,
+                                                :CommodityCode ;
+                                       rdfs:comment "Papillon"@en ;
+                                       rdfs:label "LIVE_MMLS_DOGS_Papillon"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Parson_Russell_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Parson_Russell_Terrier rdf:type owl:NamedIndividual ,
+                                                              :CommodityCode ;
+                                                     rdfs:comment "Parson Russell Terrier"@en ;
+                                                     rdfs:label "LIVE_MMLS_DOGS_Parson_Russell_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Peekapoo_Pekingese_Poodle_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Peekapoo_Pekingese_Poodle_Mix rdf:type owl:NamedIndividual ,
+                                                                     :CommodityCode ;
+                                                            rdfs:comment "Peekapoo-Pekingese Poodle Mix"@en ;
+                                                            rdfs:label "LIVE_MMLS_DOGS_Peekapoo_Pekingese_Poodle_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Pekingese
+:CommodityCode_LIVE_MMLS_DOGS_Pekingese rdf:type owl:NamedIndividual ,
+                                                 :CommodityCode ;
+                                        rdfs:comment "Pekingese"@en ;
+                                        rdfs:label "LIVE_MMLS_DOGS_Pekingese"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Pembroke_Welsh_Corgi
+:CommodityCode_LIVE_MMLS_DOGS_Pembroke_Welsh_Corgi rdf:type owl:NamedIndividual ,
+                                                            :CommodityCode ;
+                                                   rdfs:comment "Pembroke Welsh Corgi"@en ;
+                                                   rdfs:label "LIVE_MMLS_DOGS_Pembroke_Welsh_Corgi"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Petit_Basset_Griffon_Vendéen
+:CommodityCode_LIVE_MMLS_DOGS_Petit_Basset_Griffon_Vendéen rdf:type owl:NamedIndividual ,
+                                                                    :CommodityCode ;
+                                                           rdfs:comment "Petit Basset Griffon Vendéen"@en ;
+                                                           rdfs:label "LIVE_MMLS_DOGS_Petit_Basset_Griffon_Vendéen"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Pharaoh_Hound
+:CommodityCode_LIVE_MMLS_DOGS_Pharaoh_Hound rdf:type owl:NamedIndividual ,
+                                                     :CommodityCode ;
+                                            rdfs:comment "Pharaoh Hound"@en ;
+                                            rdfs:label "LIVE_MMLS_DOGS_Pharaoh_Hound"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Pit_Bull
+:CommodityCode_LIVE_MMLS_DOGS_Pit_Bull rdf:type owl:NamedIndividual ,
+                                                :CommodityCode ;
+                                       rdfs:comment "Pit Bull"@en ;
+                                       rdfs:label "LIVE_MMLS_DOGS_Pit_Bull"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Pit_Plott_Pitbull_Plott_Hound_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Pit_Plott_Pitbull_Plott_Hound_Mix rdf:type owl:NamedIndividual ,
+                                                                         :CommodityCode ;
+                                                                rdfs:comment "Pit Plott-Pitbull Plott Hound Mix"@en ;
+                                                                rdfs:label "LIVE_MMLS_DOGS_Pit_Plott_Pitbull_Plott_Hound_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Plott_Hound
+:CommodityCode_LIVE_MMLS_DOGS_Plott_Hound rdf:type owl:NamedIndividual ,
+                                                   :CommodityCode ;
+                                          rdfs:comment "Plott Hound"@en ;
+                                          rdfs:label "LIVE_MMLS_DOGS_Plott_Hound"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Pointer
+:CommodityCode_LIVE_MMLS_DOGS_Pointer rdf:type owl:NamedIndividual ,
+                                               :CommodityCode ;
+                                      rdfs:comment "Pointer"@en ;
+                                      rdfs:label "LIVE_MMLS_DOGS_Pointer"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Polish_Lowland_Sheepdog
+:CommodityCode_LIVE_MMLS_DOGS_Polish_Lowland_Sheepdog rdf:type owl:NamedIndividual ,
+                                                               :CommodityCode ;
+                                                      rdfs:comment "Polish Lowland Sheepdog"@en ;
+                                                      rdfs:label "LIVE_MMLS_DOGS_Polish_Lowland_Sheepdog"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Pomapoo_Pomeranian_Poodle_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Pomapoo_Pomeranian_Poodle_Mix rdf:type owl:NamedIndividual ,
+                                                                     :CommodityCode ;
+                                                            rdfs:comment "Pomapoo-Pomeranian Poodle Mix"@en ;
+                                                            rdfs:label "LIVE_MMLS_DOGS_Pomapoo_Pomeranian_Poodle_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Pomchi_Pomeranian_Chihuahua_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Pomchi_Pomeranian_Chihuahua_Mix rdf:type owl:NamedIndividual ,
+                                                                       :CommodityCode ;
+                                                              rdfs:comment "Pomchi-Pomeranian Chihuahua Mix"@en ;
+                                                              rdfs:label "LIVE_MMLS_DOGS_Pomchi_Pomeranian_Chihuahua_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Pomeranian
+:CommodityCode_LIVE_MMLS_DOGS_Pomeranian rdf:type owl:NamedIndividual ,
+                                                  :CommodityCode ;
+                                         rdfs:comment "Pomeranian"@en ;
+                                         rdfs:label "LIVE_MMLS_DOGS_Pomeranian"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Pomsky_Pomeranian_Siberian_Husky_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Pomsky_Pomeranian_Siberian_Husky_Mix rdf:type owl:NamedIndividual ,
+                                                                            :CommodityCode ;
+                                                                   rdfs:comment "Pomsky-Pomeranian Siberian Husky Mix"@en ;
+                                                                   rdfs:label "LIVE_MMLS_DOGS_Pomsky_Pomeranian_Siberian_Husky_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Poochon_Poodle_Bichon_Frise_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Poochon_Poodle_Bichon_Frise_Mix rdf:type owl:NamedIndividual ,
+                                                                       :CommodityCode ;
+                                                              rdfs:comment "Poochon-Poodle Bichon Frise Mix"@en ;
+                                                              rdfs:label "LIVE_MMLS_DOGS_Poochon_Poodle_Bichon_Frise_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Poodle
+:CommodityCode_LIVE_MMLS_DOGS_Poodle rdf:type owl:NamedIndividual ,
+                                              :CommodityCode ;
+                                     rdfs:comment "Poodle"@en ;
+                                     rdfs:label "LIVE_MMLS_DOGS_Poodle"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Portuguese_Water_Dog
+:CommodityCode_LIVE_MMLS_DOGS_Portuguese_Water_Dog rdf:type owl:NamedIndividual ,
+                                                            :CommodityCode ;
+                                                   rdfs:comment "Portuguese Water Dog"@en ;
+                                                   rdfs:label "LIVE_MMLS_DOGS_Portuguese_Water_Dog"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Presa_Canario
+:CommodityCode_LIVE_MMLS_DOGS_Presa_Canario rdf:type owl:NamedIndividual ,
+                                                     :CommodityCode ;
+                                            rdfs:comment "Presa Canario"@en ;
+                                            rdfs:label "LIVE_MMLS_DOGS_Presa_Canario"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Pug
+:CommodityCode_LIVE_MMLS_DOGS_Pug rdf:type owl:NamedIndividual ,
+                                           :CommodityCode ;
+                                  rdfs:comment "Pug"@en ;
+                                  rdfs:label "LIVE_MMLS_DOGS_Pug"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Pugapoo_Pug_Poodle_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Pugapoo_Pug_Poodle_Mix rdf:type owl:NamedIndividual ,
+                                                              :CommodityCode ;
+                                                     rdfs:comment "Pugapoo-Pug Poodle Mix"@en ;
+                                                     rdfs:label "LIVE_MMLS_DOGS_Pugapoo_Pug_Poodle_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Puggle_Pug_Beagle_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Puggle_Pug_Beagle_Mix rdf:type owl:NamedIndividual ,
+                                                             :CommodityCode ;
+                                                    rdfs:comment "Puggle-Pug Beagle Mix"@en ;
+                                                    rdfs:label "LIVE_MMLS_DOGS_Puggle_Pug_Beagle_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Puli
+:CommodityCode_LIVE_MMLS_DOGS_Puli rdf:type owl:NamedIndividual ,
+                                            :CommodityCode ;
+                                   rdfs:comment "Puli"@en ;
+                                   rdfs:label "LIVE_MMLS_DOGS_Puli"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Pyrenean_Mastiff
+:CommodityCode_LIVE_MMLS_DOGS_Pyrenean_Mastiff rdf:type owl:NamedIndividual ,
+                                                        :CommodityCode ;
+                                               rdfs:comment "Pyrenean Mastiff"@en ;
+                                               rdfs:label "LIVE_MMLS_DOGS_Pyrenean_Mastiff"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Pyrenean_Shepherd
+:CommodityCode_LIVE_MMLS_DOGS_Pyrenean_Shepherd rdf:type owl:NamedIndividual ,
+                                                         :CommodityCode ;
+                                                rdfs:comment "Pyrenean Shepherd"@en ;
+                                                rdfs:label "LIVE_MMLS_DOGS_Pyrenean_Shepherd"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Rat_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Rat_Terrier rdf:type owl:NamedIndividual ,
+                                                   :CommodityCode ;
+                                          rdfs:comment "Rat Terrier"@en ;
+                                          rdfs:label "LIVE_MMLS_DOGS_Rat_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Redbone_Coonhound
+:CommodityCode_LIVE_MMLS_DOGS_Redbone_Coonhound rdf:type owl:NamedIndividual ,
+                                                         :CommodityCode ;
+                                                rdfs:comment "Redbone Coonhound"@en ;
+                                                rdfs:label "LIVE_MMLS_DOGS_Redbone_Coonhound"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Rhodesian_Ridgeback
+:CommodityCode_LIVE_MMLS_DOGS_Rhodesian_Ridgeback rdf:type owl:NamedIndividual ,
+                                                           :CommodityCode ;
+                                                  rdfs:comment "Rhodesian Ridgeback"@en ;
+                                                  rdfs:label "LIVE_MMLS_DOGS_Rhodesian_Ridgeback"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Rottweiler
+:CommodityCode_LIVE_MMLS_DOGS_Rottweiler rdf:type owl:NamedIndividual ,
+                                                  :CommodityCode ;
+                                         rdfs:comment "Rottweiler"@en ;
+                                         rdfs:label "LIVE_MMLS_DOGS_Rottweiler"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Russell_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Russell_Terrier rdf:type owl:NamedIndividual ,
+                                                       :CommodityCode ;
+                                              rdfs:comment "Russell Terrier"@en ;
+                                              rdfs:label "LIVE_MMLS_DOGS_Russell_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Saint_Bernard
+:CommodityCode_LIVE_MMLS_DOGS_Saint_Bernard rdf:type owl:NamedIndividual ,
+                                                     :CommodityCode ;
+                                            rdfs:comment "Saint Bernard"@en ;
+                                            rdfs:label "LIVE_MMLS_DOGS_Saint_Bernard"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Saluki
+:CommodityCode_LIVE_MMLS_DOGS_Saluki rdf:type owl:NamedIndividual ,
+                                              :CommodityCode ;
+                                     rdfs:comment "Saluki"@en ;
+                                     rdfs:label "LIVE_MMLS_DOGS_Saluki"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Samoyed
+:CommodityCode_LIVE_MMLS_DOGS_Samoyed rdf:type owl:NamedIndividual ,
+                                               :CommodityCode ;
+                                      rdfs:comment "Samoyed"@en ;
+                                      rdfs:label "LIVE_MMLS_DOGS_Samoyed"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Schipperke
+:CommodityCode_LIVE_MMLS_DOGS_Schipperke rdf:type owl:NamedIndividual ,
+                                                  :CommodityCode ;
+                                         rdfs:comment "Schipperke"@en ;
+                                         rdfs:label "LIVE_MMLS_DOGS_Schipperke"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Schnoodle_Schnauzer_Poodle_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Schnoodle_Schnauzer_Poodle_Mix rdf:type owl:NamedIndividual ,
+                                                                      :CommodityCode ;
+                                                             rdfs:comment "Schnoodle-Schnauzer Poodle Mix"@en ;
+                                                             rdfs:label "LIVE_MMLS_DOGS_Schnoodle_Schnauzer_Poodle_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Scottish_Deerhound
+:CommodityCode_LIVE_MMLS_DOGS_Scottish_Deerhound rdf:type owl:NamedIndividual ,
+                                                          :CommodityCode ;
+                                                 rdfs:comment "Scottish Deerhound"@en ;
+                                                 rdfs:label "LIVE_MMLS_DOGS_Scottish_Deerhound"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Scottish_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Scottish_Terrier rdf:type owl:NamedIndividual ,
+                                                        :CommodityCode ;
+                                               rdfs:comment "Scottish Terrier"@en ;
+                                               rdfs:label "LIVE_MMLS_DOGS_Scottish_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Sealyham_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Sealyham_Terrier rdf:type owl:NamedIndividual ,
+                                                        :CommodityCode ;
+                                               rdfs:comment "Sealyham Terrier"@en ;
+                                               rdfs:label "LIVE_MMLS_DOGS_Sealyham_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Shar_Pei
+:CommodityCode_LIVE_MMLS_DOGS_Shar_Pei rdf:type owl:NamedIndividual ,
+                                                :CommodityCode ;
+                                       rdfs:comment "Shar Pei"@en ;
+                                       rdfs:label "LIVE_MMLS_DOGS_Shar_Pei"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Sheepadoodle_Old_English_Sheepdog_Poodle_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Sheepadoodle_Old_English_Sheepdog_Poodle_Mix rdf:type owl:NamedIndividual ,
+                                                                                    :CommodityCode ;
+                                                                           rdfs:comment "Sheepadoodle-Old English Sheepdog Poodle Mix"@en ;
+                                                                           rdfs:label "LIVE_MMLS_DOGS_Sheepadoodle_Old_English_Sheepdog_Poodle_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Shetland_Sheepdog
+:CommodityCode_LIVE_MMLS_DOGS_Shetland_Sheepdog rdf:type owl:NamedIndividual ,
+                                                         :CommodityCode ;
+                                                rdfs:comment "Shetland Sheepdog"@en ;
+                                                rdfs:label "LIVE_MMLS_DOGS_Shetland_Sheepdog"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Shiba_Inu
+:CommodityCode_LIVE_MMLS_DOGS_Shiba_Inu rdf:type owl:NamedIndividual ,
+                                                 :CommodityCode ;
+                                        rdfs:comment "Shiba Inu"@en ;
+                                        rdfs:label "LIVE_MMLS_DOGS_Shiba_Inu"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Shih_Poo
+:CommodityCode_LIVE_MMLS_DOGS_Shih_Poo rdf:type owl:NamedIndividual ,
+                                                :CommodityCode ;
+                                       rdfs:comment "Shih-Poo"@en ;
+                                       rdfs:label "LIVE_MMLS_DOGS_Shih_Poo"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Shih_Tzu
+:CommodityCode_LIVE_MMLS_DOGS_Shih_Tzu rdf:type owl:NamedIndividual ,
+                                                :CommodityCode ;
+                                       rdfs:comment "Shih Tzu"@en ;
+                                       rdfs:label "LIVE_MMLS_DOGS_Shih_Tzu"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Shihpoo_Shih_Tzu_Poodle_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Shihpoo_Shih_Tzu_Poodle_Mix rdf:type owl:NamedIndividual ,
+                                                                   :CommodityCode ;
+                                                          rdfs:comment "Shihpoo-Shih Tzu Poodle Mix"@en ;
+                                                          rdfs:label "LIVE_MMLS_DOGS_Shihpoo_Shih_Tzu_Poodle_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Siberian_Husky
+:CommodityCode_LIVE_MMLS_DOGS_Siberian_Husky rdf:type owl:NamedIndividual ,
+                                                      :CommodityCode ;
+                                             rdfs:comment "Siberian Husky"@en ;
+                                             rdfs:label "LIVE_MMLS_DOGS_Siberian_Husky"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Silky_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Silky_Terrier rdf:type owl:NamedIndividual ,
+                                                     :CommodityCode ;
+                                            rdfs:comment "Silky Terrier"@en ;
+                                            rdfs:label "LIVE_MMLS_DOGS_Silky_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Skye_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Skye_Terrier rdf:type owl:NamedIndividual ,
+                                                    :CommodityCode ;
+                                           rdfs:comment "Skye Terrier"@en ;
+                                           rdfs:label "LIVE_MMLS_DOGS_Skye_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Sloughi_Arabian_Greyhound
+:CommodityCode_LIVE_MMLS_DOGS_Sloughi_Arabian_Greyhound rdf:type owl:NamedIndividual ,
+                                                                 :CommodityCode ;
+                                                        rdfs:comment "Sloughi-Arabian Greyhound"@en ;
+                                                        rdfs:label "LIVE_MMLS_DOGS_Sloughi_Arabian_Greyhound"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Smooth_Fox_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Smooth_Fox_Terrier rdf:type owl:NamedIndividual ,
+                                                          :CommodityCode ;
+                                                 rdfs:comment "Smooth Fox Terrier"@en ;
+                                                 rdfs:label "LIVE_MMLS_DOGS_Smooth_Fox_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Soft_Coated_Wheaten_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Soft_Coated_Wheaten_Terrier rdf:type owl:NamedIndividual ,
+                                                                   :CommodityCode ;
+                                                          rdfs:comment "Soft-Coated Wheaten Terrier"@en ;
+                                                          rdfs:label "LIVE_MMLS_DOGS_Soft_Coated_Wheaten_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_South_African_Mastiff
+:CommodityCode_LIVE_MMLS_DOGS_South_African_Mastiff rdf:type owl:NamedIndividual ,
+                                                             :CommodityCode ;
+                                                    rdfs:comment "South African Mastiff"@en ;
+                                                    rdfs:label "LIVE_MMLS_DOGS_South_African_Mastiff"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Spanish_Mastiff
+:CommodityCode_LIVE_MMLS_DOGS_Spanish_Mastiff rdf:type owl:NamedIndividual ,
+                                                       :CommodityCode ;
+                                              rdfs:comment "Spanish Mastiff"@en ;
+                                              rdfs:label "LIVE_MMLS_DOGS_Spanish_Mastiff"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Spanish_Water_Dog
+:CommodityCode_LIVE_MMLS_DOGS_Spanish_Water_Dog rdf:type owl:NamedIndividual ,
+                                                         :CommodityCode ;
+                                                rdfs:comment "Spanish Water Dog"@en ;
+                                                rdfs:label "LIVE_MMLS_DOGS_Spanish_Water_Dog"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Spinone_Italiano
+:CommodityCode_LIVE_MMLS_DOGS_Spinone_Italiano rdf:type owl:NamedIndividual ,
+                                                        :CommodityCode ;
+                                               rdfs:comment "Spinone Italiano"@en ;
+                                               rdfs:label "LIVE_MMLS_DOGS_Spinone_Italiano"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Staffordshire_Bull_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Staffordshire_Bull_Terrier rdf:type owl:NamedIndividual ,
+                                                                  :CommodityCode ;
+                                                         rdfs:comment "Staffordshire Bull Terrier"@en ;
+                                                         rdfs:label "LIVE_MMLS_DOGS_Staffordshire_Bull_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Standard_Schnauzer
+:CommodityCode_LIVE_MMLS_DOGS_Standard_Schnauzer rdf:type owl:NamedIndividual ,
+                                                          :CommodityCode ;
+                                                 rdfs:comment "Standard Schnauzer"@en ;
+                                                 rdfs:label "LIVE_MMLS_DOGS_Standard_Schnauzer"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Sussex_Spaniel
+:CommodityCode_LIVE_MMLS_DOGS_Sussex_Spaniel rdf:type owl:NamedIndividual ,
+                                                      :CommodityCode ;
+                                             rdfs:comment "Sussex Spaniel"@en ;
+                                             rdfs:label "LIVE_MMLS_DOGS_Sussex_Spaniel"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Swedish_Vallhund
+:CommodityCode_LIVE_MMLS_DOGS_Swedish_Vallhund rdf:type owl:NamedIndividual ,
+                                                        :CommodityCode ;
+                                               rdfs:comment "Swedish Vallhund"@en ;
+                                               rdfs:label "LIVE_MMLS_DOGS_Swedish_Vallhund"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Tibetan_Mastiff
+:CommodityCode_LIVE_MMLS_DOGS_Tibetan_Mastiff rdf:type owl:NamedIndividual ,
+                                                       :CommodityCode ;
+                                              rdfs:comment "Tibetan Mastiff"@en ;
+                                              rdfs:label "LIVE_MMLS_DOGS_Tibetan_Mastiff"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Tibetan_Spaniel
+:CommodityCode_LIVE_MMLS_DOGS_Tibetan_Spaniel rdf:type owl:NamedIndividual ,
+                                                       :CommodityCode ;
+                                              rdfs:comment "Tibetan Spaniel"@en ;
+                                              rdfs:label "LIVE_MMLS_DOGS_Tibetan_Spaniel"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Tibetan_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Tibetan_Terrier rdf:type owl:NamedIndividual ,
+                                                       :CommodityCode ;
+                                              rdfs:comment "Tibetan Terrier"@en ;
+                                              rdfs:label "LIVE_MMLS_DOGS_Tibetan_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Tosa_Japanese_Mastiff
+:CommodityCode_LIVE_MMLS_DOGS_Tosa_Japanese_Mastiff rdf:type owl:NamedIndividual ,
+                                                             :CommodityCode ;
+                                                    rdfs:comment "Tosa-Japanese Mastiff"@en ;
+                                                    rdfs:label "LIVE_MMLS_DOGS_Tosa_Japanese_Mastiff"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Toy_Fox_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Toy_Fox_Terrier rdf:type owl:NamedIndividual ,
+                                                       :CommodityCode ;
+                                              rdfs:comment "Toy Fox Terrier"@en ;
+                                              rdfs:label "LIVE_MMLS_DOGS_Toy_Fox_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Treeing_Walker_Coonhound
+:CommodityCode_LIVE_MMLS_DOGS_Treeing_Walker_Coonhound rdf:type owl:NamedIndividual ,
+                                                                :CommodityCode ;
+                                                       rdfs:comment "Treeing Walker Coonhound"@en ;
+                                                       rdfs:label "LIVE_MMLS_DOGS_Treeing_Walker_Coonhound"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Utonagan_Northern_Inuit_Dog
+:CommodityCode_LIVE_MMLS_DOGS_Utonagan_Northern_Inuit_Dog rdf:type owl:NamedIndividual ,
+                                                                   :CommodityCode ;
+                                                          rdfs:comment "Utonagan-Northern Inuit Dog"@en ;
+                                                          rdfs:label "LIVE_MMLS_DOGS_Utonagan_Northern_Inuit_Dog"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Valley_Bulldog
+:CommodityCode_LIVE_MMLS_DOGS_Valley_Bulldog rdf:type owl:NamedIndividual ,
+                                                      :CommodityCode ;
+                                             rdfs:comment "Valley Bulldog"@en ;
+                                             rdfs:label "LIVE_MMLS_DOGS_Valley_Bulldog"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Vizsla
+:CommodityCode_LIVE_MMLS_DOGS_Vizsla rdf:type owl:NamedIndividual ,
+                                              :CommodityCode ;
+                                     rdfs:comment "Vizsla"@en ;
+                                     rdfs:label "LIVE_MMLS_DOGS_Vizsla"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Weimaraner
+:CommodityCode_LIVE_MMLS_DOGS_Weimaraner rdf:type owl:NamedIndividual ,
+                                                  :CommodityCode ;
+                                         rdfs:comment "Weimaraner"@en ;
+                                         rdfs:label "LIVE_MMLS_DOGS_Weimaraner"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Welsh_Springer_Spaniel
+:CommodityCode_LIVE_MMLS_DOGS_Welsh_Springer_Spaniel rdf:type owl:NamedIndividual ,
+                                                              :CommodityCode ;
+                                                     rdfs:comment "Welsh Springer Spaniel"@en ;
+                                                     rdfs:label "LIVE_MMLS_DOGS_Welsh_Springer_Spaniel"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Welsh_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Welsh_Terrier rdf:type owl:NamedIndividual ,
+                                                     :CommodityCode ;
+                                            rdfs:comment "Welsh Terrier"@en ;
+                                            rdfs:label "LIVE_MMLS_DOGS_Welsh_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_West_Highland_White_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_West_Highland_White_Terrier rdf:type owl:NamedIndividual ,
+                                                                   :CommodityCode ;
+                                                          rdfs:comment "West Highland White Terrier"@en ;
+                                                          rdfs:label "LIVE_MMLS_DOGS_West_Highland_White_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Whippet
+:CommodityCode_LIVE_MMLS_DOGS_Whippet rdf:type owl:NamedIndividual ,
+                                               :CommodityCode ;
+                                      rdfs:comment "Whippet"@en ;
+                                      rdfs:label "LIVE_MMLS_DOGS_Whippet"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Wire_Fox_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Wire_Fox_Terrier rdf:type owl:NamedIndividual ,
+                                                        :CommodityCode ;
+                                               rdfs:comment "Wire Fox Terrier"@en ;
+                                               rdfs:label "LIVE_MMLS_DOGS_Wire_Fox_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Wirehaired_Pointing_Griffon
+:CommodityCode_LIVE_MMLS_DOGS_Wirehaired_Pointing_Griffon rdf:type owl:NamedIndividual ,
+                                                                   :CommodityCode ;
+                                                          rdfs:comment "Wirehaired Pointing Griffon"@en ;
+                                                          rdfs:label "LIVE_MMLS_DOGS_Wirehaired_Pointing_Griffon"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Wirehaired_Vizsla
+:CommodityCode_LIVE_MMLS_DOGS_Wirehaired_Vizsla rdf:type owl:NamedIndividual ,
+                                                         :CommodityCode ;
+                                                rdfs:comment "Wirehaired Vizsla"@en ;
+                                                rdfs:label "LIVE_MMLS_DOGS_Wirehaired_Vizsla"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Xoloitzcuintli_Mexican_Hairless_Dog
+:CommodityCode_LIVE_MMLS_DOGS_Xoloitzcuintli_Mexican_Hairless_Dog rdf:type owl:NamedIndividual ,
+                                                                           :CommodityCode ;
+                                                                  rdfs:comment "Xoloitzcuintli-Mexican Hairless Dog"@en ;
+                                                                  rdfs:label "LIVE_MMLS_DOGS_Xoloitzcuintli_Mexican_Hairless_Dog"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Yorkipoo_Yorkshire_Terrier_Poodle_Mix
+:CommodityCode_LIVE_MMLS_DOGS_Yorkipoo_Yorkshire_Terrier_Poodle_Mix rdf:type owl:NamedIndividual ,
+                                                                             :CommodityCode ;
+                                                                    rdfs:comment "Yorkipoo-Yorkshire Terrier Poodle Mix"@en ;
+                                                                    rdfs:label "LIVE_MMLS_DOGS_Yorkipoo_Yorkshire_Terrier_Poodle_Mix"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_DOGS_Yorkshire_Terrier
+:CommodityCode_LIVE_MMLS_DOGS_Yorkshire_Terrier rdf:type owl:NamedIndividual ,
+                                                         :CommodityCode ;
+                                                rdfs:comment "Yorkshire Terrier"@en ;
+                                                rdfs:label "LIVE_MMLS_DOGS_Yorkshire_Terrier"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_FERR
+:CommodityCode_LIVE_MMLS_FERR rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Ferrets"@en ;
+                              rdfs:label "LIVE_MMLS_FERR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_GOAT
+:CommodityCode_LIVE_MMLS_GOAT rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Goats"@en ;
+                              rdfs:label "LIVE_MMLS_GOAT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_HORS
+:CommodityCode_LIVE_MMLS_HORS rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Horses"@en ;
+                              rdfs:label "LIVE_MMLS_HORS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_MNKY
+:CommodityCode_LIVE_MMLS_MNKY rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Monkeys"@en ;
+                              rdfs:label "LIVE_MMLS_MNKY"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_PIGS
+:CommodityCode_LIVE_MMLS_PIGS rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Pigs"@en ;
+                              rdfs:label "LIVE_MMLS_PIGS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_RDNT
+:CommodityCode_LIVE_MMLS_RDNT rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Rodents"@en ;
+                              rdfs:label "LIVE_MMLS_RDNT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_MMLS_SHEP
+:CommodityCode_LIVE_MMLS_SHEP rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Sheep"@en ;
+                              rdfs:label "LIVE_MMLS_SHEP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_REPT
+:CommodityCode_LIVE_REPT rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Reptiles"@en ;
+                         rdfs:label "LIVE_REPT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_VANI
+:CommodityCode_LIVE_VANI rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Venomous animals"@en ;
+                         rdfs:label "LIVE_VANI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_LIVE_ZOOA
+:CommodityCode_LIVE_ZOOA rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Zoo animals"@en ;
+                         rdfs:label "LIVE_ZOOA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_MAIL
+:CommodityCode_MAIL rdf:type owl:NamedIndividual ,
+                             :CommodityCode ;
+                    rdfs:comment "Mail"@en ;
+                    rdfs:label "MAIL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_MART
+:CommodityCode_MART rdf:type owl:NamedIndividual ,
+                             :CommodityCode ;
+                    rdfs:comment "Musical Instruments & Art"@en ;
+                    rdfs:label "MART"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_MART_ART
+:CommodityCode_MART_ART rdf:type owl:NamedIndividual ,
+                                 :CommodityCode ;
+                        rdfs:comment "Art"@en ;
+                        rdfs:label "MART_ART"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_MART_ENGR
+:CommodityCode_MART_ENGR rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Engraving"@en ;
+                         rdfs:label "MART_ENGR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_MART_HAND
+:CommodityCode_MART_HAND rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Handicraft products"@en ;
+                         rdfs:label "MART_HAND"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_MART_MUEQ
+:CommodityCode_MART_MUEQ rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Musical equipment"@en ;
+                         rdfs:label "MART_MUEQ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_MART_MUSI
+:CommodityCode_MART_MUSI rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Musical instruments"@en ;
+                         rdfs:label "MART_MUSI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_MART_PNTG
+:CommodityCode_MART_PNTG rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Painting"@en ;
+                         rdfs:label "MART_PNTG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_MLTY
+:CommodityCode_MLTY rdf:type owl:NamedIndividual ,
+                             :CommodityCode ;
+                    rdfs:comment "Military, Weapons and Ammunition"@en ;
+                    rdfs:label "MLTY"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_MLTY_AMUN
+:CommodityCode_MLTY_AMUN rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Munitions"@en ;
+                         rdfs:label "MLTY_AMUN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_MLTY_MSUP
+:CommodityCode_MLTY_MSUP rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Military supplies"@en ;
+                         rdfs:label "MLTY_MSUP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_MLTY_SPWE
+:CommodityCode_MLTY_SPWE rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Sporting weapons"@en ;
+                         rdfs:label "MLTY_SPWE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_MLTY_WPNS
+:CommodityCode_MLTY_WPNS rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Weapons"@en ;
+                         rdfs:label "MLTY_WPNS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_PHAR
+:CommodityCode_PHAR rdf:type owl:NamedIndividual ,
+                             :CommodityCode ;
+                    rdfs:comment "Pharmaceutical, Medical And Biological"@en ;
+                    rdfs:label "PHAR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_PHAR_BIOP
+:CommodityCode_PHAR_BIOP rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Biological products"@en ;
+                         rdfs:label "PHAR_BIOP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_PHAR_BIOP_BIOC
+:CommodityCode_PHAR_BIOP_BIOC rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Biochemicals"@en ;
+                              rdfs:label "PHAR_BIOP_BIOC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_PHAR_BIOP_HEMO
+:CommodityCode_PHAR_BIOP_HEMO rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Hemoderivatives"@en ;
+                              rdfs:label "PHAR_BIOP_HEMO"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_PHAR_BIOP_HUBL
+:CommodityCode_PHAR_BIOP_HUBL rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Human blood"@en ;
+                              rdfs:label "PHAR_BIOP_HUBL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_PHAR_BIOP_HUSR
+:CommodityCode_PHAR_BIOP_HUSR rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Human serum"@en ;
+                              rdfs:label "PHAR_BIOP_HUSR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_PHAR_BIOP_LHOR
+:CommodityCode_PHAR_BIOP_LHOR rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Live human organs"@en ;
+                              rdfs:label "PHAR_BIOP_LHOR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_PHAR_BIOP_SEME
+:CommodityCode_PHAR_BIOP_SEME rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Semen"@en ;
+                              rdfs:label "PHAR_BIOP_SEME"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_PHAR_BIOP_SMPL
+:CommodityCode_PHAR_BIOP_SMPL rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Samples"@en ;
+                              rdfs:label "PHAR_BIOP_SMPL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_PHAR_MDCN
+:CommodityCode_PHAR_MDCN rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Medicines"@en ;
+                         rdfs:label "PHAR_MDCN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_PHAR_MDCN_ANTB
+:CommodityCode_PHAR_MDCN_ANTB rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Antibiotics and Vitamins"@en ;
+                              rdfs:label "PHAR_MDCN_ANTB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_PHAR_MDCN_VACC
+:CommodityCode_PHAR_MDCN_VACC rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Vaccines"@en ;
+                              rdfs:label "PHAR_MDCN_VACC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_PHAR_MDCN_VETE
+:CommodityCode_PHAR_MDCN_VETE rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Vetenary products"@en ;
+                              rdfs:label "PHAR_MDCN_VETE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_PHAR_MEDI
+:CommodityCode_PHAR_MEDI rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Medical"@en ;
+                         rdfs:label "PHAR_MEDI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_PHAR_PHAR
+:CommodityCode_PHAR_PHAR rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Pharmaceutical products"@en ;
+                         rdfs:label "PHAR_PHAR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_PHAR_PHAR_SUEQ
+:CommodityCode_PHAR_PHAR_SUEQ rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Surgical equipment"@en ;
+                              rdfs:label "PHAR_PHAR_SUEQ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_PRIN
+:CommodityCode_PRIN rdf:type owl:NamedIndividual ,
+                             :CommodityCode ;
+                    rdfs:comment "Printed Matter"@en ;
+                    rdfs:label "PRIN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_PRIN_ADVM
+:CommodityCode_PRIN_ADVM rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Advertising materials"@en ;
+                         rdfs:label "PRIN_ADVM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_PRIN_BOOK
+:CommodityCode_PRIN_BOOK rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Books"@en ;
+                         rdfs:label "PRIN_BOOK"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_PRIN_DOCU
+:CommodityCode_PRIN_DOCU rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Documents and Tickets"@en ;
+                         rdfs:label "PRIN_DOCU"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_PRIN_EDUM
+:CommodityCode_PRIN_EDUM rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Educational materials"@en ;
+                         rdfs:label "PRIN_EDUM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_PRIN_NEWS
+:CommodityCode_PRIN_NEWS rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Newspapers and Magazines"@en ;
+                         rdfs:label "PRIN_NEWS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_PRIN_PPRP
+:CommodityCode_PRIN_PPRP rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Paper products"@en ;
+                         rdfs:label "PRIN_PPRP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_RAWM
+:CommodityCode_RAWM rdf:type owl:NamedIndividual ,
+                             :CommodityCode ;
+                    rdfs:comment "Raw materials (Construction, Metals, Wood, Minerals, Plastic)"@en ;
+                    rdfs:label "RAWM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_RAWM_BLDM
+:CommodityCode_RAWM_BLDM rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Building material"@en ;
+                         rdfs:label "RAWM_BLDM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_RAWM_CLAY
+:CommodityCode_RAWM_CLAY rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Clay products"@en ;
+                         rdfs:label "RAWM_CLAY"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_RAWM_GLAS
+:CommodityCode_RAWM_GLAS rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Glass products"@en ;
+                         rdfs:label "RAWM_GLAS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_RAWM_GRAN
+:CommodityCode_RAWM_GRAN rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Granite slabs"@en ;
+                         rdfs:label "RAWM_GRAN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_RAWM_GUMS
+:CommodityCode_RAWM_GUMS rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Gums-Resines"@en ;
+                         rdfs:label "RAWM_GUMS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_RAWM_MARB
+:CommodityCode_RAWM_MARB rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Marble"@en ;
+                         rdfs:label "RAWM_MARB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_RAWM_METL
+:CommodityCode_RAWM_METL rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Metals"@en ;
+                         rdfs:label "RAWM_METL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_RAWM_METP
+:CommodityCode_RAWM_METP rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Metal products"@en ;
+                         rdfs:label "RAWM_METP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_RAWM_MICA
+:CommodityCode_RAWM_MICA rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Mica products"@en ;
+                         rdfs:label "RAWM_MICA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_RAWM_MINE
+:CommodityCode_RAWM_MINE rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Minerals"@en ;
+                         rdfs:label "RAWM_MINE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_RAWM_MIRR
+:CommodityCode_RAWM_MIRR rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Mirre"@en ;
+                         rdfs:label "RAWM_MIRR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_RAWM_OILS
+:CommodityCode_RAWM_OILS rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Oils"@en ;
+                         rdfs:label "RAWM_OILS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_RAWM_PLST
+:CommodityCode_RAWM_PLST rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Plastic products"@en ;
+                         rdfs:label "RAWM_PLST"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_RAWM_QRTZ
+:CommodityCode_RAWM_QRTZ rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Quartz"@en ;
+                         rdfs:label "RAWM_QRTZ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_RAWM_RUBR
+:CommodityCode_RAWM_RUBR rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Rubber products"@en ;
+                         rdfs:label "RAWM_RUBR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_RAWM_RUBR_RTYR
+:CommodityCode_RAWM_RUBR_RTYR rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Rubber tyres"@en ;
+                              rdfs:label "RAWM_RUBR_RTYR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_RAWM_STNS
+:CommodityCode_RAWM_STNS rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Stones"@en ;
+                         rdfs:label "RAWM_STNS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_RAWM_WOOD
+:CommodityCode_RAWM_WOOD rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Wood products"@en ;
+                         rdfs:label "RAWM_WOOD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_SCIN
+:CommodityCode_SCIN rdf:type owl:NamedIndividual ,
+                             :CommodityCode ;
+                    rdfs:comment "Scientific Instruments"@en ;
+                    rdfs:label "SCIN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_SCIN_DEEQ
+:CommodityCode_SCIN_DEEQ rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Densist equipment"@en ;
+                         rdfs:label "SCIN_DEEQ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_SCIN_DIAG
+:CommodityCode_SCIN_DIAG rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Diagnostics equipment"@en ;
+                         rdfs:label "SCIN_DIAG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_SCIN_HEAR
+:CommodityCode_SCIN_HEAR rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Hearing aids"@en ;
+                         rdfs:label "SCIN_HEAR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_SCIN_LBEQ
+:CommodityCode_SCIN_LBEQ rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Laboratory equipment"@en ;
+                         rdfs:label "SCIN_LBEQ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_SCIN_MEEQ
+:CommodityCode_SCIN_MEEQ rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Medical equipment"@en ;
+                         rdfs:label "SCIN_MEEQ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_SCIN_OPTI
+:CommodityCode_SCIN_OPTI rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Optical instruments"@en ;
+                         rdfs:label "SCIN_OPTI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_SCIN_PRCI
+:CommodityCode_SCIN_PRCI rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Precision instruments"@en ;
+                         rdfs:label "SCIN_PRCI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_TRPH
+:CommodityCode_TRPH rdf:type owl:NamedIndividual ,
+                             :CommodityCode ;
+                    rdfs:comment "Trophies"@en ;
+                    rdfs:label "TRPH"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_TRPH_HTRH
+:CommodityCode_TRPH_HTRH rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Hunting Trophies"@en ;
+                         rdfs:label "TRPH_HTRH"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_TRPH_OTRH
+:CommodityCode_TRPH_OTRH rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Trophies (not hunting)"@en ;
+                         rdfs:label "TRPH_OTRH"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_TXTL
+:CommodityCode_TXTL rdf:type owl:NamedIndividual ,
+                             :CommodityCode ;
+                    rdfs:comment "Textiles, Leather and Furs"@en ;
+                    rdfs:label "TXTL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_TXTL_FREW
+:CommodityCode_TXTL_FREW rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Furs excluding Wear"@en ;
+                         rdfs:label "TXTL_FREW"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_TXTL_FUR
+:CommodityCode_TXTL_FUR rdf:type owl:NamedIndividual ,
+                                 :CommodityCode ;
+                        rdfs:comment "Fur"@en ;
+                        rdfs:label "TXTL_FUR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_TXTL_FURW
+:CommodityCode_TXTL_FURW rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Furs wear"@en ;
+                         rdfs:label "TXTL_FURW"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_TXTL_LEXW
+:CommodityCode_TXTL_LEXW rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Leather excluding Wear"@en ;
+                         rdfs:label "TXTL_LEXW"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_TXTL_LTHR
+:CommodityCode_TXTL_LTHR rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Leather"@en ;
+                         rdfs:label "TXTL_LTHR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_TXTL_LTWR
+:CommodityCode_TXTL_LTWR rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Leather wear"@en ;
+                         rdfs:label "TXTL_LTWR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_TXTL_TXEW
+:CommodityCode_TXTL_TXEW rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Textiles excluding Wear"@en ;
+                         rdfs:label "TXTL_TXEW"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_TXTL_TXEW_CARP
+:CommodityCode_TXTL_TXEW_CARP rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Carpets and Rugs"@en ;
+                              rdfs:label "TXTL_TXEW_CARP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_TXTL_TXEW_CURT
+:CommodityCode_TXTL_TXEW_CURT rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Curtains and Drapery"@en ;
+                              rdfs:label "TXTL_TXEW_CURT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_TXTL_TXEW_FABR
+:CommodityCode_TXTL_TXEW_FABR rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Textile fabric"@en ;
+                              rdfs:label "TXTL_TXEW_FABR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_TXTL_TXEW_FURN
+:CommodityCode_TXTL_TXEW_FURN rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Textile furnish"@en ;
+                              rdfs:label "TXTL_TXEW_FURN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_TXTL_TXEW_HIDE
+:CommodityCode_TXTL_TXEW_HIDE rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Hide"@en ;
+                              rdfs:label "TXTL_TXEW_HIDE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_TXTL_TXEW_NDLE
+:CommodityCode_TXTL_TXEW_NDLE rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Needlework"@en ;
+                              rdfs:label "TXTL_TXEW_NDLE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_TXTL_TXEW_SKIN
+:CommodityCode_TXTL_TXEW_SKIN rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Skins"@en ;
+                              rdfs:label "TXTL_TXEW_SKIN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_TXTL_TXEW_TRLS
+:CommodityCode_TXTL_TXEW_TRLS rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Textile rolls"@en ;
+                              rdfs:label "TXTL_TXEW_TRLS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_TXTL_TXEW_YARN
+:CommodityCode_TXTL_TXEW_YARN rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Yarns"@en ;
+                              rdfs:label "TXTL_TXEW_YARN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_TXTL_TXLW
+:CommodityCode_TXTL_TXLW rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Textile wear"@en ;
+                         rdfs:label "TXTL_TXLW"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_TXTL_TXLW_APPR
+:CommodityCode_TXTL_TXLW_APPR rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Wearing appareil"@en ;
+                              rdfs:label "TXTL_TXLW_APPR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_TXTL_TXLW_CLTH
+:CommodityCode_TXTL_TXLW_CLTH rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Clothing"@en ;
+                              rdfs:label "TXTL_TXLW_CLTH"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_TXTL_TXLW_FOOT
+:CommodityCode_TXTL_TXLW_FOOT rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Footwear"@en ;
+                              rdfs:label "TXTL_TXLW_FOOT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_TXTL_TXLW_GARM
+:CommodityCode_TXTL_TXLW_GARM rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Garments"@en ;
+                              rdfs:label "TXTL_TXLW_GARM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_TXTL_TXTL
+:CommodityCode_TXTL_TXTL rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Textiles"@en ;
+                         rdfs:label "TXTL_TXTL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VALU
+:CommodityCode_VALU rdf:type owl:NamedIndividual ,
+                             :CommodityCode ;
+                    rdfs:comment "Valuables"@en ;
+                    rdfs:label "VALU"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VALU_BANK
+:CommodityCode_VALU_BANK rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Bank notes and Coins"@en ;
+                         rdfs:label "VALU_BANK"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VALU_DIAM
+:CommodityCode_VALU_DIAM rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Diamonds"@en ;
+                         rdfs:label "VALU_DIAM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VALU_GOLD
+:CommodityCode_VALU_GOLD rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Gold"@en ;
+                         rdfs:label "VALU_GOLD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VALU_JWRY
+:CommodityCode_VALU_JWRY rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Jewelery"@en ;
+                         rdfs:label "VALU_JWRY"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VALU_PLAT
+:CommodityCode_VALU_PLAT rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Platinum"@en ;
+                         rdfs:label "VALU_PLAT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VALU_PMET
+:CommodityCode_VALU_PMET rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Precious metal"@en ;
+                         rdfs:label "VALU_PMET"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VALU_PSTN
+:CommodityCode_VALU_PSTN rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Precious stones"@en ;
+                         rdfs:label "VALU_PSTN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VALU_SLVR
+:CommodityCode_VALU_SLVR rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Silver"@en ;
+                         rdfs:label "VALU_SLVR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VALU_WTCH
+:CommodityCode_VALU_WTCH rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Watches"@en ;
+                         rdfs:label "VALU_WTCH"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL
+:CommodityCode_VHCL rdf:type owl:NamedIndividual ,
+                             :CommodityCode ;
+                    rdfs:comment "Vehicle / Machinary, Parts, Spares"@en ;
+                    rdfs:label "VHCL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_AIRC
+:CommodityCode_VHCL_AIRC rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Aircraft"@en ;
+                         rdfs:label "VHCL_AIRC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_AIRC_AACC
+:CommodityCode_VHCL_AIRC_AACC rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Aircraft accessories"@en ;
+                              rdfs:label "VHCL_AIRC_AACC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_AIRC_AENG
+:CommodityCode_VHCL_AIRC_AENG rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Aicraft engines"@en ;
+                              rdfs:label "VHCL_AIRC_AENG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_AIRC_AMTR
+:CommodityCode_VHCL_AIRC_AMTR rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Aircraft motors"@en ;
+                              rdfs:label "VHCL_AIRC_AMTR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_AIRC_APRT
+:CommodityCode_VHCL_AIRC_APRT rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Aircraft parts"@en ;
+                              rdfs:label "VHCL_AIRC_APRT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_AIRC_ASUP
+:CommodityCode_VHCL_AIRC_ASUP rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Aircraft supplies"@en ;
+                              rdfs:label "VHCL_AIRC_ASUP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_AIRC_AWHL
+:CommodityCode_VHCL_AIRC_AWHL rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Aircraft wheels"@en ;
+                              rdfs:label "VHCL_AIRC_AWHL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_AIRC_HELI
+:CommodityCode_VHCL_AIRC_HELI rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Helicopter"@en ;
+                              rdfs:label "VHCL_AIRC_HELI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_AIRC_HPRT
+:CommodityCode_VHCL_AIRC_HPRT rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Helicopter parts"@en ;
+                              rdfs:label "VHCL_AIRC_HPRT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_MACH
+:CommodityCode_VHCL_MACH rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Machinery and Tools"@en ;
+                         rdfs:label "VHCL_MACH"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_MACH_COIL
+:CommodityCode_VHCL_MACH_COIL rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Cable coil"@en ;
+                              rdfs:label "VHCL_MACH_COIL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_MACH_COMP
+:CommodityCode_VHCL_MACH_COMP rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Comperssors"@en ;
+                              rdfs:label "VHCL_MACH_COMP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_MACH_HRDW
+:CommodityCode_VHCL_MACH_HRDW rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Hardware and Equipment"@en ;
+                              rdfs:label "VHCL_MACH_HRDW"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_MACH_MECH
+:CommodityCode_VHCL_MACH_MECH rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Mechanic products"@en ;
+                              rdfs:label "VHCL_MACH_MECH"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_MACH_MTSP
+:CommodityCode_VHCL_MACH_MTSP rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Machinery supplies and Parts"@en ;
+                              rdfs:label "VHCL_MACH_MTSP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_MACH_OILD
+:CommodityCode_VHCL_MACH_OILD rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Oil drilling equipment"@en ;
+                              rdfs:label "VHCL_MACH_OILD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_MACH_PART
+:CommodityCode_VHCL_MACH_PART rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Spare parts"@en ;
+                              rdfs:label "VHCL_MACH_PART"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_MACH_PUEQ
+:CommodityCode_VHCL_MACH_PUEQ rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Pumping equipment"@en ;
+                              rdfs:label "VHCL_MACH_PUEQ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_SHIP
+:CommodityCode_VHCL_SHIP rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Ships"@en ;
+                         rdfs:label "VHCL_SHIP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_SHIP_SENG
+:CommodityCode_VHCL_SHIP_SENG rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Engines and Turbines"@en ;
+                              rdfs:label "VHCL_SHIP_SENG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_SHIP_SMTR
+:CommodityCode_VHCL_SHIP_SMTR rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Motor and Generator"@en ;
+                              rdfs:label "VHCL_SHIP_SMTR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_SHIP_SPAR
+:CommodityCode_VHCL_SHIP_SPAR rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Ship parts"@en ;
+                              rdfs:label "VHCL_SHIP_SPAR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_SHIP_SSPA
+:CommodityCode_VHCL_SHIP_SSPA rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Ship spares"@en ;
+                              rdfs:label "VHCL_SHIP_SSPA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_SVCL
+:CommodityCode_VHCL_SVCL rdf:type owl:NamedIndividual ,
+                                  :CommodityCode ;
+                         rdfs:comment "Surface vehicles"@en ;
+                         rdfs:label "VHCL_SVCL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_SVCL_AUTO
+:CommodityCode_VHCL_SVCL_AUTO rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Automobiles"@en ;
+                              rdfs:label "VHCL_SVCL_AUTO"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_SVCL_BICY
+:CommodityCode_VHCL_SVCL_BICY rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Bicycles"@en ;
+                              rdfs:label "VHCL_SVCL_BICY"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_SVCL_CRTA
+:CommodityCode_VHCL_SVCL_CRTA rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Cartainer"@en ;
+                              rdfs:label "VHCL_SVCL_CRTA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_SVCL_MOTO
+:CommodityCode_VHCL_SVCL_MOTO rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Motorcycles"@en ;
+                              rdfs:label "VHCL_SVCL_MOTO"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_SVCL_PENDING
+:CommodityCode_VHCL_SVCL_PENDING rdf:type owl:NamedIndividual ,
+                                          :CommodityCode ;
+                                 rdfs:comment "Automobile parts"@en ;
+                                 rdfs:label "VHCL_SVCL_PENDING"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode_VHCL_SVCL_TIRE
+:CommodityCode_VHCL_SVCL_TIRE rdf:type owl:NamedIndividual ,
+                                       :CommodityCode ;
+                              rdfs:comment "Tires"@en ;
+                              rdfs:label "VHCL_SVCL_TIRE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_AED
+:CurrencyCode_AED rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "UAE Dirham"@en ;
+                  rdfs:label "AED"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_AFN
+:CurrencyCode_AFN rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Afghani"@en ;
+                  rdfs:label "AFN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_ALL
+:CurrencyCode_ALL rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Albanian Lek"@en ;
+                  rdfs:label "ALL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_AMD
+:CurrencyCode_AMD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Armenian Dram"@en ;
+                  rdfs:label "AMD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_ANG
+:CurrencyCode_ANG rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Netherlands Antillean Guilder"@en ;
+                  rdfs:label "ANG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_AOA
+:CurrencyCode_AOA rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Kwanza"@en ;
+                  rdfs:label "AOA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_ARS
+:CurrencyCode_ARS rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Argentine Peso"@en ;
+                  rdfs:label "ARS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_AUD
+:CurrencyCode_AUD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Australian Dollar"@en ;
+                  rdfs:label "AUD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_AWG
+:CurrencyCode_AWG rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Aruban Florin"@en ;
+                  rdfs:label "AWG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_AZN
+:CurrencyCode_AZN rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Azerbaijanian Manat"@en ;
+                  rdfs:label "AZN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_BAM
+:CurrencyCode_BAM rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Convertible Mark"@en ;
+                  rdfs:label "BAM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_BBD
+:CurrencyCode_BBD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Barbados Dollar"@en ;
+                  rdfs:label "BBD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_BDT
+:CurrencyCode_BDT rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Bangladeshi Taka"@en ;
+                  rdfs:label "BDT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_BGN
+:CurrencyCode_BGN rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Bulgarian Lev"@en ;
+                  rdfs:label "BGN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_BHD
+:CurrencyCode_BHD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Bahraini Dinar"@en ;
+                  rdfs:label "BHD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_BIF
+:CurrencyCode_BIF rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Burundi Franc"@en ;
+                  rdfs:label "BIF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_BMD
+:CurrencyCode_BMD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Bermudian Dollar"@en ;
+                  rdfs:label "BMD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_BND
+:CurrencyCode_BND rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Brunei Dollar"@en ;
+                  rdfs:label "BND"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_BOB
+:CurrencyCode_BOB rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Boliviano"@en ;
+                  rdfs:label "BOB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_BRL
+:CurrencyCode_BRL rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Brazilian Real"@en ;
+                  rdfs:label "BRL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_BSD
+:CurrencyCode_BSD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Bahamian Dollar"@en ;
+                  rdfs:label "BSD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_BTN
+:CurrencyCode_BTN rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Bhutanese Ngultrum"@en ;
+                  rdfs:label "BTN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_BWP
+:CurrencyCode_BWP rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Botswana Pula"@en ;
+                  rdfs:label "BWP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_BYR
+:CurrencyCode_BYR rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Belarussian Ruble"@en ;
+                  rdfs:label "BYR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_BZD
+:CurrencyCode_BZD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Belize Dollar"@en ;
+                  rdfs:label "BZD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_CAD
+:CurrencyCode_CAD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Canadian Dollar"@en ;
+                  rdfs:label "CAD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_CDF
+:CurrencyCode_CDF rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Congolese Franc"@en ;
+                  rdfs:label "CDF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_CHF
+:CurrencyCode_CHF rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Swiss Franc"@en ;
+                  rdfs:label "CHF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_CLF
+:CurrencyCode_CLF rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Unidades de Fomento"@en ;
+                  rdfs:label "CLF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_CLP
+:CurrencyCode_CLP rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Chilean Peso"@en ;
+                  rdfs:label "CLP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_CNH
+:CurrencyCode_CNH rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "CNH"@en ;
+                  rdfs:label "CNH"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_CNX
+:CurrencyCode_CNX rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "CNX"@en ;
+                  rdfs:label "CNX"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_CNY
+:CurrencyCode_CNY rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Yuan Renminbi"@en ;
+                  rdfs:label "CNY"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_COP
+:CurrencyCode_COP rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Colombian Peso"@en ;
+                  rdfs:label "COP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_CRC
+:CurrencyCode_CRC rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Costa Rican Colon"@en ;
+                  rdfs:label "CRC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_CUP
+:CurrencyCode_CUP rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Cuban Peso"@en ;
+                  rdfs:label "CUP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_CVE
+:CurrencyCode_CVE rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Cape Verde Escudo"@en ;
+                  rdfs:label "CVE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_CZK
+:CurrencyCode_CZK rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Czech Koruna"@en ;
+                  rdfs:label "CZK"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_DJF
+:CurrencyCode_DJF rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Djibouti Franc"@en ;
+                  rdfs:label "DJF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_DKK
+:CurrencyCode_DKK rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Danish Krone"@en ;
+                  rdfs:label "DKK"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_DOP
+:CurrencyCode_DOP rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Dominican Peso"@en ;
+                  rdfs:label "DOP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_DZD
+:CurrencyCode_DZD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Algerian Dinar"@en ;
+                  rdfs:label "DZD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_EGP
+:CurrencyCode_EGP rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Egyptian Pound"@en ;
+                  rdfs:label "EGP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_ESA
+:CurrencyCode_ESA rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "ESA"@en ;
+                  rdfs:label "ESA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_ETB
+:CurrencyCode_ETB rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Ethiopian Birr"@en ;
+                  rdfs:label "ETB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_EUR
+:CurrencyCode_EUR rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Euro"@en ;
+                  rdfs:label "EUR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_FJD
+:CurrencyCode_FJD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Fiji Dollar"@en ;
+                  rdfs:label "FJD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_FKP
+:CurrencyCode_FKP rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Falkland Islands Pound"@en ;
+                  rdfs:label "FKP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_GBP
+:CurrencyCode_GBP rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Pound Sterling"@en ;
+                  rdfs:label "GBP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_GEL
+:CurrencyCode_GEL rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Lari"@en ;
+                  rdfs:label "GEL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_GHS
+:CurrencyCode_GHS rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Ghana Cedi"@en ;
+                  rdfs:label "GHS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_GIP
+:CurrencyCode_GIP rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Gibraltar Pound"@en ;
+                  rdfs:label "GIP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_GMD
+:CurrencyCode_GMD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Dalasi"@en ;
+                  rdfs:label "GMD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_GNF
+:CurrencyCode_GNF rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Guinea Franc"@en ;
+                  rdfs:label "GNF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_GTQ
+:CurrencyCode_GTQ rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Quetzal"@en ;
+                  rdfs:label "GTQ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_GYD
+:CurrencyCode_GYD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Guyana Dollar"@en ;
+                  rdfs:label "GYD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_HKD
+:CurrencyCode_HKD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Hong Kong Dollar"@en ;
+                  rdfs:label "HKD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_HNL
+:CurrencyCode_HNL rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Lempira"@en ;
+                  rdfs:label "HNL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_HRK
+:CurrencyCode_HRK rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Croatian Kuna"@en ;
+                  rdfs:label "HRK"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_HTG
+:CurrencyCode_HTG rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Gourde"@en ;
+                  rdfs:label "HTG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_HUF
+:CurrencyCode_HUF rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Forint"@en ;
+                  rdfs:label "HUF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_IDR
+:CurrencyCode_IDR rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Rupiah"@en ;
+                  rdfs:label "IDR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_ILS
+:CurrencyCode_ILS rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "New Israeli Sheqel"@en ;
+                  rdfs:label "ILS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_INR
+:CurrencyCode_INR rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Indian Rupee"@en ;
+                  rdfs:label "INR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_IQD
+:CurrencyCode_IQD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Iraqi Dinar"@en ;
+                  rdfs:label "IQD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_ISK
+:CurrencyCode_ISK rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Iceland Krona"@en ;
+                  rdfs:label "ISK"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_JMD
+:CurrencyCode_JMD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Jamaican Dollar"@en ;
+                  rdfs:label "JMD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_JOD
+:CurrencyCode_JOD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Jordanian Dinar"@en ;
+                  rdfs:label "JOD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_JPY
+:CurrencyCode_JPY rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Yen"@en ;
+                  rdfs:label "JPY"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_KES
+:CurrencyCode_KES rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Kenyan Shilling"@en ;
+                  rdfs:label "KES"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_KGS
+:CurrencyCode_KGS rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Kyrgyzstan Soma"@en ;
+                  rdfs:label "KGS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_KHR
+:CurrencyCode_KHR rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Riel"@en ;
+                  rdfs:label "KHR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_KMF
+:CurrencyCode_KMF rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Comoro Franc"@en ;
+                  rdfs:label "KMF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_KRW
+:CurrencyCode_KRW rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Won"@en ;
+                  rdfs:label "KRW"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_KWD
+:CurrencyCode_KWD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Kuwaiti Dinar"@en ;
+                  rdfs:label "KWD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_KYD
+:CurrencyCode_KYD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Cayman Islands Dollar"@en ;
+                  rdfs:label "KYD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_KZT
+:CurrencyCode_KZT rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Tenge"@en ;
+                  rdfs:label "KZT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_LAK
+:CurrencyCode_LAK rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Kip"@en ;
+                  rdfs:label "LAK"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_LBP
+:CurrencyCode_LBP rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Lebanese Pound"@en ;
+                  rdfs:label "LBP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_LKR
+:CurrencyCode_LKR rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Sri Lanka Rupee"@en ;
+                  rdfs:label "LKR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_LRD
+:CurrencyCode_LRD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Liberian Dollar"@en ;
+                  rdfs:label "LRD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_LSL
+:CurrencyCode_LSL rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Loti"@en ;
+                  rdfs:label "LSL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_LYD
+:CurrencyCode_LYD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Libyan Dinar"@en ;
+                  rdfs:label "LYD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_MAD
+:CurrencyCode_MAD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Moroccan Dirham"@en ;
+                  rdfs:label "MAD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_MDL
+:CurrencyCode_MDL rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Moldovan Leu"@en ;
+                  rdfs:label "MDL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_MGA
+:CurrencyCode_MGA rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Malagasy Ariary"@en ;
+                  rdfs:label "MGA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_MKD
+:CurrencyCode_MKD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Denar"@en ;
+                  rdfs:label "MKD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_MMK
+:CurrencyCode_MMK rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Kyat"@en ;
+                  rdfs:label "MMK"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_MNT
+:CurrencyCode_MNT rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Tugrik"@en ;
+                  rdfs:label "MNT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_MOP
+:CurrencyCode_MOP rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Pataca"@en ;
+                  rdfs:label "MOP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_MRO
+:CurrencyCode_MRO rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Ouguiya"@en ;
+                  rdfs:label "MRO"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_MRU
+:CurrencyCode_MRU rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Ouguiya"@en ;
+                  rdfs:label "MRU"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_MUR
+:CurrencyCode_MUR rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Mauritius Rupee"@en ;
+                  rdfs:label "MUR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_MVR
+:CurrencyCode_MVR rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Rufiyaa"@en ;
+                  rdfs:label "MVR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_MWK
+:CurrencyCode_MWK rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Kwacha"@en ;
+                  rdfs:label "MWK"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_MXN
+:CurrencyCode_MXN rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Mexican Peso"@en ;
+                  rdfs:label "MXN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_MYR
+:CurrencyCode_MYR rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Malaysian Ringgit"@en ;
+                  rdfs:label "MYR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_MZN
+:CurrencyCode_MZN rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Mozambique Metical"@en ;
+                  rdfs:label "MZN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_NAD
+:CurrencyCode_NAD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Namibia Dollar"@en ;
+                  rdfs:label "NAD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_NGN
+:CurrencyCode_NGN rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Naira"@en ;
+                  rdfs:label "NGN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_NIO
+:CurrencyCode_NIO rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Cordoba Oro"@en ;
+                  rdfs:label "NIO"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_NOK
+:CurrencyCode_NOK rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Norwegian Krone"@en ;
+                  rdfs:label "NOK"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_NPR
+:CurrencyCode_NPR rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Nepalese Rupee"@en ;
+                  rdfs:label "NPR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_NZD
+:CurrencyCode_NZD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "New Zealand Dollar"@en ;
+                  rdfs:label "NZD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_OMR
+:CurrencyCode_OMR rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Rial Omani"@en ;
+                  rdfs:label "OMR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_PAB
+:CurrencyCode_PAB rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Balboa"@en ;
+                  rdfs:label "PAB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_PEN
+:CurrencyCode_PEN rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Nuevo Sol"@en ;
+                  rdfs:label "PEN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_PGK
+:CurrencyCode_PGK rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Kina"@en ;
+                  rdfs:label "PGK"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_PHP
+:CurrencyCode_PHP rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Philippine Peso"@en ;
+                  rdfs:label "PHP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_PKR
+:CurrencyCode_PKR rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Pakistan Rupee"@en ;
+                  rdfs:label "PKR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_PLN
+:CurrencyCode_PLN rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Zloty"@en ;
+                  rdfs:label "PLN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_PYG
+:CurrencyCode_PYG rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Guarani"@en ;
+                  rdfs:label "PYG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_QAR
+:CurrencyCode_QAR rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Qatari Rial"@en ;
+                  rdfs:label "QAR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_RON
+:CurrencyCode_RON rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "New Romanian Leu"@en ;
+                  rdfs:label "RON"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_RSD
+:CurrencyCode_RSD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Serbian Dinar"@en ;
+                  rdfs:label "RSD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_RUB
+:CurrencyCode_RUB rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Russian Ruble"@en ;
+                  rdfs:label "RUB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_RWF
+:CurrencyCode_RWF rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Rwanda Franc"@en ;
+                  rdfs:label "RWF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_SAR
+:CurrencyCode_SAR rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Saudi Riyal"@en ;
+                  rdfs:label "SAR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_SBD
+:CurrencyCode_SBD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Solomon Islands dollar"@en ;
+                  rdfs:label "SBD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_SCR
+:CurrencyCode_SCR rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Seychelles Rupee"@en ;
+                  rdfs:label "SCR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_SDG
+:CurrencyCode_SDG rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Sudanese Pound"@en ;
+                  rdfs:label "SDG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_SEK
+:CurrencyCode_SEK rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Swedish Krona"@en ;
+                  rdfs:label "SEK"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_SGD
+:CurrencyCode_SGD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Singapore Dollar"@en ;
+                  rdfs:label "SGD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_SHP
+:CurrencyCode_SHP rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Saint Helena Pound"@en ;
+                  rdfs:label "SHP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_SLL
+:CurrencyCode_SLL rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Leone"@en ;
+                  rdfs:label "SLL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_SOS
+:CurrencyCode_SOS rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Somali Shilling"@en ;
+                  rdfs:label "SOS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_SRD
+:CurrencyCode_SRD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Surinam Dollar"@en ;
+                  rdfs:label "SRD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_SSP
+:CurrencyCode_SSP rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "South Sudanese Pound"@en ;
+                  rdfs:label "SSP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_STD
+:CurrencyCode_STD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Dobra"@en ;
+                  rdfs:label "STD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_STN
+:CurrencyCode_STN rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Dobra"@en ;
+                  rdfs:label "STN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_SVC
+:CurrencyCode_SVC rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "El Salvador Colon"@en ;
+                  rdfs:label "SVC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_SZL
+:CurrencyCode_SZL rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Lilangeni"@en ;
+                  rdfs:label "SZL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_THB
+:CurrencyCode_THB rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Baht"@en ;
+                  rdfs:label "THB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_TJS
+:CurrencyCode_TJS rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Somoni"@en ;
+                  rdfs:label "TJS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_TMT
+:CurrencyCode_TMT rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Turkmenistan New Manat"@en ;
+                  rdfs:label "TMT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_TND
+:CurrencyCode_TND rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Tunisian Dinar"@en ;
+                  rdfs:label "TND"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_TOP
+:CurrencyCode_TOP rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "PaÃ¢â‚¬â„¢anga"@en ;
+                  rdfs:label "TOP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_TRY
+:CurrencyCode_TRY rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Turkish Lira"@en ;
+                  rdfs:label "TRY"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_TTD
+:CurrencyCode_TTD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Trinidad and Tobago Dollar"@en ;
+                  rdfs:label "TTD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_TWD
+:CurrencyCode_TWD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "New Taiwan Dollar"@en ;
+                  rdfs:label "TWD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_TZS
+:CurrencyCode_TZS rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Tanzanian Shilling"@en ;
+                  rdfs:label "TZS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_UAH
+:CurrencyCode_UAH rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Hryvnia"@en ;
+                  rdfs:label "UAH"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_UGX
+:CurrencyCode_UGX rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Uganda Shilling"@en ;
+                  rdfs:label "UGX"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_USD
+:CurrencyCode_USD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "US Dollar"@en ;
+                  rdfs:label "USD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_UYU
+:CurrencyCode_UYU rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Peso Uruguayo"@en ;
+                  rdfs:label "UYU"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_UZS
+:CurrencyCode_UZS rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Uzbekistan Sum"@en ;
+                  rdfs:label "UZS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_VEF
+:CurrencyCode_VEF rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Bolivar"@en ;
+                  rdfs:label "VEF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_VES
+:CurrencyCode_VES rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Bolívar Soberano"@en ;
+                  rdfs:label "VES"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_VND
+:CurrencyCode_VND rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Dong"@en ;
+                  rdfs:label "VND"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_VUV
+:CurrencyCode_VUV rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Vatu"@en ;
+                  rdfs:label "VUV"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_WST
+:CurrencyCode_WST rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Tala"@en ;
+                  rdfs:label "WST"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_XAF
+:CurrencyCode_XAF rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "CFA Franc BEAC"@en ;
+                  rdfs:label "XAF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_XCD
+:CurrencyCode_XCD rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "East Caribbean Dollar"@en ;
+                  rdfs:label "XCD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_XOF
+:CurrencyCode_XOF rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "CFA Franc BCEAO"@en ;
+                  rdfs:label "XOF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_XPF
+:CurrencyCode_XPF rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "CFP Franc"@en ;
+                  rdfs:label "XPF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_YER
+:CurrencyCode_YER rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Yemeni Rial"@en ;
+                  rdfs:label "YER"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_ZAR
+:CurrencyCode_ZAR rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Rand"@en ;
+                  rdfs:label "ZAR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode_ZMW
+:CurrencyCode_ZMW rdf:type owl:NamedIndividual ,
+                           :CurrencyCode ;
+                  rdfs:comment "Zambian Kwacha"@en ;
+                  rdfs:label "ZMW"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_CAO
+:DangerousGoodsCode_CAO rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Cargo Aircraft Only"@en ;
+                        rdfs:label "CAO"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_EBI
+:DangerousGoodsCode_EBI rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Lithium ion batteries excepted as per Section II of PI 965"@en ;
+                        rdfs:label "EBI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_EBM
+:DangerousGoodsCode_EBM rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Lithium metal batteries excepted as per Section II of PI 968"@en ;
+                        rdfs:label "EBM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_ELI
+:DangerousGoodsCode_ELI rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Lithium Ion Batteries otherwise excepted from the IATA DGR"@en ;
+                        rdfs:label "ELI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_ELM
+:DangerousGoodsCode_ELM rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Lithium Metal Batteries otherwise excepted from the IATA DGR"@en ;
+                        rdfs:label "ELM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_ICE
+:DangerousGoodsCode_ICE rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Dry Ice"@en ;
+                        rdfs:label "ICE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_MAG
+:DangerousGoodsCode_MAG rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Magnetized Material"@en ;
+                        rdfs:label "MAG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_RBI
+:DangerousGoodsCode_RBI rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Fully regulated lithium ion batteries (Class 9, UN 3480) as per Section IA and IB of PI 965"@en ;
+                        rdfs:label "RBI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_RBM
+:DangerousGoodsCode_RBM rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Fully regulated lithium metal batteries (Class 9, UN 3090) as per Section IA and IB of PI 968"@en ;
+                        rdfs:label "RBM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_RCL
+:DangerousGoodsCode_RCL rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Cryogenic Liquids"@en ;
+                        rdfs:label "RCL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_RCM
+:DangerousGoodsCode_RCM rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Corrosive"@en ;
+                        rdfs:label "RCM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_RCX
+:DangerousGoodsCode_RCX rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Explosives 1.3C"@en ;
+                        rdfs:label "RCX"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_REX
+:DangerousGoodsCode_REX rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "To be reserved for normally forbidden Explosives, Divisions 1.1, 1.2, 1.3, 1.4F, 1.5 and 1.6"@en ;
+                        rdfs:label "REX"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_RFG
+:DangerousGoodsCode_RFG rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Flammable Gas"@en ;
+                        rdfs:label "RFG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_RFL
+:DangerousGoodsCode_RFL rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Flammable Liquid"@en ;
+                        rdfs:label "RFL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_RFS
+:DangerousGoodsCode_RFS rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Flammable Solid"@en ;
+                        rdfs:label "RFS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_RFW
+:DangerousGoodsCode_RFW rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Dangerous When Wet"@en ;
+                        rdfs:label "RFW"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_RGX
+:DangerousGoodsCode_RGX rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Explosives 1.3G"@en ;
+                        rdfs:label "RGX"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_RIS
+:DangerousGoodsCode_RIS rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Infectious Substance"@en ;
+                        rdfs:label "RIS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_RLI
+:DangerousGoodsCode_RLI rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Fully Regulated Lithium Ion Batteries (Class 9)"@en ;
+                        rdfs:label "RLI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_RLM
+:DangerousGoodsCode_RLM rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Fully Regulated Lithium Metal Batteries (Class 9)"@en ;
+                        rdfs:label "RLM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_RMD
+:DangerousGoodsCode_RMD rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Miscellaneous Dangerous Goods"@en ;
+                        rdfs:label "RMD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_RNG
+:DangerousGoodsCode_RNG rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Non-Flammable Non-Toxic Gas"@en ;
+                        rdfs:label "RNG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_ROP
+:DangerousGoodsCode_ROP rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Organic Peroxide"@en ;
+                        rdfs:label "ROP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_ROX
+:DangerousGoodsCode_ROX rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Oxidizer"@en ;
+                        rdfs:label "ROX"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_RPB
+:DangerousGoodsCode_RPB rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Toxic Substance"@en ;
+                        rdfs:label "RPB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_RPG
+:DangerousGoodsCode_RPG rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Toxic Gas"@en ;
+                        rdfs:label "RPG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_RRW
+:DangerousGoodsCode_RRW rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Radioactive Material Category I-White"@en ;
+                        rdfs:label "RRW"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_RRY
+:DangerousGoodsCode_RRY rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Radioactive Material Categories II-Yellow and III-Yellow"@en ;
+                        rdfs:label "RRY"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_RSB
+:DangerousGoodsCode_RSB rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Polymeric Beads"@en ;
+                        rdfs:label "RSB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_RSC
+:DangerousGoodsCode_RSC rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Spontaneously Combustible"@en ;
+                        rdfs:label "RSC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_RXB
+:DangerousGoodsCode_RXB rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Explosives 1.4B"@en ;
+                        rdfs:label "RXB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_RXC
+:DangerousGoodsCode_RXC rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Explosives 1.4C"@en ;
+                        rdfs:label "RXC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_RXD
+:DangerousGoodsCode_RXD rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Explosives 1.4D"@en ;
+                        rdfs:label "RXD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_RXE
+:DangerousGoodsCode_RXE rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Explosives 1.4E"@en ;
+                        rdfs:label "RXE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_RXG
+:DangerousGoodsCode_RXG rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Explosives 1.4G"@en ;
+                        rdfs:label "RXG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode_RXS
+:DangerousGoodsCode_RXS rdf:type owl:NamedIndividual ,
+                                 :DangerousGoodsCode ,
+                                 :SpecialHandlingCode ;
+                        rdfs:comment "Explosives 1.4S"@en ;
+                        rdfs:label "RXS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DemurrageCode_BCC
+:DemurrageCode_BCC rdf:type owl:NamedIndividual ,
+                            :DemurrageCode ;
+                   rdfs:comment "BCC"@en ;
+                   rdfs:label "BCC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DemurrageCode_HHH
+:DemurrageCode_HHH rdf:type owl:NamedIndividual ,
+                            :DemurrageCode ;
+                   rdfs:comment "HHH"@en ;
+                   rdfs:label "HHH"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DemurrageCode_XXX
+:DemurrageCode_XXX rdf:type owl:NamedIndividual ,
+                            :DemurrageCode ;
+                   rdfs:comment "XXX"@en ;
+                   rdfs:label "XXX"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DemurrageCode_ZZZ
+:DemurrageCode_ZZZ rdf:type owl:NamedIndividual ,
+                            :DemurrageCode ;
+                   rdfs:comment "ZZZ"@en ;
+                   rdfs:label "ZZZ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#EntitlementCode_A
+:EntitlementCode_A rdf:type owl:NamedIndividual ,
+                            :EntitlementCode ;
+                   rdfs:comment "Other Charges due Agent"@en ;
+                   rdfs:label "A"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#EntitlementCode_C
+:EntitlementCode_C rdf:type owl:NamedIndividual ,
+                            :EntitlementCode ;
+                   rdfs:comment "Other Charges due Carrier"@en ;
+                   rdfs:label "C"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ExplosiveCompatibilityGroupCode_A
+:ExplosiveCompatibilityGroupCode_A rdf:type owl:NamedIndividual ,
+                                            :ExplosiveCompatibilityGroupCode ;
+                                   rdfs:comment "Primary explosive substance (Hazard Division 1.1)"@en ;
+                                   rdfs:label "A"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ExplosiveCompatibilityGroupCode_B
+:ExplosiveCompatibilityGroupCode_B rdf:type owl:NamedIndividual ,
+                                            :ExplosiveCompatibilityGroupCode ;
+                                   rdfs:comment "Article containing a primary explosive substance and not containing two or more effective protective features. Some articles, such as detonators for blasting, detonator assemblies for blasting and primers, cap type, are included, even though they do not contain primary explosives (Hazard Division 1.1; 1.2; 1.4)"@en ;
+                                   rdfs:label "B"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ExplosiveCompatibilityGroupCode_C
+:ExplosiveCompatibilityGroupCode_C rdf:type owl:NamedIndividual ,
+                                            :ExplosiveCompatibilityGroupCode ;
+                                   rdfs:comment "Propellant explosive substance or other deflagrating explosive substance or article containing such explosive substance (Hazard Division 1.1; 1.2; 1.3; 1.4)"@en ;
+                                   rdfs:label "C"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ExplosiveCompatibilityGroupCode_D
+:ExplosiveCompatibilityGroupCode_D rdf:type owl:NamedIndividual ,
+                                            :ExplosiveCompatibilityGroupCode ;
+                                   rdfs:comment "Secondary detonating explosive substance or black powder or article containing a secondary detonating explosive substance, in each case without means of initiation and without a propelling charge or article containing a primary explosive substance and containing two or more effective protective features (Hazard Division 1.1; 1.2; 1.4; 1.5)"@en ;
+                                   rdfs:label "D"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ExplosiveCompatibilityGroupCode_E
+:ExplosiveCompatibilityGroupCode_E rdf:type owl:NamedIndividual ,
+                                            :ExplosiveCompatibilityGroupCode ;
+                                   rdfs:comment "Article containing a secondary detonating explosive substance, without means of initiation, with a propelling charge (other than one containing a flammable liquid or gel or hypergolic liquids) or without a propelling charge (Hazard Division 1.1; 1.2; 1.4)"@en ;
+                                   rdfs:label "E"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ExplosiveCompatibilityGroupCode_F
+:ExplosiveCompatibilityGroupCode_F rdf:type owl:NamedIndividual ,
+                                            :ExplosiveCompatibilityGroupCode ;
+                                   rdfs:comment "Article containing a secondary detonating explosive substance, with its own means of initiation, with a propelling charge (other than one containing a flammable liquid or gel or hypergolic liquids) or without a propelling charge (Hazard Division 1.1; 1.2; 1.3; 1.4)"@en ;
+                                   rdfs:label "F"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ExplosiveCompatibilityGroupCode_G
+:ExplosiveCompatibilityGroupCode_G rdf:type owl:NamedIndividual ,
+                                            :ExplosiveCompatibilityGroupCode ;
+                                   rdfs:comment "Pyrotechnic substance, or article containing a pyrotechnic substance, or article containing both an explosive substance and an illuminating, incendiary, tear- or smoke-producing substance (other than a water -activated article or one containing white phosphorus, phosphide, a pyrophoric substance, a flammable liquid or get or hypergolic liquids) (Hazard Division 1.1; 1.2; 1.3; 1.4)"@en ;
+                                   rdfs:label "G"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ExplosiveCompatibilityGroupCode_H
+:ExplosiveCompatibilityGroupCode_H rdf:type owl:NamedIndividual ,
+                                            :ExplosiveCompatibilityGroupCode ;
+                                   rdfs:comment "Article containing both an explosive substance and white phosphorus (Hazard Division 1.2; 1.3)"@en ;
+                                   rdfs:label "H"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ExplosiveCompatibilityGroupCode_J
+:ExplosiveCompatibilityGroupCode_J rdf:type owl:NamedIndividual ,
+                                            :ExplosiveCompatibilityGroupCode ;
+                                   rdfs:comment "Article containing both an explosive substance and a flammable liquid or gel (Hazard Division 1.1; 1.2; 1.3)"@en ;
+                                   rdfs:label "J"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ExplosiveCompatibilityGroupCode_K
+:ExplosiveCompatibilityGroupCode_K rdf:type owl:NamedIndividual ,
+                                            :ExplosiveCompatibilityGroupCode ;
+                                   rdfs:comment "Article containing both an explosive substance and a toxic chemical agent (Hazard Division 1.1; 1.3)"@en ;
+                                   rdfs:label "K"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ExplosiveCompatibilityGroupCode_L
+:ExplosiveCompatibilityGroupCode_L rdf:type owl:NamedIndividual ,
+                                            :ExplosiveCompatibilityGroupCode ;
+                                   rdfs:comment "Explosive article or substance containing an explosive substance and presenting a special risk (e.g. due to water activation, or the presence of hypergolic liquids, phosphides or a pyrophoric substance) and needing isolation of each type (Hazard Division 1.2; 1.2; 1.3)"@en ;
+                                   rdfs:label "L"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ExplosiveCompatibilityGroupCode_N
+:ExplosiveCompatibilityGroupCode_N rdf:type owl:NamedIndividual ,
+                                            :ExplosiveCompatibilityGroupCode ;
+                                   rdfs:comment "Article containing only extremely insensitive detonating substances (Hazard Division 1.6)"@en ;
+                                   rdfs:label "N"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ExplosiveCompatibilityGroupCode_S
+:ExplosiveCompatibilityGroupCode_S rdf:type owl:NamedIndividual ,
+                                            :ExplosiveCompatibilityGroupCode ;
+                                   rdfs:comment "Article or substance so packed or designed that any hazardous effects arising from accidental functioning are confined within the package unless the package has been degraded by fire, in which case all blast or projection effects are limited to the extent that they do not significantly hinder or prohibit fire fighting or other emergency response efforts in the immediate vicinity of the package (Hazard Division 1.4)"@en ;
+                                   rdfs:label "S"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#GoodsTypeCode_I
+:GoodsTypeCode_I rdf:type owl:NamedIndividual ,
+                          :GoodsTypeCode ;
+                 rdfs:comment "Species included in Appendix I of CITES"@en ;
+                 rdfs:label "I"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#GoodsTypeCode_II
+:GoodsTypeCode_II rdf:type owl:NamedIndividual ,
+                           :GoodsTypeCode ;
+                  rdfs:comment "Species included in Appendix II of CITES"@en ;
+                  rdfs:label "II"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#GoodsTypeCode_III
+:GoodsTypeCode_III rdf:type owl:NamedIndividual ,
+                            :GoodsTypeCode ;
+                   rdfs:comment "Species included in Appendix III of CITES"@en ;
+                   rdfs:label "III"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#GoodsTypeExtensionCode_A
+:GoodsTypeExtensionCode_A rdf:type owl:NamedIndividual ,
+                                   :GoodsTypeExtensionCode ;
+                          rdfs:comment "Artificially propagated plant"@en ;
+                          rdfs:label "A"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#GoodsTypeExtensionCode_C
+:GoodsTypeExtensionCode_C rdf:type owl:NamedIndividual ,
+                                   :GoodsTypeExtensionCode ;
+                          rdfs:comment "Bred in captivity"@en ;
+                          rdfs:label "C"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#GoodsTypeExtensionCode_D
+:GoodsTypeExtensionCode_D rdf:type owl:NamedIndividual ,
+                                   :GoodsTypeExtensionCode ;
+                          rdfs:comment "Captive-bred animal or artificially propagated plant"@en ;
+                          rdfs:label "D"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#GoodsTypeExtensionCode_F
+:GoodsTypeExtensionCode_F rdf:type owl:NamedIndividual ,
+                                   :GoodsTypeExtensionCode ;
+                          rdfs:comment "Born in captivity"@en ;
+                          rdfs:label "F"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#GoodsTypeExtensionCode_I
+:GoodsTypeExtensionCode_I rdf:type owl:NamedIndividual ,
+                                   :GoodsTypeExtensionCode ;
+                          rdfs:comment "Confiscated or seized"@en ;
+                          rdfs:label "I"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#GoodsTypeExtensionCode_O
+:GoodsTypeExtensionCode_O rdf:type owl:NamedIndividual ,
+                                   :GoodsTypeExtensionCode ;
+                          rdfs:comment "Pre-Convention"@en ;
+                          rdfs:label "O"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#GoodsTypeExtensionCode_R
+:GoodsTypeExtensionCode_R rdf:type owl:NamedIndividual ,
+                                   :GoodsTypeExtensionCode ;
+                          rdfs:comment "Ranched animal"@en ;
+                          rdfs:label "R"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#GoodsTypeExtensionCode_U
+:GoodsTypeExtensionCode_U rdf:type owl:NamedIndividual ,
+                                   :GoodsTypeExtensionCode ;
+                          rdfs:comment "Unknown"@en ;
+                          rdfs:label "U"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#GoodsTypeExtensionCode_W
+:GoodsTypeExtensionCode_W rdf:type owl:NamedIndividual ,
+                                   :GoodsTypeExtensionCode ;
+                          rdfs:comment "Wild"@en ;
+                          rdfs:label "W"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#GoodsTypeExtensionCode_X
+:GoodsTypeExtensionCode_X rdf:type owl:NamedIndividual ,
+                                   :GoodsTypeExtensionCode ;
+                          rdfs:comment "Marine environment"@en ;
+                          rdfs:label "X"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_BQL
+:MeasurementUnitCode_BQL rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ;
+                         rdfs:comment "Becquerel"@en ;
+                         rdfs:label "BQL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_CEL
+:MeasurementUnitCode_CEL rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ,
+                                  :TemperatureUnitCode ;
+                         rdfs:comment "Degree Celsius"@en ;
+                         rdfs:label "CEL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_CGM
+:MeasurementUnitCode_CGM rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ;
+                         rdfs:comment "Centigram"@en ;
+                         rdfs:label "CGM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_CLT
+:MeasurementUnitCode_CLT rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ;
+                         rdfs:comment "Centilitre"@en ;
+                         rdfs:label "CLT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_CMQ
+:MeasurementUnitCode_CMQ rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ,
+                                  :VolumeUnitCode ;
+                         rdfs:comment "Cubic Centimetre"@en ;
+                         rdfs:label "CMQ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_CMT
+:MeasurementUnitCode_CMT rdf:type owl:NamedIndividual ,
+                                  :DimensionsUnitCode ,
+                                  :MeasurementUnitCode ;
+                         rdfs:comment "Centimetre"@en ;
+                         rdfs:label "CMT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_CUR
+:MeasurementUnitCode_CUR rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ;
+                         rdfs:comment "Curie"@en ;
+                         rdfs:label "CUR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_DLT
+:MeasurementUnitCode_DLT rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ;
+                         rdfs:comment "Decilitre"@en ;
+                         rdfs:label "DLT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_DMT
+:MeasurementUnitCode_DMT rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ;
+                         rdfs:comment "Decimetre"@en ;
+                         rdfs:label "DMT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_FAH
+:MeasurementUnitCode_FAH rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ,
+                                  :TemperatureUnitCode ;
+                         rdfs:comment "Degree Fahrenheit"@en ;
+                         rdfs:label "FAH"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_FOT
+:MeasurementUnitCode_FOT rdf:type owl:NamedIndividual ,
+                                  :DimensionsUnitCode ,
+                                  :MeasurementUnitCode ;
+                         rdfs:comment "Foot"@en ;
+                         rdfs:label "FOT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_FTQ
+:MeasurementUnitCode_FTQ rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ,
+                                  :VolumeUnitCode ;
+                         rdfs:comment "Cubic Foot"@en ;
+                         rdfs:label "FTQ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_GIA
+:MeasurementUnitCode_GIA rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ;
+                         rdfs:comment "Gill (11.8294 CM3)"@en ;
+                         rdfs:label "GIA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_GII
+:MeasurementUnitCode_GII rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ;
+                         rdfs:comment "Gigabecquerel GBQ Gill (0.142065 DM3)"@en ;
+                         rdfs:label "GII"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_GLI
+:MeasurementUnitCode_GLI rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ;
+                         rdfs:comment "Gallon (4.546092 DM3)"@en ;
+                         rdfs:label "GLI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_GLL
+:MeasurementUnitCode_GLL rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ,
+                                  :VolumeUnitCode ;
+                         rdfs:comment "Liquid Gallon (3.78541 DM3)"@en ;
+                         rdfs:label "GLL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_GRM
+:MeasurementUnitCode_GRM rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ;
+                         rdfs:comment "Gram"@en ;
+                         rdfs:label "GRM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_INH
+:MeasurementUnitCode_INH rdf:type owl:NamedIndividual ,
+                                  :DimensionsUnitCode ,
+                                  :MeasurementUnitCode ;
+                         rdfs:comment "Inch"@en ;
+                         rdfs:label "INH"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_INQ
+:MeasurementUnitCode_INQ rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ,
+                                  :VolumeUnitCode ;
+                         rdfs:comment "Cubic Inch"@en ;
+                         rdfs:label "INQ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_KBQ
+:MeasurementUnitCode_KBQ rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ;
+                         rdfs:comment "Kilobecquerel"@en ;
+                         rdfs:label "KBQ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_KEL
+:MeasurementUnitCode_KEL rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ,
+                                  :TemperatureUnitCode ;
+                         rdfs:comment "Kelvin"@en ;
+                         rdfs:label "KEL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_KGM
+:MeasurementUnitCode_KGM rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ,
+                                  :WeightUnitCode ;
+                         rdfs:comment "Kilogram"@en ;
+                         rdfs:label "KGM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_LBR
+:MeasurementUnitCode_LBR rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ,
+                                  :WeightUnitCode ;
+                         rdfs:comment "Pound UK, US (0.45359237 KGM)"@en ;
+                         rdfs:label "LBR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_LTR
+:MeasurementUnitCode_LTR rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ,
+                                  :VolumeUnitCode ;
+                         rdfs:comment "Litre (1 DM3)"@en ;
+                         rdfs:label "LTR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_MBQ
+:MeasurementUnitCode_MBQ rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ;
+                         rdfs:comment "Megabecquerel"@en ;
+                         rdfs:label "MBQ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_MGM
+:MeasurementUnitCode_MGM rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ;
+                         rdfs:comment "Milligram"@en ;
+                         rdfs:label "MGM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_MLT
+:MeasurementUnitCode_MLT rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ;
+                         rdfs:comment "Millilitre"@en ;
+                         rdfs:label "MLT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_MMT
+:MeasurementUnitCode_MMT rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ;
+                         rdfs:comment "Millimetre"@en ;
+                         rdfs:label "MMT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_MTQ
+:MeasurementUnitCode_MTQ rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ,
+                                  :VolumeUnitCode ;
+                         rdfs:comment "Cubic Metre"@en ;
+                         rdfs:label "MTQ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_MTR
+:MeasurementUnitCode_MTR rdf:type owl:NamedIndividual ,
+                                  :DimensionsUnitCode ,
+                                  :MeasurementUnitCode ;
+                         rdfs:comment "Metre"@en ;
+                         rdfs:label "MTR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_NDA
+:MeasurementUnitCode_NDA rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ;
+                         rdfs:comment "No Dimensions Available"@en ;
+                         rdfs:label "NDA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_ONZ
+:MeasurementUnitCode_ONZ rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ,
+                                  :WeightUnitCode ;
+                         rdfs:comment "Ounce UK, US (28.949523 GRM)"@en ;
+                         rdfs:label "ONZ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_OZA
+:MeasurementUnitCode_OZA rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ;
+                         rdfs:comment "Fluid Ounce (29.5795 CM3)"@en ;
+                         rdfs:label "OZA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_OZI
+:MeasurementUnitCode_OZI rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ;
+                         rdfs:comment "Fluid Ounce (28.413 CM3)"@en ;
+                         rdfs:label "OZI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_PTI
+:MeasurementUnitCode_PTI rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ;
+                         rdfs:comment "Pint (0.568262 DM3)"@en ;
+                         rdfs:label "PTI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_PTL
+:MeasurementUnitCode_PTL rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ;
+                         rdfs:comment "Liquid Pint (0.473176 DM3)"@en ;
+                         rdfs:label "PTL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_QTI
+:MeasurementUnitCode_QTI rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ;
+                         rdfs:comment "Quart (1.136523 DM3)"@en ;
+                         rdfs:label "QTI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_QTL
+:MeasurementUnitCode_QTL rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ;
+                         rdfs:comment "Liquid Quart (0.946353 DM3)"@en ;
+                         rdfs:label "QTL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_TBQ
+:MeasurementUnitCode_TBQ rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ;
+                         rdfs:comment "Terabecquerel"@en ;
+                         rdfs:label "TBQ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode_YRD
+:MeasurementUnitCode_YRD rdf:type owl:NamedIndividual ,
+                                  :MeasurementUnitCode ;
+                         rdfs:comment "Yard (0.9144 MTR)"@en ;
+                         rdfs:label "YRD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_AA
+:MovementIndicator_AA rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Actual Arrival (Touchdown)"@en ;
+                      rdfs:label "AA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_AB
+:MovementIndicator_AB rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Actual On-block"@en ;
+                      rdfs:label "AB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_AD
+:MovementIndicator_AD rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Actual Departure (Take off)"@en ;
+                      rdfs:label "AD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_AG
+:MovementIndicator_AG rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Actual gate in time - Relates to gate passing of trucks"@en ;
+                      rdfs:label "AG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_AH
+:MovementIndicator_AH rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Actual gate out time - Relates t gate passing of trucks"@en ;
+                      rdfs:label "AH"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_AK
+:MovementIndicator_AK rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Actual end of unloading time"@en ;
+                      rdfs:label "AK"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_AL
+:MovementIndicator_AL rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Actual end of loading time"@en ;
+                      rdfs:label "AL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_AO
+:MovementIndicator_AO rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Actual Off-block"@en ;
+                      rdfs:label "AO"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_AR
+:MovementIndicator_AR rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Actual driver reporting time"@en ;
+                      rdfs:label "AR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_CN
+:MovementIndicator_CN rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Cancellation"@en ;
+                      rdfs:label "CN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_DA
+:MovementIndicator_DA rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Doc Arrival"@en ;
+                      rdfs:label "DA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_DL
+:MovementIndicator_DL rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Delayed"@en ;
+                      rdfs:label "DL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_DV
+:MovementIndicator_DV rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Diversion"@en ;
+                      rdfs:label "DV"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_EA
+:MovementIndicator_EA rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Estimated Arrival (Touchdown)"@en ;
+                      rdfs:label "EA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_EB
+:MovementIndicator_EB rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Estimated On-block"@en ;
+                      rdfs:label "EB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_ED
+:MovementIndicator_ED rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Estimated Departure (Take off)"@en ;
+                      rdfs:label "ED"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_EK
+:MovementIndicator_EK rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Estimated end of unloading time"@en ;
+                      rdfs:label "EK"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_EL
+:MovementIndicator_EL rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Estimated end of loading time"@en ;
+                      rdfs:label "EL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_EO
+:MovementIndicator_EO rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Estimated Off-block"@en ;
+                      rdfs:label "EO"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_ER
+:MovementIndicator_ER rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Estimated driver reporting time"@en ;
+                      rdfs:label "ER"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_FR
+:MovementIndicator_FR rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Force Return"@en ;
+                      rdfs:label "FR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_NI
+:MovementIndicator_NI rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Next Information"@en ;
+                      rdfs:label "NI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_PA
+:MovementIndicator_PA rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Pre-announcement of the truck - to enable to pre-announce data (driver name, license plates, etc.) to GHA at departure station"@en ;
+                      rdfs:label "PA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_RR
+:MovementIndicator_RR rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Return to RAMP"@en ;
+                      rdfs:label "RR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_SA
+:MovementIndicator_SA rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Scheduled Arrival"@en ;
+                      rdfs:label "SA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_SD
+:MovementIndicator_SD rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Scheduled Departure"@en ;
+                      rdfs:label "SD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_SK
+:MovementIndicator_SK rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Scheduled end of unloading time"@en ;
+                      rdfs:label "SK"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_SL
+:MovementIndicator_SL rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Scheduled end of loading time"@en ;
+                      rdfs:label "SL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_SR
+:MovementIndicator_SR rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Scheduled latest driver reporting time for collection and/or delivery"@en ;
+                      rdfs:label "SR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator_SS
+:MovementIndicator_SS rdf:type owl:NamedIndividual ,
+                               :MovementIndicator ;
+                      rdfs:comment "Scheduled earliest driver reporting time for collection and/or delivery"@en ;
+                      rdfs:label "SS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_AC
+:OtherChargeCode_AC rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Animal Container"@en ;
+                    rdfs:label "AC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_AS
+:OtherChargeCode_AS rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Assembly Service Fee"@en ;
+                    rdfs:label "AS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_AT
+:OtherChargeCode_AT rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Attendant"@en ;
+                    rdfs:label "AT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_AW
+:OtherChargeCode_AW rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Air Waybill Fee"@en ;
+                    rdfs:label "AW"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_BA
+:OtherChargeCode_BA rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Advances and/or guarantees"@en ;
+                    rdfs:label "BA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_BB
+:OtherChargeCode_BB rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Appraisal Service"@en ;
+                    rdfs:label "BB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_BC
+:OtherChargeCode_BC rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "AWB Copy"@en ;
+                    rdfs:label "BC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_BE
+:OtherChargeCode_BE rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Collection of funds"@en ;
+                    rdfs:label "BE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_BF
+:OtherChargeCode_BF rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Copies of documents"@en ;
+                    rdfs:label "BF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_BH
+:OtherChargeCode_BH rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Messenger service"@en ;
+                    rdfs:label "BH"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_BI
+:OtherChargeCode_BI rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Import/export documents processing"@en ;
+                    rdfs:label "BI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_BL
+:OtherChargeCode_BL rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Blacklist Certificate"@en ;
+                    rdfs:label "BL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_BM
+:OtherChargeCode_BM rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Withdrawal of shipment after clearance"@en ;
+                    rdfs:label "BM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_BR
+:OtherChargeCode_BR rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Bank Release"@en ;
+                    rdfs:label "BR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_CA
+:OtherChargeCode_CA rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Bonding"@en ;
+                    rdfs:label "CA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_CB
+:OtherChargeCode_CB rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Completion/preparation of documents"@en ;
+                    rdfs:label "CB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_CC
+:OtherChargeCode_CC rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Manual data entry for customs purposes"@en ;
+                    rdfs:label "CC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_CD
+:OtherChargeCode_CD rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Clearance and Handling — Destination"@en ;
+                    rdfs:label "CD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_CE
+:OtherChargeCode_CE rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Export/Import warrant"@en ;
+                    rdfs:label "CE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_CF
+:OtherChargeCode_CF rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Inventory and/or inspection"@en ;
+                    rdfs:label "CF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_CG
+:OtherChargeCode_CG rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Electronic processing or transmission of data for customs purposes"@en ;
+                    rdfs:label "CG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_CH
+:OtherChargeCode_CH rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Clearance and Handling — Origin"@en ;
+                    rdfs:label "CH"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_CI
+:OtherChargeCode_CI rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Overtime and Other Customs Imposed Charges"@en ;
+                    rdfs:label "CI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_CJ
+:OtherChargeCode_CJ rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Removal (carrier warehouse to warehouse)"@en ;
+                    rdfs:label "CJ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_DB
+:OtherChargeCode_DB rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Disbursement Fee"@en ;
+                    rdfs:label "DB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_DC
+:OtherChargeCode_DC rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Certificate of Origin"@en ;
+                    rdfs:label "DC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_DD
+:OtherChargeCode_DD rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Preparation of Cargo manifest"@en ;
+                    rdfs:label "DD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_DF
+:OtherChargeCode_DF rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Distribution Service Fee"@en ;
+                    rdfs:label "DF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_DG
+:OtherChargeCode_DG rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "AWB Cancellation"@en ;
+                    rdfs:label "DG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_DH
+:OtherChargeCode_DH rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "AWB Charges Correction Advice"@en ;
+                    rdfs:label "DH"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_DI
+:OtherChargeCode_DI rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "AWB Re-waybilling"@en ;
+                    rdfs:label "DI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_DJ
+:OtherChargeCode_DJ rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Proof of delivery (documentation)"@en ;
+                    rdfs:label "DJ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_DK
+:OtherChargeCode_DK rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Release order"@en ;
+                    rdfs:label "DK"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_DV
+:OtherChargeCode_DV rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Veterinary and/or Phytosanitary purposes"@en ;
+                    rdfs:label "DV"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_EA
+:OtherChargeCode_EA rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Handling (Express)"@en ;
+                    rdfs:label "EA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_FA
+:OtherChargeCode_FA rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Airport arrival"@en ;
+                    rdfs:label "FA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_FB
+:OtherChargeCode_FB rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Domestic shipments"@en ;
+                    rdfs:label "FB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_FC
+:OtherChargeCode_FC rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Charges Collect Fee"@en ;
+                    rdfs:label "FC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_FD
+:OtherChargeCode_FD rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Priority"@en ;
+                    rdfs:label "FD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_FE
+:OtherChargeCode_FE rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "General (Handling)"@en ;
+                    rdfs:label "FE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_FF
+:OtherChargeCode_FF rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Loading/unloading"@en ;
+                    rdfs:label "FF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_FI
+:OtherChargeCode_FI rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Weighing"@en ;
+                    rdfs:label "FI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_GA
+:OtherChargeCode_GA rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Diplomatic consignment"@en ;
+                    rdfs:label "GA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_GT
+:OtherChargeCode_GT rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Government Tax"@en ;
+                    rdfs:label "GT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_HB
+:OtherChargeCode_HB rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Mortuary"@en ;
+                    rdfs:label "HB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_HR
+:OtherChargeCode_HR rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Human Remains"@en ;
+                    rdfs:label "HR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_IA
+:OtherChargeCode_IA rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Very important cargo (VIC)"@en ;
+                    rdfs:label "IA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_IN
+:OtherChargeCode_IN rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Insurance Premium"@en ;
+                    rdfs:label "IN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_JA
+:OtherChargeCode_JA rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Clearance, General"@en ;
+                    rdfs:label "JA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_KA
+:OtherChargeCode_KA rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Handling (Heavy/Bulky cargo)"@en ;
+                    rdfs:label "KA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_KB
+:OtherChargeCode_KB rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Loading/unloading equipment (forklift etc.)"@en ;
+                    rdfs:label "KB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_LA
+:OtherChargeCode_LA rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Live Animals"@en ;
+                    rdfs:label "LA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_LC
+:OtherChargeCode_LC rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Cleaning"@en ;
+                    rdfs:label "LC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_LE
+:OtherChargeCode_LE rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Hotel"@en ;
+                    rdfs:label "LE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_LF
+:OtherChargeCode_LF rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Quarantine"@en ;
+                    rdfs:label "LF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_LG
+:OtherChargeCode_LG rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Veterinary inspection"@en ;
+                    rdfs:label "LG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_LH
+:OtherChargeCode_LH rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Storage (Live animals)"@en ;
+                    rdfs:label "LH"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_LI
+:OtherChargeCode_LI rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Cleaning of stalls/pens"@en ;
+                    rdfs:label "LI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_LJ
+:OtherChargeCode_LJ rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Rental of Stalls/pens"@en ;
+                    rdfs:label "LJ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_MA
+:OtherChargeCode_MA rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Miscellaneous — Due Agent (see Note 1)"@en ;
+                    rdfs:label "MA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_MB
+:OtherChargeCode_MB rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Miscellaneous — Unassigned (see Note 2)"@en ;
+                    rdfs:label "MB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_MC
+:OtherChargeCode_MC rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Miscellaneous — Due Carrier (see Note 3)"@en ;
+                    rdfs:label "MC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_MD
+:OtherChargeCode_MD rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Miscellaneous — Due Last Carrier"@en ;
+                    rdfs:label "MD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_ME
+:OtherChargeCode_ME rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Miscellaneous — Due Last Carrier"@en ;
+                    rdfs:label "ME"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_MF
+:OtherChargeCode_MF rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Miscellaneous — Due Last Carrier"@en ;
+                    rdfs:label "MF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_MG
+:OtherChargeCode_MG rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Miscellaneous — Due Last Carrier"@en ;
+                    rdfs:label "MG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_MH
+:OtherChargeCode_MH rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Miscellaneous — Due Last Carrier"@en ;
+                    rdfs:label "MH"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_MI
+:OtherChargeCode_MI rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Miscellaneous — Due Last Carrier"@en ;
+                    rdfs:label "MI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_MJ
+:OtherChargeCode_MJ rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Miscellaneous — Due Last Carrier"@en ;
+                    rdfs:label "MJ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_MK
+:OtherChargeCode_MK rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Miscellaneous — Due Last Carrier"@en ;
+                    rdfs:label "MK"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_ML
+:OtherChargeCode_ML rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Miscellaneous — Due Last Carrier"@en ;
+                    rdfs:label "ML"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_MM
+:OtherChargeCode_MM rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Miscellaneous — Due Last Carrier"@en ;
+                    rdfs:label "MM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_MN
+:OtherChargeCode_MN rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Miscellaneous — Due Last Carrier"@en ;
+                    rdfs:label "MN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_MO
+:OtherChargeCode_MO rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Miscellaneous — Due Issuing Carrier"@en ;
+                    rdfs:label "MO"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_MP
+:OtherChargeCode_MP rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Miscellaneous — Due Issuing Carrier"@en ;
+                    rdfs:label "MP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_MQ
+:OtherChargeCode_MQ rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Miscellaneous — Due Issuing Carrier"@en ;
+                    rdfs:label "MQ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_MR
+:OtherChargeCode_MR rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Miscellaneous — Due Issuing Carrier"@en ;
+                    rdfs:label "MR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_MS
+:OtherChargeCode_MS rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Miscellaneous — Due Issuing Carrier"@en ;
+                    rdfs:label "MS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_MT
+:OtherChargeCode_MT rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Miscellaneous — Due Issuing Carrier"@en ;
+                    rdfs:label "MT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_MU
+:OtherChargeCode_MU rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Miscellaneous — Due Issuing Carrier"@en ;
+                    rdfs:label "MU"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_MV
+:OtherChargeCode_MV rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Miscellaneous — Due Issuing Carrier"@en ;
+                    rdfs:label "MV"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_MW
+:OtherChargeCode_MW rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Miscellaneous — Due Issuing Carrier"@en ;
+                    rdfs:label "MW"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_MX
+:OtherChargeCode_MX rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Miscellaneous — Due Issuing Carrier"@en ;
+                    rdfs:label "MX"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_MY
+:OtherChargeCode_MY rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Fuel Surcharge — Due Issuing Carrier"@en ;
+                    rdfs:label "MY"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_MZ
+:OtherChargeCode_MZ rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Miscellaneous — Due Issuing Carrier"@en ;
+                    rdfs:label "MZ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_NS
+:OtherChargeCode_NS rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Navigation Surcharge — Due Issuing Carrier"@en ;
+                    rdfs:label "NS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_PA
+:OtherChargeCode_PA rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Handling (Perishables)"@en ;
+                    rdfs:label "PA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_PB
+:OtherChargeCode_PB rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Cool/Cold room, freezer (Perishables)"@en ;
+                    rdfs:label "PB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_PK
+:OtherChargeCode_PK rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Packing/Repacking"@en ;
+                    rdfs:label "PK"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_PU
+:OtherChargeCode_PU rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Pick-Up"@en ;
+                    rdfs:label "PU"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_RA
+:OtherChargeCode_RA rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Dangerous Goods Fee"@en ;
+                    rdfs:label "RA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_RB
+:OtherChargeCode_RB rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Rejection"@en ;
+                    rdfs:label "RB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_RC
+:OtherChargeCode_RC rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Referral of Charge"@en ;
+                    rdfs:label "RC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_RD
+:OtherChargeCode_RD rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Radio-active room"@en ;
+                    rdfs:label "RD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_RF
+:OtherChargeCode_RF rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Remit Following Collection Fee"@en ;
+                    rdfs:label "RF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_SA
+:OtherChargeCode_SA rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Delivery"@en ;
+                    rdfs:label "SA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_SB
+:OtherChargeCode_SB rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Delivery notification"@en ;
+                    rdfs:label "SB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_SC
+:OtherChargeCode_SC rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Security Charge"@en ;
+                    rdfs:label "SC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_SD
+:OtherChargeCode_SD rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Surface Charge — Destination"@en ;
+                    rdfs:label "SD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_SE
+:OtherChargeCode_SE rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Proof of delivery (pickup and delivery)"@en ;
+                    rdfs:label "SE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_SF
+:OtherChargeCode_SF rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Delivery Order"@en ;
+                    rdfs:label "SF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_SI
+:OtherChargeCode_SI rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Stop in Transit"@en ;
+                    rdfs:label "SI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_SO
+:OtherChargeCode_SO rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Storage — Origin"@en ;
+                    rdfs:label "SO"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_SP
+:OtherChargeCode_SP rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Separate Early Release"@en ;
+                    rdfs:label "SP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_SR
+:OtherChargeCode_SR rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Storage — Destination"@en ;
+                    rdfs:label "SR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_SS
+:OtherChargeCode_SS rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Signature Service"@en ;
+                    rdfs:label "SS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_ST
+:OtherChargeCode_ST rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "State Sales Tax"@en ;
+                    rdfs:label "ST"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_SU
+:OtherChargeCode_SU rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Surface Charge — Origin"@en ;
+                    rdfs:label "SU"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_TA
+:OtherChargeCode_TA rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Postal Tax"@en ;
+                    rdfs:label "TA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_TB
+:OtherChargeCode_TB rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Sales Tax"@en ;
+                    rdfs:label "TB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_TC
+:OtherChargeCode_TC rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Stamp Tax"@en ;
+                    rdfs:label "TC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_TD
+:OtherChargeCode_TD rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "State Tax"@en ;
+                    rdfs:label "TD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_TE
+:OtherChargeCode_TE rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Statistical Tax"@en ;
+                    rdfs:label "TE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_TI
+:OtherChargeCode_TI rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Value Added Tax (For Import only)"@en ;
+                    rdfs:label "TI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_TR
+:OtherChargeCode_TR rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Transit"@en ;
+                    rdfs:label "TR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_TV
+:OtherChargeCode_TV rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Value Added Tax (General or for Export)"@en ;
+                    rdfs:label "TV"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_TX
+:OtherChargeCode_TX rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "General Taxes"@en ;
+                    rdfs:label "TX"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_UB
+:OtherChargeCode_UB rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Disassembly"@en ;
+                    rdfs:label "UB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_UC
+:OtherChargeCode_UC rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Adjusting of improperly loaded ULD"@en ;
+                    rdfs:label "UC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_UD
+:OtherChargeCode_UD rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Demurrage"@en ;
+                    rdfs:label "UD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_UE
+:OtherChargeCode_UE rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Leasing"@en ;
+                    rdfs:label "UE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_UF
+:OtherChargeCode_UF rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Recontouring"@en ;
+                    rdfs:label "UF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_UG
+:OtherChargeCode_UG rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Unloading (Unit Load Device)"@en ;
+                    rdfs:label "UG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_UH
+:OtherChargeCode_UH rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Handling (Unit Load Device)"@en ;
+                    rdfs:label "UH"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_VA
+:OtherChargeCode_VA rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Handling (Valuable Cargo)"@en ;
+                    rdfs:label "VA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_VB
+:OtherChargeCode_VB rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Security (armed guard/escort) handling"@en ;
+                    rdfs:label "VB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_VC
+:OtherChargeCode_VC rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Strongroom"@en ;
+                    rdfs:label "VC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_WA
+:OtherChargeCode_WA rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Handling (Vulnerable cargo)"@en ;
+                    rdfs:label "WA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_XB
+:OtherChargeCode_XB rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Security (Surcharge/premiums)"@en ;
+                    rdfs:label "XB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_XC
+:OtherChargeCode_XC rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Time"@en ;
+                    rdfs:label "XC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_XD
+:OtherChargeCode_XD rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "War risk"@en ;
+                    rdfs:label "XD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_XE
+:OtherChargeCode_XE rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Weight"@en ;
+                    rdfs:label "XE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_ZA
+:OtherChargeCode_ZA rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Re-warehousing"@en ;
+                    rdfs:label "ZA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_ZB
+:OtherChargeCode_ZB rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "General (Storage)"@en ;
+                    rdfs:label "ZB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode_ZC
+:OtherChargeCode_ZC rdf:type owl:NamedIndividual ,
+                             :OtherChargeCode ;
+                    rdfs:comment "Cool/Cold room, freezer (Storage)"@en ;
+                    rdfs:label "ZC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#PackageMarkCode_SSCC_18
+:PackageMarkCode_SSCC_18 rdf:type owl:NamedIndividual ,
+                                  :PackageMarkCode ;
+                         rdfs:comment "Serial Shipping Container Code-18 / EAN-18"@en ;
+                         rdfs:label "SSCC_18"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#PackageMarkCode_UPC
+:PackageMarkCode_UPC rdf:type owl:NamedIndividual ,
+                              :PackageMarkCode ;
+                     rdfs:comment "Universal Product Code"@en ;
+                     rdfs:label "UPC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#PackagingDangerLevelCode_I
+:PackagingDangerLevelCode_I rdf:type owl:NamedIndividual ,
+                                     :PackagingDangerLevelCode ;
+                            rdfs:comment "High danger"@en ;
+                            rdfs:label "I"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#PackagingDangerLevelCode_II
+:PackagingDangerLevelCode_II rdf:type owl:NamedIndividual ,
+                                      :PackagingDangerLevelCode ;
+                             rdfs:comment "Medium danger"@en ;
+                             rdfs:label "II"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#PackagingDangerLevelCode_III
+:PackagingDangerLevelCode_III rdf:type owl:NamedIndividual ,
+                                       :PackagingDangerLevelCode ;
+                              rdfs:comment "Low danger"@en ;
+                              rdfs:label "III"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ParticipantIdentifier_AGT
+:ParticipantIdentifier_AGT rdf:type owl:NamedIndividual ,
+                                    :ParticipantIdentifier ;
+                           rdfs:comment "Agent"@en ;
+                           rdfs:label "AGT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ParticipantIdentifier_AIR
+:ParticipantIdentifier_AIR rdf:type owl:NamedIndividual ,
+                                    :ParticipantIdentifier ;
+                           rdfs:comment "Airline"@en ;
+                           rdfs:label "AIR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ParticipantIdentifier_APT
+:ParticipantIdentifier_APT rdf:type owl:NamedIndividual ,
+                                    :ParticipantIdentifier ;
+                           rdfs:comment "Airport Authority"@en ;
+                           rdfs:label "APT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ParticipantIdentifier_BRK
+:ParticipantIdentifier_BRK rdf:type owl:NamedIndividual ,
+                                    :ParticipantIdentifier ;
+                           rdfs:comment "Broker"@en ;
+                           rdfs:label "BRK"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ParticipantIdentifier_CAG
+:ParticipantIdentifier_CAG rdf:type owl:NamedIndividual ,
+                                    :ParticipantIdentifier ;
+                           rdfs:comment "Commissionable Agent"@en ;
+                           rdfs:label "CAG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ParticipantIdentifier_CNE
+:ParticipantIdentifier_CNE rdf:type owl:NamedIndividual ,
+                                    :ParticipantIdentifier ;
+                           rdfs:comment "Consignee"@en ;
+                           rdfs:label "CNE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ParticipantIdentifier_CTM
+:ParticipantIdentifier_CTM rdf:type owl:NamedIndividual ,
+                                    :ParticipantIdentifier ;
+                           rdfs:comment "Customs"@en ;
+                           rdfs:label "CTM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ParticipantIdentifier_DCL
+:ParticipantIdentifier_DCL rdf:type owl:NamedIndividual ,
+                                    :ParticipantIdentifier ;
+                           rdfs:comment "Declarant"@en ;
+                           rdfs:label "DCL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ParticipantIdentifier_DEC
+:ParticipantIdentifier_DEC rdf:type owl:NamedIndividual ,
+                                    :ParticipantIdentifier ;
+                           rdfs:comment "Deconsolidator"@en ;
+                           rdfs:label "DEC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ParticipantIdentifier_FFW
+:ParticipantIdentifier_FFW rdf:type owl:NamedIndividual ,
+                                    :ParticipantIdentifier ;
+                           rdfs:comment "Freight Forwarder"@en ;
+                           rdfs:label "FFW"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ParticipantIdentifier_GHA
+:ParticipantIdentifier_GHA rdf:type owl:NamedIndividual ,
+                                    :ParticipantIdentifier ;
+                           rdfs:comment "Ground Handling Agent"@en ;
+                           rdfs:label "GHA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ParticipantIdentifier_PTT
+:ParticipantIdentifier_PTT rdf:type owl:NamedIndividual ,
+                                    :ParticipantIdentifier ;
+                           rdfs:comment "Post Office"@en ;
+                           rdfs:label "PTT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ParticipantIdentifier_SHP
+:ParticipantIdentifier_SHP rdf:type owl:NamedIndividual ,
+                                    :ParticipantIdentifier ;
+                           rdfs:comment "Shipper"@en ;
+                           rdfs:label "SHP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ParticipantIdentifier_TRK
+:ParticipantIdentifier_TRK rdf:type owl:NamedIndividual ,
+                                    :ParticipantIdentifier ;
+                           rdfs:comment "Trucker"@en ;
+                           rdfs:label "TRK"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#PrepaidCollectIndicator_C
+:PrepaidCollectIndicator_C rdf:type owl:NamedIndividual ,
+                                    :PrepaidCollectIndicator ;
+                           rdfs:comment "Collect Indicator"@en ;
+                           rdfs:label "C"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#PrepaidCollectIndicator_P
+:PrepaidCollectIndicator_P rdf:type owl:NamedIndividual ,
+                                    :PrepaidCollectIndicator ;
+                           rdfs:comment "Prepaid Indicator"@en ;
+                           rdfs:label "P"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RaTypeCode_III_YELLOW
+:RaTypeCode_III_YELLOW rdf:type owl:NamedIndividual ,
+                                :RaTypeCode ;
+                       rdfs:comment "III-Yellow"@en ;
+                       rdfs:label "III_YELLOW"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RaTypeCode_II_YELLOW
+:RaTypeCode_II_YELLOW rdf:type owl:NamedIndividual ,
+                               :RaTypeCode ;
+                      rdfs:comment "II-Yellow"@en ;
+                      rdfs:label "II_YELLOW"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RaTypeCode_I_WHITE
+:RaTypeCode_I_WHITE rdf:type owl:NamedIndividual ,
+                             :RaTypeCode ;
+                    rdfs:comment "I-Yellow"@en ;
+                    rdfs:label "I_WHITE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RateClassCode_B
+:RateClassCode_B rdf:type owl:NamedIndividual ,
+                          :RateClassCode ;
+                 rdfs:comment "Basic Charge"@en ;
+                 rdfs:label "B"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RateClassCode_C
+:RateClassCode_C rdf:type owl:NamedIndividual ,
+                          :BasicRateClassCode ,
+                          :RateClassCode ;
+                 rdfs:comment "Specific Commodity Rate"@en ;
+                 rdfs:label "C"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RateClassCode_E
+:RateClassCode_E rdf:type owl:NamedIndividual ,
+                          :RateClassCode ;
+                 rdfs:comment "Unit Load Device Additional Rate"@en ;
+                 rdfs:label "E"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RateClassCode_K
+:RateClassCode_K rdf:type owl:NamedIndividual ,
+                          :RateClassCode ;
+                 rdfs:comment "Rate per Kilogram"@en ;
+                 rdfs:label "K"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RateClassCode_M
+:RateClassCode_M rdf:type owl:NamedIndividual ,
+                          :BasicRateClassCode ,
+                          :RateClassCode ;
+                 rdfs:comment "Minimum Charge"@en ;
+                 rdfs:label "M"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RateClassCode_N
+:RateClassCode_N rdf:type owl:NamedIndividual ,
+                          :BasicRateClassCode ,
+                          :RateClassCode ;
+                 rdfs:comment "Normal Rate"@en ;
+                 rdfs:label "N"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RateClassCode_P
+:RateClassCode_P rdf:type owl:NamedIndividual ,
+                          :RateClassCode ;
+                 rdfs:comment "International Priority Service Rate"@en ;
+                 rdfs:label "P"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RateClassCode_Q
+:RateClassCode_Q rdf:type owl:NamedIndividual ,
+                          :BasicRateClassCode ,
+                          :RateClassCode ;
+                 rdfs:comment "Quantity Rate"@en ;
+                 rdfs:label "Q"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RateClassCode_R
+:RateClassCode_R rdf:type owl:NamedIndividual ,
+                          :RateClassCode ;
+                 rdfs:comment "Class Rate Reduction"@en ;
+                 rdfs:label "R"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RateClassCode_S
+:RateClassCode_S rdf:type owl:NamedIndividual ,
+                          :RateClassCode ;
+                 rdfs:comment "Class Rate Surcharge"@en ;
+                 rdfs:label "S"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RateClassCode_U
+:RateClassCode_U rdf:type owl:NamedIndividual ,
+                          :BasicRateClassCode ,
+                          :RateClassCode ;
+                 rdfs:comment "Unit Load Device Basic Charge or Rate"@en ;
+                 rdfs:label "U"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RateClassCode_W
+:RateClassCode_W rdf:type owl:NamedIndividual ,
+                          :RateClassCode ;
+                 rdfs:comment "Weight Increase"@en ;
+                 rdfs:label "W"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RateClassCode_X
+:RateClassCode_X rdf:type owl:NamedIndividual ,
+                          :RateClassCode ;
+                 rdfs:comment "Unit Load Device Additional Information"@en ;
+                 rdfs:label "X"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RateClassCode_Y
+:RateClassCode_Y rdf:type owl:NamedIndividual ,
+                          :RateClassCode ;
+                 rdfs:comment "Unit Load Device Discount"@en ;
+                 rdfs:label "Y"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RatingsType_A
+:RatingsType_A rdf:type owl:NamedIndividual ,
+                        :RatingsType ;
+               rdfs:comment "Actual"@en ;
+               rdfs:label "A"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RatingsType_C
+:RatingsType_C rdf:type owl:NamedIndividual ,
+                        :RatingsType ;
+               rdfs:comment "Published"@en ;
+               rdfs:label "C"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RatingsType_F
+:RatingsType_F rdf:type owl:NamedIndividual ,
+                        :RatingsType ;
+               rdfs:comment "Face"@en ;
+               rdfs:label "F"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RegulatedEntityCategoryCode_AO
+:RegulatedEntityCategoryCode_AO rdf:type owl:NamedIndividual ,
+                                         :RegulatedEntityCategoryCode ;
+                                rdfs:comment "Aircraft Operator"@en ;
+                                rdfs:label "AO"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RegulatedEntityCategoryCode_KC
+:RegulatedEntityCategoryCode_KC rdf:type owl:NamedIndividual ,
+                                         :RegulatedEntityCategoryCode ;
+                                rdfs:comment "Known Consignor (consignor for both passenger and all cargo aircraft only)"@en ;
+                                rdfs:label "KC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RegulatedEntityCategoryCode_RA
+:RegulatedEntityCategoryCode_RA rdf:type owl:NamedIndividual ,
+                                         :RegulatedEntityCategoryCode ;
+                                rdfs:comment "Regulated Agent"@en ;
+                                rdfs:label "RA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RegulatedEntityCategoryCode_RC
+:RegulatedEntityCategoryCode_RC rdf:type owl:NamedIndividual ,
+                                         :RegulatedEntityCategoryCode ;
+                                rdfs:comment "Regulated Carrier"@en ;
+                                rdfs:label "RC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ScreeningExemption_BIOM
+:ScreeningExemption_BIOM rdf:type owl:NamedIndividual ,
+                                  :ScreeningExemption ;
+                         rdfs:comment "Bio-Medical Samples"@en ;
+                         rdfs:label "BIOM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ScreeningExemption_DIPL
+:ScreeningExemption_DIPL rdf:type owl:NamedIndividual ,
+                                  :ScreeningExemption ;
+                         rdfs:comment "Diplomatic Bags or Diplomatic Mail"@en ;
+                         rdfs:label "DIPL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ScreeningExemption_LFSM
+:ScreeningExemption_LFSM rdf:type owl:NamedIndividual ,
+                                  :ScreeningExemption ;
+                         rdfs:comment "Life-Saving Materials (Save Human Life)"@en ;
+                         rdfs:label "LFSM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ScreeningExemption_MAIL
+:ScreeningExemption_MAIL rdf:type owl:NamedIndividual ,
+                                  :ScreeningExemption ;
+                         rdfs:comment "Mail"@en ;
+                         rdfs:label "MAIL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ScreeningExemption_NUCL
+:ScreeningExemption_NUCL rdf:type owl:NamedIndividual ,
+                                  :ScreeningExemption ;
+                         rdfs:comment "Nuclear Material"@en ;
+                         rdfs:label "NUCL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ScreeningExemption_SMUS
+:ScreeningExemption_SMUS rdf:type owl:NamedIndividual ,
+                                  :ScreeningExemption ;
+                         rdfs:comment "Small Undersized Shipments"@en ;
+                         rdfs:label "SMUS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ScreeningExemption_TRNS
+:ScreeningExemption_TRNS rdf:type owl:NamedIndividual ,
+                                  :ScreeningExemption ;
+                         rdfs:comment "Transfer or Transshipment"@en ;
+                         rdfs:label "TRNS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ScreeningMethod_AOM
+:ScreeningMethod_AOM rdf:type owl:NamedIndividual ,
+                              :ScreeningMethod ;
+                     rdfs:comment "Subjected to Any Other Means"@en ;
+                     rdfs:label "AOM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ScreeningMethod_CMD
+:ScreeningMethod_CMD rdf:type owl:NamedIndividual ,
+                              :ScreeningMethod ;
+                     rdfs:comment "Cargo Metal Detection"@en ;
+                     rdfs:label "CMD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ScreeningMethod_EDD
+:ScreeningMethod_EDD rdf:type owl:NamedIndividual ,
+                              :ScreeningMethod ;
+                     rdfs:comment "Explosive Detection Dogs"@en ;
+                     rdfs:label "EDD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ScreeningMethod_EDS
+:ScreeningMethod_EDS rdf:type owl:NamedIndividual ,
+                              :ScreeningMethod ;
+                     rdfs:comment "Explosive Detection System"@en ;
+                     rdfs:label "EDS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ScreeningMethod_ETD
+:ScreeningMethod_ETD rdf:type owl:NamedIndividual ,
+                              :ScreeningMethod ;
+                     rdfs:comment "Explosives Trace Detection Equipment - Particles or Vapor"@en ;
+                     rdfs:label "ETD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ScreeningMethod_PHS
+:ScreeningMethod_PHS rdf:type owl:NamedIndividual ,
+                              :ScreeningMethod ;
+                     rdfs:comment "Physical Inspection and/or Hand Search"@en ;
+                     rdfs:label "PHS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ScreeningMethod_VCK
+:ScreeningMethod_VCK rdf:type owl:NamedIndividual ,
+                              :ScreeningMethod ;
+                     rdfs:comment "Visualcheck"@en ;
+                     rdfs:label "VCK"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ScreeningMethod_XRY
+:ScreeningMethod_XRY rdf:type owl:NamedIndividual ,
+                              :ScreeningMethod ;
+                     rdfs:comment "X-ray Equipment"@en ;
+                     rdfs:label "XRY"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SecurityStatus_NSC
+:SecurityStatus_NSC rdf:type owl:NamedIndividual ,
+                             :SecurityStatus ,
+                             :SpecialHandlingCode ;
+                    rdfs:comment "Cargo Has Not Been Secured Yet for Passenger or All-Cargo Aircraft"@en ;
+                    rdfs:label "NSC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SecurityStatus_SCO
+:SecurityStatus_SCO rdf:type owl:NamedIndividual ,
+                             :SecurityStatus ,
+                             :SpecialHandlingCode ;
+                    rdfs:comment "Cargo Secure for All-Cargo Aircraft Only"@en ;
+                    rdfs:label "SCO"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SecurityStatus_SHR
+:SecurityStatus_SHR rdf:type owl:NamedIndividual ,
+                             :SecurityStatus ,
+                             :SpecialHandlingCode ;
+                    rdfs:comment "Secure for Passenger, All-Cargo and All-Mail Aircraft in Accordance with High Risk Requirements"@en ;
+                    rdfs:label "SHR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SecurityStatus_SPX
+:SecurityStatus_SPX rdf:type owl:NamedIndividual ,
+                             :SecurityStatus ,
+                             :SpecialHandlingCode ;
+                    rdfs:comment "Cargo Secure for Passenger and All-Cargo Aircraft"@en ;
+                    rdfs:label "SPX"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ServiceCode_A
+:ServiceCode_A rdf:type owl:NamedIndividual ,
+                        :ServiceCode ;
+               rdfs:comment "Airport-to-Airport"@en ;
+               rdfs:label "A"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ServiceCode_B
+:ServiceCode_B rdf:type owl:NamedIndividual ,
+                        :ServiceCode ;
+               rdfs:comment "Service Shipment"@en ;
+               rdfs:label "B"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ServiceCode_C
+:ServiceCode_C rdf:type owl:NamedIndividual ,
+                        :ServiceCode ;
+               rdfs:comment "Company Material"@en ;
+               rdfs:label "C"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ServiceCode_D
+:ServiceCode_D rdf:type owl:NamedIndividual ,
+                        :ServiceCode ;
+               rdfs:comment "Door-to-Door Service"@en ;
+               rdfs:label "D"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ServiceCode_E
+:ServiceCode_E rdf:type owl:NamedIndividual ,
+                        :ServiceCode ;
+               rdfs:comment "Airport-to-Door"@en ;
+               rdfs:label "E"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ServiceCode_F
+:ServiceCode_F rdf:type owl:NamedIndividual ,
+                        :ServiceCode ;
+               rdfs:comment "Flight Specific"@en ;
+               rdfs:label "F"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ServiceCode_G
+:ServiceCode_G rdf:type owl:NamedIndividual ,
+                        :ServiceCode ;
+               rdfs:comment "Door-to-Airport"@en ;
+               rdfs:label "G"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ServiceCode_H
+:ServiceCode_H rdf:type owl:NamedIndividual ,
+                        :ServiceCode ;
+               rdfs:comment "Company Mail"@en ;
+               rdfs:label "H"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ServiceCode_I
+:ServiceCode_I rdf:type owl:NamedIndividual ,
+                        :ServiceCode ;
+               rdfs:comment "Diplomatic Mail"@en ;
+               rdfs:label "I"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ServiceCode_J
+:ServiceCode_J rdf:type owl:NamedIndividual ,
+                        :ServiceCode ;
+               rdfs:comment "Priority Service"@en ;
+               rdfs:label "J"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ServiceCode_P
+:ServiceCode_P rdf:type owl:NamedIndividual ,
+                        :ServiceCode ;
+               rdfs:comment "Small Package Service"@en ;
+               rdfs:label "P"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ServiceCode_S
+:ServiceCode_S rdf:type owl:NamedIndividual ,
+                        :ServiceCode ;
+               rdfs:comment "Substitute Truck"@en ;
+               rdfs:label "S"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ServiceCode_T
+:ServiceCode_T rdf:type owl:NamedIndividual ,
+                        :ServiceCode ;
+               rdfs:comment "Charter"@en ;
+               rdfs:label "T"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ServiceCode_X
+:ServiceCode_X rdf:type owl:NamedIndividual ,
+                        :ServiceCode ;
+               rdfs:comment "Express Shipments"@en ;
+               rdfs:label "X"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ShipmentSecurityStatus_NCR
+:ShipmentSecurityStatus_NCR rdf:type owl:NamedIndividual ,
+                                     :ShipmentSecurityStatus ;
+                            rdfs:comment "Screened"@en ;
+                            rdfs:label "NCR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ShipmentSecurityStatus_SCR
+:ShipmentSecurityStatus_SCR rdf:type owl:NamedIndividual ,
+                                     :ShipmentSecurityStatus ;
+                            rdfs:comment "Not Screened"@en ;
+                            rdfs:label "SCR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SignatoryRole_APPLICANT
+:SignatoryRole_APPLICANT rdf:type owl:NamedIndividual ,
+                                  :SignatoryRole ;
+                         rdfs:comment "Applicant"@en ;
+                         rdfs:label "APPLICANT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SignatoryRole_EXAMINING_AUTHORITY
+:SignatoryRole_EXAMINING_AUTHORITY rdf:type owl:NamedIndividual ,
+                                            :SignatoryRole ;
+                                   rdfs:comment "Examining Authority"@en ;
+                                   rdfs:label "EXAMINING_AUTHORITY"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SignatoryRole_ISSUING_AUTHORITY
+:SignatoryRole_ISSUING_AUTHORITY rdf:type owl:NamedIndividual ,
+                                          :SignatoryRole ;
+                                 rdfs:comment "Issuing Authority"@en ;
+                                 rdfs:label "ISSUING_AUTHORITY"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SignatoryRole_MANAGEMENT_AUTHORITY
+:SignatoryRole_MANAGEMENT_AUTHORITY rdf:type owl:NamedIndividual ,
+                                             :SignatoryRole ;
+                                    rdfs:comment "Management Authority"@en ;
+                                    rdfs:label "MANAGEMENT_AUTHORITY"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SignatoryRole_PERMIT_ISSUER
+:SignatoryRole_PERMIT_ISSUER rdf:type owl:NamedIndividual ,
+                                      :SignatoryRole ;
+                             rdfs:comment "Permit Issuer"@en ;
+                             rdfs:label "PERMIT_ISSUER"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SignatureTypeCode_DETENTION
+:SignatureTypeCode_DETENTION rdf:type owl:NamedIndividual ,
+                                      :SignatureTypeCode ;
+                             rdfs:comment "Detention"@en ;
+                             rdfs:label "DETENTION"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SignatureTypeCode_FUMIGATION
+:SignatureTypeCode_FUMIGATION rdf:type owl:NamedIndividual ,
+                                       :SignatureTypeCode ;
+                              rdfs:comment "Fumigation"@en ;
+                              rdfs:label "FUMIGATION"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SignatureTypeCode_INSPECTION
+:SignatureTypeCode_INSPECTION rdf:type owl:NamedIndividual ,
+                                       :SignatureTypeCode ;
+                              rdfs:comment "Inspection"@en ;
+                              rdfs:label "INSPECTION"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SignatureTypeCode_SECURITY
+:SignatureTypeCode_SECURITY rdf:type owl:NamedIndividual ,
+                                     :SignatureTypeCode ;
+                            rdfs:comment "Security"@en ;
+                            rdfs:label "SECURITY"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_ACT
+:SpecialHandlingCode_ACT rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Active Temperature Controlled System"@en ;
+                         rdfs:label "ACT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_AOG
+:SpecialHandlingCode_AOG rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Aircraft on Ground"@en ;
+                         rdfs:label "AOG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_ATT
+:SpecialHandlingCode_ATT rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Goods Attached to Air Waybill"@en ;
+                         rdfs:label "ATT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_AVI
+:SpecialHandlingCode_AVI rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Live Animal"@en ;
+                         rdfs:label "AVI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_BIG
+:SpecialHandlingCode_BIG rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Outsized"@en ;
+                         rdfs:label "BIG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_BUP
+:SpecialHandlingCode_BUP rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Bulk Unitization Programme, Shipper/Consignee Handled Unit"@en ;
+                         rdfs:label "BUP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_CAT
+:SpecialHandlingCode_CAT rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Cargo Attendant Accompanying Shipment"@en ;
+                         rdfs:label "CAT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_CIC
+:SpecialHandlingCode_CIC rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Cargo may be loaded in the passenger cabin"@en ;
+                         rdfs:label "CIC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_COL
+:SpecialHandlingCode_COL rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Cool Goods"@en ;
+                         rdfs:label "COL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_COM
+:SpecialHandlingCode_COM rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Company Mail"@en ;
+                         rdfs:label "COM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_CRT
+:SpecialHandlingCode_CRT rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Control Room Temperature +15°C to +25°C"@en ;
+                         rdfs:label "CRT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_DIP
+:SpecialHandlingCode_DIP rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Diplomatic Mail"@en ;
+                         rdfs:label "DIP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_EAP
+:SpecialHandlingCode_EAP rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "e-freight Consignment with Accompanying Paper Documents"@en ;
+                         rdfs:label "EAP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_EAT
+:SpecialHandlingCode_EAT rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Foodstuffs"@en ;
+                         rdfs:label "EAT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_EAW
+:SpecialHandlingCode_EAW rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "e-freight Consignment with No Accompanying Paper Documents"@en ;
+                         rdfs:label "EAW"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_ECC
+:SpecialHandlingCode_ECC rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Consignment established with an electronically concluded cargo contract with no accompanying paper airwaybill"@en ;
+                         rdfs:label "ECC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_ECP
+:SpecialHandlingCode_ECP rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Consignment established with a paper air waybill contract being printed under an e-AWB agreement"@en ;
+                         rdfs:label "ECP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_EMD
+:SpecialHandlingCode_EMD rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Electronic Monitoring Devices on/in Cargo/Container"@en ;
+                         rdfs:label "EMD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_ERT
+:SpecialHandlingCode_ERT rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Extended Room Temperature +2°C to +25°C"@en ;
+                         rdfs:label "ERT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_FIL
+:SpecialHandlingCode_FIL rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Undeveloped/Unexposed Film"@en ;
+                         rdfs:label "FIL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_FRI
+:SpecialHandlingCode_FRI rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Frozen Goods Subject to Veterinary/Phytosanitary Inspections"@en ;
+                         rdfs:label "FRI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_FRO
+:SpecialHandlingCode_FRO rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Frozen Goods"@en ;
+                         rdfs:label "FRO"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_GOH
+:SpecialHandlingCode_GOH rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Hanging Garments"@en ;
+                         rdfs:label "GOH"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_HEA
+:SpecialHandlingCode_HEA rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Heavy Cargo/150 kilograms and over per piece"@en ;
+                         rdfs:label "HEA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_HEG
+:SpecialHandlingCode_HEG rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Hatching Eggs"@en ;
+                         rdfs:label "HEG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_HUM
+:SpecialHandlingCode_HUM rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Human Remains in Coffin"@en ;
+                         rdfs:label "HUM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_LHO
+:SpecialHandlingCode_LHO rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Living Human Organs/Blood"@en ;
+                         rdfs:label "LHO"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_LIC
+:SpecialHandlingCode_LIC rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "License Required"@en ;
+                         rdfs:label "LIC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_MAL
+:SpecialHandlingCode_MAL rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Mail"@en ;
+                         rdfs:label "MAL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_MUW
+:SpecialHandlingCode_MUW rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Munitions of War"@en ;
+                         rdfs:label "MUW"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_NST
+:SpecialHandlingCode_NST rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Non Stackable Cargo"@en ;
+                         rdfs:label "NST"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_NWP
+:SpecialHandlingCode_NWP rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Newspapers, Magazines"@en ;
+                         rdfs:label "NWP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_OBX
+:SpecialHandlingCode_OBX rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Obnoxious Cargo"@en ;
+                         rdfs:label "OBX"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_OHG
+:SpecialHandlingCode_OHG rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Overhang Item"@en ;
+                         rdfs:label "OHG"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_PAC
+:SpecialHandlingCode_PAC rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Passenger and Cargo"@en ;
+                         rdfs:label "PAC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_PEA
+:SpecialHandlingCode_PEA rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Hunting trophies, skin, hide and all articles made from or containing parts of species listed in the CITES (Convention on International Trade in Endangered Species) appendices"@en ;
+                         rdfs:label "PEA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_PEB
+:SpecialHandlingCode_PEB rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Animal products for non-human consumption"@en ;
+                         rdfs:label "PEB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_PEF
+:SpecialHandlingCode_PEF rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Flowers"@en ;
+                         rdfs:label "PEF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_PEM
+:SpecialHandlingCode_PEM rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Meat"@en ;
+                         rdfs:label "PEM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_PEP
+:SpecialHandlingCode_PEP rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Fruits and Vegetables"@en ;
+                         rdfs:label "PEP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_PER
+:SpecialHandlingCode_PER rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Perishable Cargo"@en ;
+                         rdfs:label "PER"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_PES
+:SpecialHandlingCode_PES rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Fish/Seafood"@en ;
+                         rdfs:label "PES"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_PHY
+:SpecialHandlingCode_PHY rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Goods subject to phytosanitary inspections"@en ;
+                         rdfs:label "PHY"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_PIL
+:SpecialHandlingCode_PIL rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Pharmaceuticals"@en ;
+                         rdfs:label "PIL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_PIP
+:SpecialHandlingCode_PIP rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Passive Insulated Packaging"@en ;
+                         rdfs:label "PIP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_QRT
+:SpecialHandlingCode_QRT rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Quick Ramp Transfer"@en ;
+                         rdfs:label "QRT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_RAC
+:SpecialHandlingCode_RAC rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Reserved Air Cargo"@en ;
+                         rdfs:label "RAC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_RDS
+:SpecialHandlingCode_RDS rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Diagnostic Specimens"@en ;
+                         rdfs:label "RDS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_REQ
+:SpecialHandlingCode_REQ rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Excepted Quantities of Dangerous Goods"@en ;
+                         rdfs:label "REQ"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_RRE
+:SpecialHandlingCode_RRE rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Excepted Quantities of Radioactive Material"@en ;
+                         rdfs:label "RRE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_SHL
+:SpecialHandlingCode_SHL rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Save Human Life"@en ;
+                         rdfs:label "SHL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_SPF
+:SpecialHandlingCode_SPF rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Laboratory Animals"@en ;
+                         rdfs:label "SPF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_SUR
+:SpecialHandlingCode_SUR rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Surface Transportation"@en ;
+                         rdfs:label "SUR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_SWP
+:SpecialHandlingCode_SWP rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Sporting Weapons"@en ;
+                         rdfs:label "SWP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_VAL
+:SpecialHandlingCode_VAL rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Valuable Cargo"@en ;
+                         rdfs:label "VAL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_VIC
+:SpecialHandlingCode_VIC rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Very Important Cargo"@en ;
+                         rdfs:label "VIC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_VOL
+:SpecialHandlingCode_VOL rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Volume"@en ;
+                         rdfs:label "VOL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_VUN
+:SpecialHandlingCode_VUN rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Vulnerable Cargo"@en ;
+                         rdfs:label "VUN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_WET
+:SpecialHandlingCode_WET rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Shipments of Wet Material not Packed in Watertight Containers"@en ;
+                         rdfs:label "WET"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode_XPS
+:SpecialHandlingCode_XPS rdf:type owl:NamedIndividual ,
+                                  :SpecialHandlingCode ;
+                         rdfs:comment "Priority Small Package"@en ;
+                         rdfs:label "XPS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_ARR
+:StatusCode_ARR rdf:type owl:NamedIndividual ,
+                         :StatusCode ;
+                rdfs:comment "The consignment has arrived on a scheduled flight at this location"@en ;
+                rdfs:label "ARR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_AWD
+:StatusCode_AWD rdf:type owl:NamedIndividual ,
+                         :StatusCode ;
+                rdfs:comment "The arrival documentation has been physically delivered to the consignee or the consignee’s agent on this date at this location"@en ;
+                rdfs:label "AWD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_AWR
+:StatusCode_AWR rdf:type owl:NamedIndividual ,
+                         :StatusCode ;
+                rdfs:comment "The arrival documentation has been physically received from a scheduled flight at this location"@en ;
+                rdfs:label "AWR"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_BKD
+:StatusCode_BKD rdf:type owl:NamedIndividual ,
+                         :StatusCode ;
+                rdfs:comment "The consignment has been booked for transport between these locations on this scheduled date and this flight"@en ;
+                rdfs:label "BKD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_CCD
+:StatusCode_CCD rdf:type owl:NamedIndividual ,
+                         :StatusCode ;
+                rdfs:comment "The consignment has been cleared by the Customs authorities on this date at this location"@en ;
+                rdfs:label "CCD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_CRC
+:StatusCode_CRC rdf:type owl:NamedIndividual ,
+                         :StatusCode ;
+                rdfs:comment "The consignment has been reported to the Customs authorities on this date at this location"@en ;
+                rdfs:label "CRC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_DDL
+:StatusCode_DDL rdf:type owl:NamedIndividual ,
+                         :StatusCode ;
+                rdfs:comment "The consignment has been physically delivered to the consignee’s door on this date at this location"@en ;
+                rdfs:label "DDL"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_DEP
+:StatusCode_DEP rdf:type owl:NamedIndividual ,
+                         :StatusCode ;
+                rdfs:comment "The consignment has physically departed this location on this scheduled date and flight for transport to the arrival location"@en ;
+                rdfs:label "DEP"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_DIS_DFLD
+:StatusCode_DIS_DFLD rdf:type owl:NamedIndividual ,
+                              :StatusCode ;
+                     rdfs:comment "An apparent error has occurred, on this date at this location, with the handling of the consignment or its documentation: Offloaded"@en ;
+                     rdfs:label "DIS_DFLD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_DIS_FDAV
+:StatusCode_DIS_FDAV rdf:type owl:NamedIndividual ,
+                              :StatusCode ;
+                     rdfs:comment "An apparent error has occurred, on this date at this location, with the handling of the consignment or its documentation: Found Mail Document"@en ;
+                     rdfs:label "DIS_FDAV"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_DIS_FDAW
+:StatusCode_DIS_FDAW rdf:type owl:NamedIndividual ,
+                              :StatusCode ;
+                     rdfs:comment "An apparent error has occurred, on this date at this location, with the handling of the consignment or its documentation: Found Air Waybill"@en ;
+                     rdfs:label "DIS_FDAW"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_DIS_FDCA
+:StatusCode_DIS_FDCA rdf:type owl:NamedIndividual ,
+                              :StatusCode ;
+                     rdfs:comment "An apparent error has occurred, on this date at this location, with the handling of the consignment or its documentation: Found Cargo"@en ;
+                     rdfs:label "DIS_FDCA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_DIS_FDMB
+:StatusCode_DIS_FDMB rdf:type owl:NamedIndividual ,
+                              :StatusCode ;
+                     rdfs:comment "An apparent error has occurred, on this date at this location, with the handling of the consignment or its documentation: Found Mailbag"@en ;
+                     rdfs:label "DIS_FDMB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_DIS_MSAV
+:StatusCode_DIS_MSAV rdf:type owl:NamedIndividual ,
+                              :StatusCode ;
+                     rdfs:comment "An apparent error has occurred, on this date at this location, with the handling of the consignment or its documentation: Missing Mail Document"@en ;
+                     rdfs:label "DIS_MSAV"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_DIS_MSAW
+:StatusCode_DIS_MSAW rdf:type owl:NamedIndividual ,
+                              :StatusCode ;
+                     rdfs:comment "An apparent error has occurred, on this date at this location, with the handling of the consignment or its documentation: Missing Air Waybill"@en ;
+                     rdfs:label "DIS_MSAW"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_DIS_MSCA
+:StatusCode_DIS_MSCA rdf:type owl:NamedIndividual ,
+                              :StatusCode ;
+                     rdfs:comment "An apparent error has occurred, on this date at this location, with the handling of the consignment or its documentation: Missing Cargo"@en ;
+                     rdfs:label "DIS_MSCA"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_DIS_MSMB
+:StatusCode_DIS_MSMB rdf:type owl:NamedIndividual ,
+                              :StatusCode ;
+                     rdfs:comment "An apparent error has occurred, on this date at this location, with the handling of the consignment or its documentation: Definitely Loaded"@en ;
+                     rdfs:label "DIS_MSMB"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_DIS_OFLD
+:StatusCode_DIS_OFLD rdf:type owl:NamedIndividual ,
+                              :StatusCode ;
+                     rdfs:comment "An apparent error has occurred, on this date at this location, with the handling of the consignment or its documentation: Overcarried"@en ;
+                     rdfs:label "DIS_OFLD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_DIS_OVCD
+:StatusCode_DIS_OVCD rdf:type owl:NamedIndividual ,
+                              :StatusCode ;
+                     rdfs:comment "An apparent error has occurred, on this date at this location, with the handling of the consignment or its documentation: Shortshipped"@en ;
+                     rdfs:label "DIS_OVCD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_DIS_SSPD
+:StatusCode_DIS_SSPD rdf:type owl:NamedIndividual ,
+                              :StatusCode ;
+                     rdfs:comment "An apparent error has occurred, on this date at this location, with the handling of the consignment or its documentation: Found Air Waybill"@en ;
+                     rdfs:label "DIS_SSPD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_DLV
+:StatusCode_DLV rdf:type owl:NamedIndividual ,
+                         :StatusCode ;
+                rdfs:comment "The consignment has been physically delivered to the consignee or the Consignee’s agent on this date at this location"@en ;
+                rdfs:label "DLV"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_DOC
+:StatusCode_DOC rdf:type owl:NamedIndividual ,
+                         :StatusCode ;
+                rdfs:comment "Documents Received by Handling Party"@en ;
+                rdfs:label "DOC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_DPU
+:StatusCode_DPU rdf:type owl:NamedIndividual ,
+                         :StatusCode ;
+                rdfs:comment "The consignment has been physically picked up from the shipper’s door on this date at this location"@en ;
+                rdfs:label "DPU"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_FIW
+:StatusCode_FIW rdf:type owl:NamedIndividual ,
+                         :StatusCode ;
+                rdfs:comment "Freight Into Warehouse Control"@en ;
+                rdfs:label "FIW"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_FOH
+:StatusCode_FOH rdf:type owl:NamedIndividual ,
+                         :StatusCode ;
+                rdfs:comment "The consignment is on hand on this date at this location pending “ready for carriage” determination"@en ;
+                rdfs:label "FOH"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_FOW
+:StatusCode_FOW rdf:type owl:NamedIndividual ,
+                         :StatusCode ;
+                rdfs:comment "Freight Out of Warehouse Control"@en ;
+                rdfs:label "FOW"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_MAN
+:StatusCode_MAN rdf:type owl:NamedIndividual ,
+                         :StatusCode ;
+                rdfs:comment "The consignment has been manifested for this flight on this scheduled date for transport between these locations"@en ;
+                rdfs:label "MAN"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_NFD
+:StatusCode_NFD rdf:type owl:NamedIndividual ,
+                         :StatusCode ;
+                rdfs:comment "The consignee or the consignee’s agent has been notified, on this date at this location, of the arrival of the consignment"@en ;
+                rdfs:label "NFD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_OCI
+:StatusCode_OCI rdf:type owl:NamedIndividual ,
+                         :StatusCode ;
+                rdfs:comment "Other Customs, Security and Regulatory Control Information"@en ;
+                rdfs:label "OCI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_OSI
+:StatusCode_OSI rdf:type owl:NamedIndividual ,
+                         :StatusCode ;
+                rdfs:comment "Other Service Information"@en ;
+                rdfs:label "OSI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_PRE
+:StatusCode_PRE rdf:type owl:NamedIndividual ,
+                         :StatusCode ;
+                rdfs:comment "The consignment has been prepared for loading on this flight for transport between these locations on this scheduled date"@en ;
+                rdfs:label "PRE"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_RCF
+:StatusCode_RCF rdf:type owl:NamedIndividual ,
+                         :StatusCode ;
+                rdfs:comment "The consignment has been physically received from a given flight or surface transport of the given airline"@en ;
+                rdfs:label "RCF"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_RCS
+:StatusCode_RCS rdf:type owl:NamedIndividual ,
+                         :StatusCode ;
+                rdfs:comment "The consignment has been physically received from the shipper or the shipper’s agent and is considered by the carrier as ready for carriage on this date at this location"@en ;
+                rdfs:label "RCS"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_RCT
+:StatusCode_RCT rdf:type owl:NamedIndividual ,
+                         :StatusCode ;
+                rdfs:comment "The consignment has been physically received from this carrier on this date at this location"@en ;
+                rdfs:label "RCT"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_TFD
+:StatusCode_TFD rdf:type owl:NamedIndividual ,
+                         :StatusCode ;
+                rdfs:comment "The consignment has been physically transferred to this carrier on this date at this location"@en ;
+                rdfs:label "TFD"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_TGC
+:StatusCode_TGC rdf:type owl:NamedIndividual ,
+                         :StatusCode ;
+                rdfs:comment "The consignment has been transferred to Customs/Government control"@en ;
+                rdfs:label "TGC"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode_TRM
+:StatusCode_TRM rdf:type owl:NamedIndividual ,
+                         :StatusCode ;
+                rdfs:comment "The consignment has been manifested and/or will be physically transferred to this carrier at this location"@en ;
+                rdfs:label "TRM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#TransactionPurposeCode_B
+:TransactionPurposeCode_B rdf:type owl:NamedIndividual ,
+                                   :TransactionPurposeCode ;
+                          rdfs:comment "Breeding in captivity or artificial propagation"@en ;
+                          rdfs:label "B"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#TransactionPurposeCode_E
+:TransactionPurposeCode_E rdf:type owl:NamedIndividual ,
+                                   :TransactionPurposeCode ;
+                          rdfs:comment "Educational"@en ;
+                          rdfs:label "E"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#TransactionPurposeCode_G
+:TransactionPurposeCode_G rdf:type owl:NamedIndividual ,
+                                   :TransactionPurposeCode ;
+                          rdfs:comment "Botanical garden"@en ;
+                          rdfs:label "G"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#TransactionPurposeCode_H
+:TransactionPurposeCode_H rdf:type owl:NamedIndividual ,
+                                   :TransactionPurposeCode ;
+                          rdfs:comment "Hunting trophy"@en ;
+                          rdfs:label "H"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#TransactionPurposeCode_L
+:TransactionPurposeCode_L rdf:type owl:NamedIndividual ,
+                                   :TransactionPurposeCode ;
+                          rdfs:comment "Law enforcement / judicial / forensic"@en ;
+                          rdfs:label "L"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#TransactionPurposeCode_M
+:TransactionPurposeCode_M rdf:type owl:NamedIndividual ,
+                                   :TransactionPurposeCode ;
+                          rdfs:comment "Medical (including biomedical research)"@en ;
+                          rdfs:label "M"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#TransactionPurposeCode_N
+:TransactionPurposeCode_N rdf:type owl:NamedIndividual ,
+                                   :TransactionPurposeCode ;
+                          rdfs:comment "Reintroduction or introduction into the wild"@en ;
+                          rdfs:label "N"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#TransactionPurposeCode_P
+:TransactionPurposeCode_P rdf:type owl:NamedIndividual ,
+                                   :TransactionPurposeCode ;
+                          rdfs:comment "Personal"@en ;
+                          rdfs:label "P"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#TransactionPurposeCode_Q
+:TransactionPurposeCode_Q rdf:type owl:NamedIndividual ,
+                                   :TransactionPurposeCode ;
+                          rdfs:comment "Circus or travelling exhibition"@en ;
+                          rdfs:label "Q"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#TransactionPurposeCode_S
+:TransactionPurposeCode_S rdf:type owl:NamedIndividual ,
+                                   :TransactionPurposeCode ;
+                          rdfs:comment "Scientific"@en ;
+                          rdfs:label "S"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#TransactionPurposeCode_T
+:TransactionPurposeCode_T rdf:type owl:NamedIndividual ,
+                                   :TransactionPurposeCode ;
+                          rdfs:comment "Commercial"@en ;
+                          rdfs:label "T"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#TransactionPurposeCode_Z
+:TransactionPurposeCode_Z rdf:type owl:NamedIndividual ,
+                                   :TransactionPurposeCode ;
+                          rdfs:comment "Zoo"@en ;
+                          rdfs:label "Z"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#TransportMeansServiceType_FREIGHTER
+:TransportMeansServiceType_FREIGHTER rdf:type owl:NamedIndividual ,
+                                              :TransportMeansServiceType ;
+                                     rdfs:comment "Transport leg performed by freighter aircraft"@en ;
+                                     rdfs:label "FREIGHTER"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#TransportMeansServiceType_MIXED_CONFIGURATION_COMBI
+:TransportMeansServiceType_MIXED_CONFIGURATION_COMBI rdf:type owl:NamedIndividual ,
+                                                              :TransportMeansServiceType ;
+                                                     rdfs:comment "Transport leg performed by mixed configuration combi aircraft"@en ;
+                                                     rdfs:label "MIXED_CONFIGURATION_COMBI"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#TransportMeansServiceType_PASSENGER
+:TransportMeansServiceType_PASSENGER rdf:type owl:NamedIndividual ,
+                                              :TransportMeansServiceType ;
+                                     rdfs:comment "Transport leg performed by passenger aircraft"@en ;
+                                     rdfs:label "PASSENGER"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#TransportMeansServiceType_TRUCK
+:TransportMeansServiceType_TRUCK rdf:type owl:NamedIndividual ,
+                                          :TransportMeansServiceType ;
+                                 rdfs:comment "Transport leg performed by truck"@en ;
+                                 rdfs:label "TRUCK"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ULDChargeCode_A
+:ULDChargeCode_A rdf:type owl:NamedIndividual ,
+                          :ULDChargeCode ;
+                 rdfs:comment "Pivot Rate per kilogram"@en ;
+                 rdfs:label "A"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ULDChargeCode_B
+:ULDChargeCode_B rdf:type owl:NamedIndividual ,
+                          :ULDChargeCode ;
+                 rdfs:comment "First Minimum Charge — minimum weight"@en ;
+                 rdfs:label "B"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ULDChargeCode_C
+:ULDChargeCode_C rdf:type owl:NamedIndividual ,
+                          :ULDChargeCode ;
+                 rdfs:comment "First over pivot rate per kilogram"@en ;
+                 rdfs:label "C"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ULDChargeCode_D
+:ULDChargeCode_D rdf:type owl:NamedIndividual ,
+                          :ULDChargeCode ;
+                 rdfs:comment "Second Minimum Charge — minimum weight"@en ;
+                 rdfs:label "D"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ULDChargeCode_E
+:ULDChargeCode_E rdf:type owl:NamedIndividual ,
+                          :ULDChargeCode ;
+                 rdfs:comment "Second over pivot rate per kilogram"@en ;
+                 rdfs:label "E"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ULDChargeCode_F
+:ULDChargeCode_F rdf:type owl:NamedIndividual ,
+                          :ULDChargeCode ;
+                 rdfs:comment "Third Minimum Charge — minimum weight"@en ;
+                 rdfs:label "F"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ULDChargeCode_G
+:ULDChargeCode_G rdf:type owl:NamedIndividual ,
+                          :ULDChargeCode ;
+                 rdfs:comment "Third over pivot rate per kilogram"@en ;
+                 rdfs:label "G"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ULDChargeCode_H
+:ULDChargeCode_H rdf:type owl:NamedIndividual ,
+                          :ULDChargeCode ;
+                 rdfs:comment "Flat Charge — (without weight or with minimum weight)"@en ;
+                 rdfs:label "H"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ULDChargeCode_I
+:ULDChargeCode_I rdf:type owl:NamedIndividual ,
+                          :ULDChargeCode ;
+                 rdfs:comment "Flat Charge — maximum weight"@en ;
+                 rdfs:label "I"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ULDConditionCode_DAM
+:ULDConditionCode_DAM rdf:type owl:NamedIndividual ,
+                               :ULDConditionCode ;
+                      rdfs:comment "Damaged But Still Serviceable"@en ;
+                      rdfs:label "DAM"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ULDConditionCode_SER
+:ULDConditionCode_SER rdf:type owl:NamedIndividual ,
+                               :ULDConditionCode ;
+                      rdfs:comment "Serviceable"@en ;
+                      rdfs:label "SER"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ULDLoadingIndicator_L
+:ULDLoadingIndicator_L rdf:type owl:NamedIndividual ,
+                                :ULDLoadingIndicator ;
+                       rdfs:comment "ULD Height below 160 centimetres"@en ;
+                       rdfs:label "L"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ULDLoadingIndicator_M
+:ULDLoadingIndicator_M rdf:type owl:NamedIndividual ,
+                                :ULDLoadingIndicator ;
+                       rdfs:comment "Main Deck Loading only"@en ;
+                       rdfs:label "M"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ULDLoadingIndicator_N
+:ULDLoadingIndicator_N rdf:type owl:NamedIndividual ,
+                                :ULDLoadingIndicator ;
+                       rdfs:comment "Nose Door Loading only"@en ;
+                       rdfs:label "N"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ULDLoadingIndicator_R
+:ULDLoadingIndicator_R rdf:type owl:NamedIndividual ,
+                                :ULDLoadingIndicator ;
+                       rdfs:comment "ULD Height above 244 centimetres"@en ;
+                       rdfs:label "R"@en .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ULDLoadingIndicator_U
+:ULDLoadingIndicator_U rdf:type owl:NamedIndividual ,
+                                :ULDLoadingIndicator ;
+                       rdfs:comment "ULD Height between 160 centimetres and 244 centimetres"@en ;
+                       rdfs:label "U"@en .
+
+
+###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi

--- a/working_draft/ontology/IATA-1R-DM-Ontology.ttl
+++ b/working_draft/ontology/IATA-1R-DM-Ontology.ttl
@@ -9,11 +9,11 @@
 @base <https://onerecord.iata.org/ns/cargo> .
 
 <https://onerecord.iata.org/ns/cargo> rdf:type owl:Ontology ;
-                                       owl:versionIRI <https://onerecord.iata.org/ns/cargo/3.0.0-RC4.1> ;
+                                       owl:versionIRI <https://onerecord.iata.org/ns/cargo/3.0.0-RC5a> ;
                                        dc:description "The ONE Record vocabulary, described using W3C RDF Schema and the Web Ontology Language."@en ;
                                        dc:title "ONE Record Ontology"@en ;
                                        terms:abstract "The ontology of the ONE Record standard is the core data model underlying the Linked Data solution drafted by the ONE Record standard: https://github.com/IATA-Cargo/ONE-Record. ONE Record is a standard for data sharing and creates a single record view of the shipment. This standard defines a common data model for the data that is shared via standardized and secured web API."@en ;
-                                       terms:modified "02-06-2023" ;
+                                       terms:modified "10-07-2023" ;
                                        terms:title "ONE Record Ontology"@en ;
                                        rdfs:comment """Details availalble on GitHub https://github.com/IATA-Cargo/ONE-Record
 Version 2.0.0
@@ -57,10 +57,22 @@ Version 3.0.0 RC 4.1
 - Renamed \"locationOfPerformance\" and \"loactionOfCreation\" to \"performedAtLocation\" and \"createdAtLocation\" for consistency
 - Renamed \"forBookingOptions\" to \"forBookingOption\" for consistency
 - Addded \"resultOfCheck\" and \"usedInCheck\" properties as backlinks from CheckTotalResult and CheckTemplate to Check
-- Fixed \"describedByProduct\" restriction in Item LO"""@en ;
+- Fixed \"describedByProduct\" restriction in Item LO
+Version 3.0.0 RC5
+- Fixed missing label and description in subtotal and billing charges properties
+- Changed Shipment from PhysicalLO to LO
+- Lifted cardinality restriction from insuredShipment property and changed name and IRI suffix to insuredShipments
+- Deprecated nvdindicator for consistency
+- Moved weightValuationIndicator and otherChargesIndicator from Shipment to Waybill
+- Added slac to LoadingUnit
+- Deprecated handlingInstructions property and HandlingInstructions class for properties textualHandlingInstructions (OCI and SSR) and specialHandlingCodes (SPH); added them to Piece, Shipment, BookingShipment
+- Added TACTRateDescription, OtherCharge, TotalCharge classes and respective properties
+- Changed domain of re-used properties to owl:Thing of the abovementioned classes
+- Added properties serviceCode, chargesAtDestination and carrierCharge code to Waybill
+- Added tactRateDescriptions, chargeTotals and otherCharges to Waybill to connect with the new LOs"""@en ;
                                        rdfs:isDefinedBy "https://www.iata.org/one-record/"^^xsd:anyURI ;
                                        rdfs:label "ONE Record Ontology"@en ;
-                                       owl:versionInfo "3.0.0 RC 4 .1"@en .
+                                       owl:versionInfo "3.0.0 RC 5a"@en .
 
 #################################################################
 #    Annotation properties
@@ -161,6 +173,14 @@ owl:thing rdf:type rdfs:Datatype .
              rdfs:comment "Information about Adjustments performed on the BillingDetails"@en ;
              rdfs:label "adjustments"@en ;
              owl:comment "Possible RDF good practice IRI: :hasAdjustment "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#amountTotal
+:amountTotal rdf:type owl:ObjectProperty ;
+             rdfs:domain :TotalCharge ;
+             rdfs:range :Value ;
+             rdfs:comment "PENDING"@en ;
+             rdfs:label "amountTotal"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#answer
@@ -402,6 +422,14 @@ owl:thing rdf:type rdfs:Datatype .
                   owl:comment "Possible RDF good practice IRI: :isCertifiedByActor "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#chargeTotals
+:chargeTotals rdf:type owl:ObjectProperty ;
+              rdfs:domain :Waybill ;
+              rdfs:range :TotalCharge ;
+              rdfs:comment "Information about Total Charges applying to this Waybill"@en ;
+              rdfs:label "chargeTotals"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#chargeableWeight
 :chargeableWeight rdf:type owl:ObjectProperty ;
                   rdfs:domain :VolumetricWeight ;
@@ -409,6 +437,22 @@ owl:thing rdf:type rdfs:Datatype .
                   rdfs:comment "Chargeable weight"@en ;
                   rdfs:label "chargeableWeight"@en ;
                   owl:comment "Possible RDF good practice IRI: :hasChargeableWeight "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#chargeableWeightForRate
+:chargeableWeightForRate rdf:type owl:ObjectProperty ;
+                         rdfs:domain :TACTRateDescription ;
+                         rdfs:range :Value ;
+                         rdfs:comment "PENDING"@en ;
+                         rdfs:label "chargeableWeightForRate"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#chargesAtDestination
+:chargesAtDestination rdf:type owl:ObjectProperty ;
+                      rdfs:domain :Waybill ;
+                      rdfs:range :Value ;
+                      rdfs:comment "PENDING"@en ;
+                      rdfs:label "chargesAtDestination"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#checkActions
@@ -472,6 +516,14 @@ owl:thing rdf:type rdfs:Datatype .
               rdfs:comment "References to CO2Emissions"@en ;
               rdfs:label "co2Emissions"@en ;
               owl:comment "Possible RDF good practice IRI: :hasCo2Emissions "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#collectChargesInDestinationCurrency
+:collectChargesInDestinationCurrency rdf:type owl:ObjectProperty ;
+                                     rdfs:domain :TotalCharge ;
+                                     rdfs:range :Value ;
+                                     rdfs:comment "PENDING"@en ;
+                                     rdfs:label "collectChargesInDestinationCurrency"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#company
@@ -671,6 +723,14 @@ owl:thing rdf:type rdfs:Datatype .
                    owl:comment "Possible RDF good practice IRI: :isCreatedAt "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#currencyConversionRate
+:currencyConversionRate rdf:type owl:ObjectProperty ;
+                        rdfs:domain :TotalCharge ;
+                        rdfs:range :Value ;
+                        rdfs:comment "PENDING"@en ;
+                        rdfs:label "currencyConversionRate"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#customsInformation
 :customsInformation rdf:type owl:ObjectProperty ;
                     rdfs:domain :Piece ;
@@ -679,6 +739,22 @@ owl:thing rdf:type rdfs:Datatype .
                     rdfs:label "customsInformation"@en ;
                     owl:comment "Possible RDF good practice IRI: :hasCustomsInformation "@en ;
                     owl:versionInfo "v3.0 renamed from piece:customsInfo"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#declaredValueForCarriage
+:declaredValueForCarriage rdf:type owl:ObjectProperty ;
+                          rdfs:domain :Waybill ;
+                          rdfs:range :Value ;
+                          rdfs:comment "The value of a shipment declared for carriage purposes"@en ;
+                          rdfs:label "declaredValueForCarriage"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#declaredValueForCustoms
+:declaredValueForCustoms rdf:type owl:ObjectProperty ;
+                         rdfs:domain :Waybill ;
+                         rdfs:range :Value ;
+                         rdfs:comment "The value of a shipment declared for customs purposes"@en ;
+                         rdfs:label "declaredValueForCustoms"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#deliveryLocation
@@ -1004,13 +1080,22 @@ owl:thing rdf:type rdfs:Datatype .
              owl:comment "Possible RDF good practice IRI: :hasGrossWeight "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#grossWeightForRate
+:grossWeightForRate rdf:type owl:ObjectProperty ;
+                    rdfs:domain :TACTRateDescription ;
+                    rdfs:range :Value ;
+                    rdfs:comment "PENDING"@en ;
+                    rdfs:label "grossWeightForRate"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#handlingInstructions
 :handlingInstructions rdf:type owl:ObjectProperty ;
                       rdfs:domain :Piece ;
                       rdfs:range :HandlingInstructions ;
                       rdfs:comment "Links to Handling instructions / service requests of the piece"@en ;
                       rdfs:label "handlingInstructions"@en ;
-                      owl:comment "Possible RDF good practice IRI: :hasHandlingInstructions "@en .
+                      owl:comment "Possible RDF good practice IRI: :hasHandlingInstructions "@en ;
+                      owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#height
@@ -1062,14 +1147,14 @@ owl:thing rdf:type rdfs:Datatype .
                owl:versionInfo "v3.0 renamed from insurance:insuranceAmount"@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#insuredShipment
-:insuredShipment rdf:type owl:ObjectProperty ;
-                 rdfs:domain :Insurance ;
-                 rdfs:range :Shipment ;
-                 rdfs:comment "Reference to the shipment insured"@en ;
-                 rdfs:label "insuredShipment"@en ;
-                 owl:comment "Possible RDF good practice IRI: :insuresShipment "@en ;
-                 owl:versionInfo "v3.0 renamed from insurance:insuranceShipment"@en .
+###  https://onerecord.iata.org/ns/cargo#insuredShipments
+:insuredShipments rdf:type owl:ObjectProperty ;
+                  rdfs:domain :Insurance ;
+                  rdfs:range :Shipment ;
+                  rdfs:comment "Reference to the shipments insured"@en ;
+                  rdfs:label "insuredShipments"@en ;
+                  owl:comment "Possible RDF good practice IRI: :insuresShipment "@en ;
+                  owl:versionInfo "v3.0 renamed from insurance:insuranceShipment"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#involvedInActions
@@ -1378,6 +1463,22 @@ owl:thing rdf:type rdfs:Datatype .
                       owl:versionInfo "v3.0 renamed from product:characteristics"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#otherChargeAmount
+:otherChargeAmount rdf:type owl:ObjectProperty ;
+                   rdfs:domain :OtherCharge ;
+                   rdfs:range :Value ;
+                   rdfs:comment "PENDING"@en ;
+                   rdfs:label "otherChargeAmount"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#otherCharges
+:otherCharges rdf:type owl:ObjectProperty ;
+              rdfs:domain :Waybill ;
+              rdfs:range :OtherCharge ;
+              rdfs:comment "Information about Other Charges applying to this Waybill"@en ;
+              rdfs:label "otherCharges"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#otherIdentifiers
 :otherIdentifiers rdf:type owl:ObjectProperty ;
                   rdfs:domain owl:Thing ;
@@ -1545,6 +1646,22 @@ owl:thing rdf:type rdfs:Datatype .
         rdfs:comment "Reference to the ranges"@en ;
         rdfs:label "ranges"@en ;
         owl:comment "Possible RDF good practice IRI: :hasRange "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#rateCharge
+:rateCharge rdf:type owl:ObjectProperty ;
+            rdfs:domain :TACTRateDescription ;
+            rdfs:range :Value ;
+            rdfs:comment "PENDING"@en ;
+            rdfs:label "rateCharge"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#ratePercentage
+:ratePercentage rdf:type owl:ObjectProperty ;
+                rdfs:domain :TACTRateDescription ;
+                rdfs:range :Value ;
+                rdfs:comment "PENDING"@en ;
+                rdfs:label "ratePercentage"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#ratings
@@ -1821,6 +1938,14 @@ owl:thing rdf:type rdfs:Datatype .
                  owl:comment "Possible RDF good practice IRI: :hasSubOrganization "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#tactRateDescriptions
+:tactRateDescriptions rdf:type owl:ObjectProperty ;
+                      rdfs:domain :Waybill ;
+                      rdfs:range :TACTRateDescription ;
+                      rdfs:comment "Information about TACT rates applying to this Waybill"@en ;
+                      rdfs:label "tactRateDescriptions"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#tareWeight
 :tareWeight rdf:type owl:ObjectProperty ;
             rdfs:domain :LoadingUnit ;
@@ -1864,6 +1989,14 @@ owl:thing rdf:type rdfs:Datatype .
                  rdfs:comment "Schedule preferences of the request"@en ;
                  rdfs:label "timePreferences"@en ;
                  owl:comment "Possible RDF good practice IRI: :hasTimePreferences "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#total
+:total rdf:type owl:ObjectProperty ;
+       rdfs:domain :TACTRateDescription ;
+       rdfs:range :Value ;
+       rdfs:comment "PENDING"@en ;
+       rdfs:label "total"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#totalDimensions
@@ -2347,9 +2480,9 @@ owl:thing rdf:type rdfs:Datatype .
 ###  https://onerecord.iata.org/ns/cargo#billingChargeIdentifier
 :billingChargeIdentifier rdf:type owl:DatatypeProperty ;
                          rdfs:domain :Ratings ;
-                         rdfs:range xsd:double ;
-                         rdfs:comment "Subtotal of the charge"@en ;
-                         rdfs:label "subTotal"@en ;
+                         rdfs:range xsd:string ;
+                         rdfs:comment "Billing charge identifiers to be used for CASS. Refer to CargoXML Code List 1.33"@en ;
+                         rdfs:label "billingChargeIdentifier"@en ;
                          owl:comment "Possible RDF good practice IRI: :hasBillingChargeIdentifier "@en .
 
 
@@ -2374,7 +2507,7 @@ owl:thing rdf:type rdfs:Datatype .
 
 ###  https://onerecord.iata.org/ns/cargo#carrierChargeCode
 :carrierChargeCode rdf:type owl:DatatypeProperty ;
-                   rdfs:domain :Price ;
+                   rdfs:domain owl:Thing ;
                    rdfs:range xsd:string ;
                    rdfs:comment "Charge code for carrier, eg. CA, CB, etc"@en ;
                    rdfs:label "carrierChargeCode"@en ;
@@ -2483,7 +2616,7 @@ owl:thing rdf:type rdfs:Datatype .
 
 ###  https://onerecord.iata.org/ns/cargo#chargePaymentType
 :chargePaymentType rdf:type owl:DatatypeProperty ;
-                   rdfs:domain :Ratings ;
+                   rdfs:domain owl:Thing ;
                    rdfs:range [ rdf:type rdfs:Datatype ;
                                 owl:oneOf [ rdf:type rdf:List ;
                                             rdf:first "C" ;
@@ -2500,7 +2633,7 @@ owl:thing rdf:type rdfs:Datatype .
 
 ###  https://onerecord.iata.org/ns/cargo#chargeType
 :chargeType rdf:type owl:DatatypeProperty ;
-            rdfs:domain :Ratings ;
+            rdfs:domain owl:Thing ;
             rdfs:range xsd:string ;
             rdfs:comment "Type of charge that should match the code expressed in either chargeCode, otherChargeCode or billingChargeIndentifier data properties."@en ;
             rdfs:label "chargeType"@en ;
@@ -2591,7 +2724,7 @@ owl:thing rdf:type rdfs:Datatype .
 
 ###  https://onerecord.iata.org/ns/cargo#commodityItemNumber
 :commodityItemNumber rdf:type owl:DatatypeProperty ;
-                     rdfs:domain :Product ;
+                     rdfs:domain owl:Thing ;
                      rdfs:range xsd:string ;
                      rdfs:comment "Indicates the specific commodity on which the rate class code is applied"@en ;
                      rdfs:label "commodityItemNumber"@en ;
@@ -2826,24 +2959,6 @@ List to be provided by local authorities"""@en ;
       owl:comment "Possible RDF good practice IRI: :hasTemplateReleaseDate "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#declaredValueForCarriage
-:declaredValueForCarriage rdf:type owl:DatatypeProperty ;
-                          rdfs:domain :Piece ;
-                          rdfs:range xsd:string ;
-                          rdfs:comment "The value of a shipment declared for carriage purposes , NVD if no value declared"@en ;
-                          rdfs:label "declaredValueForCarriage"@en ;
-                          owl:comment "Possible RDF good practice IRI: :hasDeclaredValueForCarriage "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#declaredValueForCustoms
-:declaredValueForCustoms rdf:type owl:DatatypeProperty ;
-                         rdfs:domain :Piece ;
-                         rdfs:range xsd:string ;
-                         rdfs:comment "The value of a shipment declared for customs purposes , NVD if no value declared"@en ;
-                         rdfs:label "declaredValueForCustoms"@en ;
-                         owl:comment "Possible RDF good practice IRI: :hasDeclaredValueForCustoms "@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#deliveryDate
 :deliveryDate rdf:type owl:DatatypeProperty ;
               rdfs:domain :Shipment ;
@@ -3043,7 +3158,7 @@ List to be provided by local authorities"""@en ;
 
 ###  https://onerecord.iata.org/ns/cargo#entitlement
 :entitlement rdf:type owl:DatatypeProperty ;
-             rdfs:domain :Ratings ;
+             rdfs:domain owl:Thing ;
              rdfs:range [ rdf:type rdfs:Datatype ;
                           owl:oneOf [ rdf:type rdf:List ;
                                       rdf:first "A" ;
@@ -4025,7 +4140,8 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
               rdfs:range xsd:boolean ;
               rdfs:comment "When no value is declared for Insurance this field should be completed with the value TRUE otherwise FALSE"@en ;
               rdfs:label "nvdIndicator"@en ;
-              owl:comment "Possible RDF good practice IRI: :hasNvdIndicator "@en .
+              owl:comment "Possible RDF good practice IRI: :hasNvdIndicator "@en ;
+              owl:deprecated "true"^^xsd:boolean .
 
 
 ###  https://onerecord.iata.org/ns/cargo#odlnCode
@@ -4085,7 +4201,7 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
 
 ###  https://onerecord.iata.org/ns/cargo#otherChargeCode
 :otherChargeCode rdf:type owl:DatatypeProperty ;
-                 rdfs:domain :Ratings ;
+                 rdfs:domain owl:Thing ;
                  rdfs:range xsd:string ;
                  rdfs:comment "Refer to CargoXML Code List 1.2 for Other Charges"@en ;
                  rdfs:label "otherChargeCode" ;
@@ -4094,7 +4210,7 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
 
 ###  https://onerecord.iata.org/ns/cargo#otherChargesIndicator
 :otherChargesIndicator rdf:type owl:DatatypeProperty ;
-                       rdfs:domain :Shipment ;
+                       rdfs:domain :Waybill ;
                        rdfs:range [ rdf:type rdfs:Datatype ;
                                     owl:oneOf [ rdf:type rdf:List ;
                                                 rdf:first "C" ;
@@ -4277,6 +4393,14 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                       owl:comment "Possible RDF good practice IRI: :hasPhysicalChemicalForm "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#pieceCountForRate
+:pieceCountForRate rdf:type owl:DatatypeProperty ;
+                   rdfs:domain :TACTRateDescription ;
+                   rdfs:range xsd:integer ;
+                   rdfs:comment "PENDING"@en ;
+                   rdfs:label "pieceCountForRate"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#postOfficeBox
 :postOfficeBox rdf:type owl:DatatypeProperty ;
                rdfs:domain :Address ;
@@ -4437,11 +4561,19 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
 
 ###  https://onerecord.iata.org/ns/cargo#rateClassCode
 :rateClassCode rdf:type owl:DatatypeProperty ;
-               rdfs:domain :Ranges ;
+               rdfs:domain owl:Thing ;
                rdfs:range xsd:string ;
                rdfs:comment "Rate class code e.g. Q. Refer to CXML Code List 1.4 Rate Class Codes"@en ;
                rdfs:label "rateClassCode"@en ;
                owl:comment "Possible RDF good practice IRI: :hasRateClassCode "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#rateClassCodeBasic
+:rateClassCodeBasic rdf:type owl:DatatypeProperty ;
+                    rdfs:domain :TACTRateDescription ;
+                    rdfs:range xsd:string ;
+                    rdfs:comment "PENDING"@en ;
+                    rdfs:label "rateClassCodeBasic"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#rateQuantity
@@ -4484,7 +4616,7 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
 
 ###  https://onerecord.iata.org/ns/cargo#rcp
 :rcp rdf:type owl:DatatypeProperty ;
-     rdfs:domain :Ratings ;
+     rdfs:domain owl:Thing ;
      rdfs:range xsd:string ;
      rdfs:comment "IATA 3-letter code of the rate combination point"@en ;
      rdfs:label "rcp"@en ;
@@ -4816,6 +4948,14 @@ AOM - Subjected to any other means: this entry should be followed by free text s
               owl:comment "Possible RDF good practice IRI: :hasSerialNumber "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#serviceCode
+:serviceCode rdf:type owl:DatatypeProperty ;
+             rdfs:domain :Waybill ;
+             rdfs:range xsd:string ;
+             rdfs:comment "PENDING"@en ;
+             rdfs:label "serviceCode"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#serviceabilityCode
 :serviceabilityCode rdf:type owl:DatatypeProperty ;
                     rdfs:domain :LoadingUnit ;
@@ -4984,7 +5124,7 @@ AOM - Subjected to any other means: this entry should be followed by free text s
 
 ###  https://onerecord.iata.org/ns/cargo#slac
 :slac rdf:type owl:DatatypeProperty ;
-      rdfs:domain :Piece ;
+      rdfs:domain :PhysicalLogisticsObject ;
       rdfs:range xsd:integer ;
       rdfs:comment "Shipper's Load And Count  ( total contained piece count as provided by shipper)"@en ;
       rdfs:label "slac"@en ;
@@ -5007,6 +5147,13 @@ AOM - Subjected to any other means: this entry should be followed by free text s
                       rdfs:comment "A notation that the material is special form"@en ;
                       rdfs:label "specialFormIndicator"@en ;
                       owl:comment "Possible RDF good practice IRI: :isSpecialForm "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#specialHandlingCodes
+:specialHandlingCodes rdf:type owl:DatatypeProperty ;
+                      rdfs:domain :Piece ;
+                      rdfs:comment "Three-letter special handling code (SPH)"@en ;
+                      rdfs:label "specialHandlingCodes"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#specialProvisionId
@@ -5110,6 +5257,8 @@ AOM - Subjected to any other means: this entry should be followed by free text s
 
 ###  https://onerecord.iata.org/ns/cargo#subTotal
 :subTotal rdf:type owl:DatatypeProperty ;
+          rdfs:domain :Ratings ;
+          rdfs:range xsd:double ;
           rdfs:comment "Subtotal of the charge"@en ;
           rdfs:label "subTotal"@en ;
           owl:comment "Possible RDF good practice IRI: :hasSubTotal "@en .
@@ -5169,6 +5318,14 @@ Condition: At least one of the three elements (Country Code, Information Identif
       rdfs:comment "Text for the Answer"@en ;
       rdfs:label "text"@en ;
       owl:comment "Possible RDF good practice IRI: :hasAnswerText "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#textualHandlingInstructions
+:textualHandlingInstructions rdf:type owl:DatatypeProperty ;
+                             rdfs:domain :Piece ;
+                             rdfs:range xsd:string ;
+                             rdfs:comment "Strings to provide free text handling instructions such as SSR and OSI"@en ;
+                             rdfs:label "textualHandlingInstructions"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#textualValue
@@ -5326,6 +5483,14 @@ Condition: At least one of the three elements (Country Code, Information Identif
           rdfs:comment "Packaging type identifier as per UNECE Rec 21 Annex V and VI e.g. 1A - Drum, steel - Packaging material code. Identifies the Logistic Unit package type. UN Recommendation on Transport of Dangerous Goods, Model Regulations "@en ;
           rdfs:label "typeCode"@en ;
           owl:comment "Possible RDF good practice IRI: :hasTypeCode "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#uldRateClassType
+:uldRateClassType rdf:type owl:DatatypeProperty ;
+                  rdfs:domain :TACTRateDescription ;
+                  rdfs:range xsd:integer ;
+                  rdfs:comment "PENDING"@en ;
+                  rdfs:label "uldRateClassType"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#uldSerialNumber
@@ -5523,7 +5688,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
 
 ###  https://onerecord.iata.org/ns/cargo#weightValuationIndicator
 :weightValuationIndicator rdf:type owl:DatatypeProperty ;
-                          rdfs:domain :Shipment ;
+                          rdfs:domain :Waybill ;
                           rdfs:range [ rdf:type rdfs:Datatype ;
                                        owl:oneOf [ rdf:type rdf:List ;
                                                    rdf:first "C" ;
@@ -6222,6 +6387,10 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                  ] ,
                                  [ rdf:type owl:Restriction ;
                                    owl:onProperty :loadType ;
+                                   owl:allValuesFrom xsd:string
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty :textualHandlingInstructions ;
                                    owl:allValuesFrom xsd:string
                                  ] ,
                                  [ rdf:type owl:Restriction ;
@@ -7325,7 +7494,8 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                         owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                       ] ;
                       rdfs:comment "Used to provide handling instructions such as Special service request (SSR), Special handling codes (SPH) or Other service information (OSI)"@en ;
-                      rdfs:label "HandlingInstructions"@en .
+                      rdfs:label "HandlingInstructions"@en ;
+                      owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#Insurance
@@ -7340,7 +7510,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
                              owl:allValuesFrom :Value
                            ] ,
                            [ rdf:type owl:Restriction ;
-                             owl:onProperty :insuredShipment ;
+                             owl:onProperty :insuredShipments ;
                              owl:allValuesFrom :Shipment
                            ] ,
                            [ rdf:type owl:Restriction ;
@@ -7349,10 +7519,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                            ] ,
                            [ rdf:type owl:Restriction ;
                              owl:onProperty :insuredAmount ;
-                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty :insuredShipment ;
                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
                            ] ,
                            [ rdf:type owl:Restriction ;
@@ -7840,7 +8006,15 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                owl:allValuesFrom xsd:string
                              ] ,
                              [ rdf:type owl:Restriction ;
+                               owl:onProperty :slac ;
+                               owl:allValuesFrom xsd:integer
+                             ] ,
+                             [ rdf:type owl:Restriction ;
                                owl:onProperty :remarks ;
+                               owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty :slac ;
                                owl:maxCardinality "1"^^xsd:nonNegativeInteger
                              ] ;
              rdfs:comment "Common loading unit/container details"@en ;
@@ -8294,6 +8468,44 @@ Condition: At least one of the three elements (Country Code, Information Identif
               rdfs:label "Organization"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#OtherCharge
+:OtherCharge rdf:type owl:Class ;
+             rdfs:subClassOf [ rdf:type owl:Restriction ;
+                               owl:onProperty :otherChargeAmount ;
+                               owl:allValuesFrom :Value
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty :otherChargeAmount ;
+                               owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty :chargePaymentType ;
+                               owl:allValuesFrom xsd:string
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty :entitlement ;
+                               owl:allValuesFrom xsd:string
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty :otherChargeCode ;
+                               owl:allValuesFrom xsd:string
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty :chargePaymentType ;
+                               owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty :entitlement ;
+                               owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty :otherChargeCode ;
+                               owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                             ] ;
+             rdfs:comment "PENDING"@en ;
+             rdfs:label "OtherCharge"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#OtherIdentifier
 :OtherIdentifier rdf:type owl:Class ;
                  rdfs:subClassOf [ rdf:type owl:Restriction ;
@@ -8587,14 +8799,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                          owl:allValuesFrom xsd:boolean
                        ] ,
                        [ rdf:type owl:Restriction ;
-                         owl:onProperty :declaredValueForCarriage ;
-                         owl:allValuesFrom xsd:string
-                       ] ,
-                       [ rdf:type owl:Restriction ;
-                         owl:onProperty :declaredValueForCustoms ;
-                         owl:allValuesFrom xsd:string
-                       ] ,
-                       [ rdf:type owl:Restriction ;
                          owl:onProperty :fulfillsUldTypeCode ;
                          owl:allValuesFrom xsd:string
                        ] ,
@@ -8631,8 +8835,16 @@ Condition: At least one of the three elements (Country Code, Information Identif
                          owl:allValuesFrom xsd:integer
                        ] ,
                        [ rdf:type owl:Restriction ;
+                         owl:onProperty :specialHandlingCodes ;
+                         owl:allValuesFrom xsd:string
+                       ] ,
+                       [ rdf:type owl:Restriction ;
                          owl:onProperty :stackable ;
                          owl:allValuesFrom xsd:boolean
+                       ] ,
+                       [ rdf:type owl:Restriction ;
+                         owl:onProperty :textualHandlingInstructions ;
+                         owl:allValuesFrom xsd:string
                        ] ,
                        [ rdf:type owl:Restriction ;
                          owl:onProperty :turnable ;
@@ -8644,14 +8856,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                        ] ,
                        [ rdf:type owl:Restriction ;
                          owl:onProperty :coload ;
-                         owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                       ] ,
-                       [ rdf:type owl:Restriction ;
-                         owl:onProperty :declaredValueForCarriage ;
-                         owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                       ] ,
-                       [ rdf:type owl:Restriction ;
-                         owl:onProperty :declaredValueForCustoms ;
                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
                        ] ,
                        [ rdf:type owl:Restriction ;
@@ -9708,7 +9912,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
 
 ###  https://onerecord.iata.org/ns/cargo#Shipment
 :Shipment rdf:type owl:Class ;
-          rdfs:subClassOf :PhysicalLogisticsObject ,
+          rdfs:subClassOf :LogisticsObject ,
                           [ rdf:type owl:Restriction ;
                             owl:onProperty :deliveryLocation ;
                             owl:allValuesFrom :Location
@@ -9774,16 +9978,16 @@ Condition: At least one of the three elements (Country Code, Information Identif
                             owl:allValuesFrom xsd:string
                           ] ,
                           [ rdf:type owl:Restriction ;
-                            owl:onProperty :otherChargesIndicator ;
+                            owl:onProperty :specialHandlingCodes ;
+                            owl:allValuesFrom xsd:string
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty :textualHandlingInstructions ;
                             owl:allValuesFrom xsd:string
                           ] ,
                           [ rdf:type owl:Restriction ;
                             owl:onProperty :totalSLAC ;
                             owl:allValuesFrom xsd:integer
-                          ] ,
-                          [ rdf:type owl:Restriction ;
-                            owl:onProperty :weightValuationIndicator ;
-                            owl:allValuesFrom xsd:string
                           ] ,
                           [ rdf:type owl:Restriction ;
                             owl:onProperty :deliveryDate ;
@@ -9798,15 +10002,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
                           ] ,
                           [ rdf:type owl:Restriction ;
-                            owl:onProperty :otherChargesIndicator ;
-                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                          ] ,
-                          [ rdf:type owl:Restriction ;
                             owl:onProperty :totalSLAC ;
-                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                          ] ,
-                          [ rdf:type owl:Restriction ;
-                            owl:onProperty :weightValuationIndicator ;
                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
                           ] ;
           rdfs:comment "Shipment details"@en ;
@@ -9857,6 +10053,146 @@ Condition: At least one of the three elements (Country Code, Information Identif
                          ] ;
          rdfs:comment "Action to describe store-in or store-out"@en ;
          rdfs:label "Storing"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#TACTRateDescription
+:TACTRateDescription rdf:type owl:Class ;
+                     rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                       owl:onProperty :chargeableWeightForRate ;
+                                       owl:allValuesFrom :Value
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty :grossWeightForRate ;
+                                       owl:allValuesFrom :Value
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty :rateCharge ;
+                                       owl:allValuesFrom :Value
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty :ratePercentage ;
+                                       owl:allValuesFrom :Value
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty :total ;
+                                       owl:allValuesFrom :Value
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty :chargeableWeightForRate ;
+                                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty :grossWeightForRate ;
+                                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty :rateCharge ;
+                                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty :ratePercentage ;
+                                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty :total ;
+                                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty :commodityItemNumber ;
+                                       owl:allValuesFrom xsd:string
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty :pieceCountForRate ;
+                                       owl:allValuesFrom xsd:integer
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty :rateClassCode ;
+                                       owl:allValuesFrom xsd:string
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty :rateClassCodeBasic ;
+                                       owl:allValuesFrom xsd:string
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty :rcp ;
+                                       owl:allValuesFrom xsd:string
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty :uldRateClassType ;
+                                       owl:allValuesFrom xsd:integer
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty :commodityItemNumber ;
+                                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty :pieceCountForRate ;
+                                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty :rateClassCode ;
+                                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty :rateClassCodeBasic ;
+                                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty :rcp ;
+                                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty :uldRateClassType ;
+                                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                     ] ;
+                     rdfs:comment "PENDING"@en ;
+                     rdfs:label "TACTRateDescription"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#TotalCharge
+:TotalCharge rdf:type owl:Class ;
+             rdfs:subClassOf [ rdf:type owl:Restriction ;
+                               owl:onProperty :amountTotal ;
+                               owl:allValuesFrom :Value
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty :collectChargesInDestinationCurrency ;
+                               owl:allValuesFrom :Value
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty :currencyConversionRate ;
+                               owl:allValuesFrom :Value
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty :amountTotal ;
+                               owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty :collectChargesInDestinationCurrency ;
+                               owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty :currencyConversionRate ;
+                               owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty :chargePaymentType ;
+                               owl:allValuesFrom xsd:string
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty :chargeType ;
+                               owl:allValuesFrom xsd:string
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty :chargePaymentType ;
+                               owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty :chargeType ;
+                               owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                             ] ;
+             rdfs:comment "PENDING"@en ;
+             rdfs:label "TotalCharge"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#TransportMeans
@@ -10239,6 +10575,22 @@ Condition: At least one of the three elements (Country Code, Information Identif
                            owl:allValuesFrom :Location
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty :chargeTotals ;
+                           owl:allValuesFrom :TotalCharge
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :chargesAtDestination ;
+                           owl:allValuesFrom :Value
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :declaredValueForCarriage ;
+                           owl:allValuesFrom :Value
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :declaredValueForCustoms ;
+                           owl:allValuesFrom :Value
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty :departureLocation ;
                            owl:allValuesFrom :Location
                          ] ,
@@ -10255,12 +10607,20 @@ Condition: At least one of the three elements (Country Code, Information Identif
                            owl:allValuesFrom :Waybill
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty :otherCharges ;
+                           owl:allValuesFrom :OtherCharge
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty :referredBookingOption ;
                            owl:allValuesFrom :Booking
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :shipment ;
                            owl:allValuesFrom :Shipment
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :tactRateDescriptions ;
+                           owl:allValuesFrom :TACTRateDescription
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :arrivalLocation ;
@@ -10272,6 +10632,18 @@ Condition: At least one of the three elements (Country Code, Information Identif
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :carrierDeclarationPlace ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :chargesAtDestination ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :declaredValueForCarriage ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :declaredValueForCustoms ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
@@ -10292,6 +10664,10 @@ Condition: At least one of the three elements (Country Code, Information Identif
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :accountingInformation ;
+                           owl:allValuesFrom xsd:string
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :carrierChargeCode ;
                            owl:allValuesFrom xsd:string
                          ] ,
                          [ rdf:type owl:Restriction ;
@@ -10331,6 +10707,14 @@ Condition: At least one of the three elements (Country Code, Information Identif
                            owl:allValuesFrom xsd:string
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty :otherChargesIndicator ;
+                           owl:allValuesFrom xsd:string
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :serviceCode ;
+                           owl:allValuesFrom xsd:string
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty :shippingInfo ;
                            owl:allValuesFrom xsd:string
                          ] ,
@@ -10351,7 +10735,15 @@ Condition: At least one of the three elements (Country Code, Information Identif
                            owl:allValuesFrom xsd:string
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty :weightValuationIndicator ;
+                           owl:allValuesFrom xsd:string
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty :accountingInformation ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :carrierChargeCode ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
@@ -10387,6 +10779,14 @@ Condition: At least one of the three elements (Country Code, Information Identif
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty :otherChargesIndicator ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :serviceCode ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty :shippingInfo ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
@@ -10404,6 +10804,10 @@ Condition: At least one of the three elements (Country Code, Information Identif
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :waybillType ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :weightValuationIndicator ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ;
          rdfs:comment "Waybill details"@en ;

--- a/working_draft/ontology/IATA-1R-DM-Ontology.ttl
+++ b/working_draft/ontology/IATA-1R-DM-Ontology.ttl
@@ -6,16 +6,16 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix terms: <http://purl.org/dc/terms/> .
-@prefix ccodes: <<https://onerecord.iata.org/ns/coreCodeLists#> .
+@prefix ccodes: <https://onerecord.iata.org/ns/coreCodeLists#> .
 @base <https://onerecord.iata.org/ns/cargo> .
 
 <https://onerecord.iata.org/ns/cargo> rdf:type owl:Ontology ;
-                                       owl:versionIRI <https://onerecord.iata.org/ns/cargo/3.0.0-RC5g> ;
-                                       owl:imports <https://onerecord.iata.org/ns/coreCodeLists/0.0.2> ;
+                                       owl:versionIRI <https://onerecord.iata.org/ns/cargo/3.0.0-RC5> ;
+                                       owl:imports <https://onerecord.iata.org/ns/coreCodeLists/0.0.3> ;
                                        dc:description "The ONE Record vocabulary, described using W3C RDF Schema and the Web Ontology Language."@en ;
                                        dc:title "ONE Record Ontology"@en ;
                                        terms:abstract "The ontology of the ONE Record standard is the core data model underlying the Linked Data solution drafted by the ONE Record standard: https://github.com/IATA-Cargo/ONE-Record. ONE Record is a standard for data sharing and creates a single record view of the shipment. This standard defines a common data model for the data that is shared via standardized and secured web API."@en ;
-                                       terms:modified "28-08-2023" ;
+                                       terms:modified "31-08-2023" ;
                                        terms:title "ONE Record Ontology"@en ;
                                        rdfs:comment """Details availalble on GitHub https://github.com/IATA-Cargo/ONE-Record
 Version 2.0.0
@@ -99,10 +99,14 @@ Version 3.0.0 RC5f - Code list integration part I - Integration playbook pending
 - Added otherIdentifier to LogisticActions to be able to transmit custom identifiers such as Loading/Unloading lists in trucking/milk runs
 Version 3.0.0 RC5g - Code list integration part II - Integration playbook pending
 - Converted the remaning enums into code lists
-- Aligned with core code lists ontology 0.0.2"""@en ;
+- Aligned with core code lists ontology 0.0.2
+Version 3.0.0 RC5h 
+- Initial implementation of MCD 2.0 - not bug-fixed yet
+- Details to come from IATA
+- Aligned with core code lists ontology 0.0.3"""@en ;
                                        rdfs:isDefinedBy "https://www.iata.org/one-record/"^^xsd:anyURI ;
                                        rdfs:label "ONE Record Ontology"@en ;
-                                       owl:versionInfo "3.0.0 RC 5g"@en .
+                                       owl:versionInfo "3.0.0 RC 5"@en .
 
 #################################################################
 #    Annotation properties
@@ -234,11 +238,10 @@ owl:thing rdf:type rdfs:Datatype .
 
 ###  https://onerecord.iata.org/ns/cargo#aircraftPossibilityCode
 :aircraftPossibilityCode rdf:type owl:ObjectProperty ;
-                         rdfs:domain :Routing ;
+                         rdfs:domain :BookingPreferences ;
                          rdfs:range ccodes:AircraftPossibilityCode ;
-                         rdfs:comment "Aircraft possibility code - Refers to CXML Code List 1.46 that contains values such as \"Pure freighter flight carrying Loose Load Cargo - BBF\""@en ;
-                         rdfs:label "aircraftPossibilityCode"@en ;
-                         owl:comment "Possible RDF good practice IRI: :hasAircraftPossibilityCode "@en .
+                         rdfs:comment "Type of aircraft to be used if any specific requirements (e.g. Pure freighter, etc.)"@en ;
+                         rdfs:label "aircraftPossibilityCode"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#amountTotal
@@ -390,7 +393,7 @@ owl:thing rdf:type rdfs:Datatype .
 :bookingOption rdf:type owl:ObjectProperty ;
                rdfs:domain owl:Thing ;
                rdfs:range :BookingOption ;
-               rdfs:comment "Reference to the BookingOptions"@en ;
+               rdfs:comment "Reference to the BookingOption"@en ;
                rdfs:label "bookingOption"@en ;
                owl:comment "Possible RDF good practice IRI: :hasBookingOption "@en .
 
@@ -400,9 +403,32 @@ owl:thing rdf:type rdfs:Datatype .
                       rdfs:domain owl:Thing ;
                       rdfs:range :BookingOptionRequest ;
                       rdfs:comment "Reference to the BookingOptionRequest"@en ;
-                      rdfs:label "bookingOptionRequest"@en ,
-                                 "requests"@en ;
+                      rdfs:label "bookingOptionRequest"@en ;
                       owl:comment "Possible RDF good practice IRI: :hasBookingOptionRequest "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#bookingOptionRequestId
+:bookingOptionRequestId rdf:type owl:ObjectProperty ;
+                        rdfs:domain :BookingOption ;
+                        rdfs:range :BookingOptionRequest ;
+                        rdfs:comment "Reference to the Booking Option Request"@en ;
+                        rdfs:label "bookingOptionRequestId"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#bookingOptions
+:bookingOptions rdf:type owl:ObjectProperty ;
+                rdfs:domain :BookingOptionRequest ;
+                rdfs:range :BookingOption ;
+                rdfs:comment "Reference to all Booking Options"@en ;
+                rdfs:label "bookingOptions"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#bookingPreference
+:bookingPreference rdf:type owl:ObjectProperty ;
+                   rdfs:domain :BookingOptionRequest ;
+                   rdfs:range :BookingPreferences ;
+                   rdfs:comment "Reference to the Booking preferences"@en ;
+                   rdfs:label "bookingPreference"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#bookingRef
@@ -414,13 +440,22 @@ owl:thing rdf:type rdfs:Datatype .
             owl:deprecated "true"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#bookingRequestId
+:bookingRequestId rdf:type owl:ObjectProperty ;
+                  rdfs:domain :Booking ;
+                  rdfs:range :BookingRequest ;
+                  rdfs:comment "Reference to the Booking Request"@en ;
+                  rdfs:label "bookingRequestId"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#bookingSegment
 :bookingSegment rdf:type owl:ObjectProperty ;
                 rdfs:domain owl:Thing ;
                 rdfs:range :BookingSegment ;
                 rdfs:comment "Reference to the Booking Segment"@en ;
                 rdfs:label "bookingSegment"@en ;
-                owl:comment "Possible RDF good practice IRI: :hasBookingSegment "@en .
+                owl:comment "Possible RDF good practice IRI: :hasBookingSegment "@en ;
+                owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#bookingShipmentDetails
@@ -432,13 +467,30 @@ owl:thing rdf:type rdfs:Datatype .
                         owl:comment "Possible RDF good practice IRI: :hasBookingShipment "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#bookingStatus
+:bookingStatus rdf:type owl:ObjectProperty ;
+               rdfs:domain :Booking ;
+               rdfs:range :BookingStatus ;
+               rdfs:comment "Status of the Booking"@en ;
+               rdfs:label "bookingStatus"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#bookingTimes
 :bookingTimes rdf:type owl:ObjectProperty ;
               rdfs:domain :BookingOption ;
               rdfs:range :BookingTimes ;
               rdfs:comment "booking times details of the Booking Option (proposed or actual)"@en ;
               rdfs:label "bookingTimes"@en ;
-              owl:comment "Possible RDF good practice IRI: :hasBookingTime "@en .
+              owl:comment "Possible RDF good practice IRI: :hasBookingTime "@en ;
+              owl:deprecated "true"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#bookingToUpdate
+:bookingToUpdate rdf:type owl:ObjectProperty ;
+                 rdfs:domain :BookingOptionRequest ;
+                 rdfs:range :Booking ;
+                 rdfs:comment "Reference to the Booking to update"@en ;
+                 rdfs:label "bookingToUpdate"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#branch
@@ -471,12 +523,11 @@ owl:thing rdf:type rdfs:Datatype .
 
 ###  https://onerecord.iata.org/ns/cargo#carrier
 :carrier rdf:type owl:ObjectProperty ;
-         rdfs:domain :Waybill ;
-         rdfs:range :Organization ;
-         rdfs:comment "Reference to the Organization that fulfills the role of the carrier in this Waybill"@en ;
+         rdfs:domain :BookingOption ;
+         rdfs:range :Carrier ;
+         rdfs:comment "Reference to the operating carrier"@en ;
          rdfs:label "carrier"@en ;
-         owl:comment "Possible RDF good practice IRI: :hasCarrier "@en ;
-         owl:deprecated "true"@en .
+         owl:comment "Possible RDF good practice IRI: :hasCarrier "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#carrierChargeCode
@@ -498,13 +549,23 @@ owl:thing rdf:type rdfs:Datatype .
                          owl:comment "Possible RDF good practice IRI: :hasCarrierDeclarationPlace "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#carrierProduct
+:carrierProduct rdf:type owl:ObjectProperty ;
+                rdfs:domain :BookingOption ,
+                            :BookingOptionRequest ;
+                rdfs:range :CarrierProduct ;
+                rdfs:comment "Reference to the Carrier product if known"@en ;
+                rdfs:label "carrierProduct"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#carrierProductInfo
 :carrierProductInfo rdf:type owl:ObjectProperty ;
                     rdfs:domain :BookingOption ;
                     rdfs:range :CarrierProduct ;
                     rdfs:comment "Reference to the Carrier products included in the offer"@en ;
                     rdfs:label "carrierProductInfo"@en ;
-                    owl:comment "Possible RDF good practice IRI: :isOfCarrierProduct "@en .
+                    owl:comment "Possible RDF good practice IRI: :isOfCarrierProduct "@en ;
+                    owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#certifiedByActor
@@ -518,7 +579,7 @@ owl:thing rdf:type rdfs:Datatype .
 
 ###  https://onerecord.iata.org/ns/cargo#chargeCode
 :chargeCode rdf:type owl:ObjectProperty ;
-            rdfs:domain :Ratings ;
+            rdfs:domain :Price ;
             rdfs:range ccodes:ChargeCode ;
             rdfs:comment "Charge code, refer to CargoXML Code List 1.1"@en ;
             rdfs:label "chargeCode"@en ;
@@ -641,7 +702,7 @@ owl:thing rdf:type rdfs:Datatype .
 
 ###  https://onerecord.iata.org/ns/cargo#co2Emissions
 :co2Emissions rdf:type owl:ObjectProperty ;
-              rdfs:domain :TransportMovement ;
+              rdfs:domain :LogisticsObject ;
               rdfs:range :CO2Emissions ;
               rdfs:comment "References to CO2Emissions"@en ;
               rdfs:label "co2Emissions"@en ;
@@ -893,6 +954,14 @@ Condition: At least one of the three elements (Country Code, Information Identif
                    owl:comment "Possible RDF good practice IRI: :isCreatedAt "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#currency
+:currency rdf:type owl:ObjectProperty ;
+          rdfs:domain :UnitsPreference ;
+          rdfs:range ccodes:CurrencyCode ;
+          rdfs:comment "Preferred unit for currency"@en ;
+          rdfs:label "currency"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#currencyConversionRate
 :currencyConversionRate rdf:type owl:ObjectProperty ;
                         rdfs:domain :TotalCharge ;
@@ -1057,6 +1126,14 @@ List to be provided by local authorities"""@en ;
             owl:comment "Possible RDF good practice IRI: :hasDimensions "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#dimensionsUnit
+:dimensionsUnit rdf:type owl:ObjectProperty ;
+                rdfs:domain :UnitsPreference ;
+                rdfs:range ccodes:DimensionsUnitCode ;
+                rdfs:comment "Preferred unit for measurement and dimensions"@en ;
+                rdfs:label "dimensionsUnit"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#direction
 :direction rdf:type owl:ObjectProperty ;
            rdfs:domain :MovementTime ;
@@ -1092,6 +1169,14 @@ List to be provided by local authorities"""@en ;
            rdfs:label "documents"@en ;
            owl:comment "Possible RDF good practice IRI: :hasDocument "@en ;
            owl:versionInfo "Added in v1.1"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#dryIceWeight
+:dryIceWeight rdf:type owl:ObjectProperty ;
+              rdfs:domain :PieceGroup ;
+              rdfs:range :Value ;
+              rdfs:comment "Weight of dry ice"@en ;
+              rdfs:label "dryIceWeight"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#elevation
@@ -1179,7 +1264,7 @@ List to be provided by local authorities"""@en ;
 
 ###  https://onerecord.iata.org/ns/cargo#excludedViaPoints
 :excludedViaPoints rdf:type owl:ObjectProperty ;
-                   rdfs:domain :Routing ;
+                   rdfs:domain :BookingPreferences ;
                    rdfs:range :Location ;
                    rdfs:comment "Locations of excluded Via Points"@en ;
                    rdfs:label "excludedViaPoints"@en ;
@@ -1193,6 +1278,22 @@ List to be provided by local authorities"""@en ;
                  rdfs:comment "Enum stating the status of the Activity"@en ;
                  rdfs:label "executionStatus"@en ;
                  owl:comment "Possible RDF good practice IRI: :hasExecutionStatus "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#expectedCommodity
+:expectedCommodity rdf:type owl:ObjectProperty ;
+                   rdfs:domain :BookingShipment ;
+                   rdfs:range ccodes:CommodityCode ;
+                   rdfs:comment "Expected commodity of the shipment as per Commodity Code list. Either this or expected HS code required"@en ;
+                   rdfs:label "expectedCommodity"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#expectedHScode
+:expectedHScode rdf:type owl:ObjectProperty ;
+                rdfs:domain :BookingShipment ;
+                rdfs:range :CodeListElement ;
+                rdfs:comment "Expected commodity of the shipment as per HS code (at least 6 digits). Either this or expectedCommodityCode required"@en ;
+                rdfs:label "expectedHScode"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#explosiveCompatibilityGroupCode
@@ -1247,7 +1348,8 @@ List to be provided by local authorities"""@en ;
                    rdfs:range :BookingRequest ;
                    rdfs:comment "Reference to the BookingOptionRequest the LogisticsObject is detailling"@en ;
                    rdfs:label "forBookingRequest"@en ;
-                   owl:comment "Possible RDF good practice IRI: :isForBookingRequested "@en .
+                   owl:comment "Possible RDF good practice IRI: :isForBookingRequested "@en ;
+                   owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#forEpermit
@@ -1293,7 +1395,8 @@ List to be provided by local authorities"""@en ;
              rdfs:range :Carrier ;
              rdfs:comment "Carrier details"@en ;
              rdfs:label "fromCarrier"@en ;
-             owl:comment "Possible RDF good practice IRI: :isFromCarrier "@en .
+             owl:comment "Possible RDF good practice IRI: :isFromCarrier "@en ;
+             owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#fuelAmountCalculated
@@ -1392,9 +1495,10 @@ TRNS - transfer or transshipment"""@en ;
 
 ###  https://onerecord.iata.org/ns/cargo#handlingInstructions
 :handlingInstructions rdf:type owl:ObjectProperty ;
-                      rdfs:domain :Piece ;
+                      rdfs:domain owl:Thing ;
                       rdfs:range :HandlingInstructions ;
-                      rdfs:comment "Links to Handling instructions / service requests of the piece"@en ;
+                      rdfs:comment "Handling instructions such as special handling codes, excluding specific temperature ranges."@en ,
+                                   "Links to Handling instructions / service requests of the piece"@en ;
                       rdfs:label "handlingInstructions"@en ;
                       owl:comment "Possible RDF good practice IRI: :hasHandlingInstructions "@en ;
                       owl:deprecated "true"@en .
@@ -1445,6 +1549,14 @@ TRNS - transfer or transshipment"""@en ;
                    rdfs:range :UnitComposition ;
                    dc:description "Reference to the Unit Composition the LoadingUnit is in"@en ;
                    rdfs:label "inUnitComposition"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#includedViaPoints
+:includedViaPoints rdf:type owl:ObjectProperty ;
+                   rdfs:domain :BookingPreferences ;
+                   rdfs:range :Location ;
+                   rdfs:comment "Locations or stations to included in the routing"@en ;
+                   rdfs:label "includedViaPoints"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#incoterms
@@ -1693,6 +1805,14 @@ TRNS - transfer or transshipment"""@en ;
                owl:comment "Possible RDF good practice IRI: :hasMasterWaybill "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#maxTemperature
+:maxTemperature rdf:type owl:ObjectProperty ;
+                rdfs:domain :TemperatureInstructions ;
+                rdfs:range :Value ;
+                rdfs:comment "Maximum temperature of the range"@en ;
+                rdfs:label "maxTemperature"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#measurementValue
 :measurementValue rdf:type owl:ObjectProperty ;
                   rdfs:domain :Measurement ;
@@ -1731,6 +1851,14 @@ TRNS - transfer or transshipment"""@en ;
                    owl:comment "Possible RDF good practice IRI: :hasRecordedMeasurementOther "@en ;
                    owl:deprecated "true"@en ;
                    owl:versionInfo "v3. renamed from sensorOther:val"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#minTemperature
+:minTemperature rdf:type owl:ObjectProperty ;
+                rdfs:domain :TemperatureInstructions ;
+                rdfs:range :Value ;
+                rdfs:comment "Minimum temperature of the range"@en ;
+                rdfs:label "minTemperature"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#modeCode
@@ -2093,6 +2221,54 @@ TRNS - transfer or transshipment"""@en ;
                       owl:comment "Possible RDF good practice IRI: :hasPhysicalChemicalForm "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#pieceGroupGrossWeight
+:pieceGroupGrossWeight rdf:type owl:ObjectProperty ;
+                       rdfs:domain :PieceGroup ;
+                       rdfs:range :Value ;
+                       rdfs:comment "Total gross weight of the piece group"@en ;
+                       rdfs:label "pieceGroupGrossWeight"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#pieceGroups
+:pieceGroups rdf:type owl:ObjectProperty ;
+             rdfs:domain :BookingShipment ;
+             rdfs:range :PieceGroup ;
+             rdfs:comment "Reference to the Piece groups of the shipment"@en ;
+             rdfs:label "pieceGroups"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#pieceHeight
+:pieceHeight rdf:type owl:ObjectProperty ;
+             rdfs:domain :LoosePiece ;
+             rdfs:range :Value ;
+             rdfs:comment "Height of a single piece"@en ;
+             rdfs:label "pieceHeight"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#pieceLength
+:pieceLength rdf:type owl:ObjectProperty ;
+             rdfs:domain :LoosePiece ;
+             rdfs:range :Value ;
+             rdfs:comment "Length of a single piece"@en ;
+             rdfs:label "pieceLength"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#pieceWeight
+:pieceWeight rdf:type owl:ObjectProperty ;
+             rdfs:domain :LoosePiece ;
+             rdfs:range :Value ;
+             rdfs:comment "Weight of a single piece"@en ;
+             rdfs:label "pieceWeight"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#pieceWidth
+:pieceWidth rdf:type owl:ObjectProperty ;
+            rdfs:domain :LoosePiece ;
+            rdfs:range :Value ;
+            rdfs:comment "Width of a single piece"@en ;
+            rdfs:label "pieceWidth"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#postalCode
 :postalCode rdf:type owl:ObjectProperty ;
             rdfs:domain :Address ;
@@ -2108,7 +2284,8 @@ TRNS - transfer or transshipment"""@en ;
                       rdfs:range :BookingOptionRequest ;
                       rdfs:comment "Reference to the BookingOptionRequests"@en ;
                       rdfs:label "preferenceOfRequests"@en ;
-                      owl:comment "Possible RDF good practice IRI: :isPreferenceOfRequests "@en .
+                      owl:comment "Possible RDF good practice IRI: :isPreferenceOfRequests "@en ;
+                      owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#preferredHandling
@@ -2117,7 +2294,8 @@ TRNS - transfer or transshipment"""@en ;
                    rdfs:range :HandlingInstructions ;
                    rdfs:comment "Information about preferred HandlingInstructions for the BookingShipment"@en ;
                    rdfs:label "preferredHandling"@en ;
-                   owl:comment "Possible RDF good practice IRI: :hasHandlingPreference "@en .
+                   owl:comment "Possible RDF good practice IRI: :hasHandlingPreference "@en ;
+                   owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#price
@@ -2213,7 +2391,8 @@ TRNS - transfer or transshipment"""@en ;
             rdfs:range ccodes:ULDChargeCode ;
             rdfs:comment "rating type - Refer to CXML Code List 1.44 ULD Charge Codes"@en ;
             rdfs:label "ratingType"@en ;
-            owl:comment "Possible RDF good practice IRI: :hasRatingType "@en .
+            owl:comment "Possible RDF good practice IRI: :hasRatingType "@en ;
+            owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#ratings
@@ -2231,7 +2410,8 @@ TRNS - transfer or transshipment"""@en ;
                    rdfs:range :Ratings ;
                    rdfs:comment "Ratings preferences of the request"@en ;
                    rdfs:label "ratingsPreference"@en ;
-                   owl:comment "Possible RDF good practice IRI: :hasRatingsPreference "@en .
+                   owl:comment "Possible RDF good practice IRI: :hasRatingsPreference "@en ;
+                   owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#ratingsType
@@ -2240,7 +2420,8 @@ TRNS - transfer or transshipment"""@en ;
              rdfs:range ccodes:RatingsType ;
              rdfs:comment "Used to identify if the Ratings are Face, Published or Actual ratings. Expected values are F, A, C."@en ;
              rdfs:label "ratingsType" ;
-             owl:comment "Possible RDF good practice IRI: :hasRatingsType "@en .
+             owl:comment "Possible RDF good practice IRI: :hasRatingsType "@en ;
+             owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#receivedFrom
@@ -2319,7 +2500,8 @@ TRNS - transfer or transshipment"""@en ;
             rdfs:range :BookingOptionRequest ;
             rdfs:comment "Reference to the Booking option request"@en ;
             rdfs:label "requestRef"@en ;
-            owl:comment "Possible RDF good practice IRI: :isAnsweringToRequest "@en .
+            owl:comment "Possible RDF good practice IRI: :isAnsweringToRequest "@en ;
+            owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#requestedByActor
@@ -2364,7 +2546,8 @@ TRNS - transfer or transshipment"""@en ;
          rdfs:range :Routing ;
          rdfs:comment "Routing details of the offer, to be compared with routing preferences of the quote request"@en ;
          rdfs:label "routing"@en ;
-         owl:comment "Possible RDF good practice IRI: :hasRoutingDetails "@en .
+         owl:comment "Possible RDF good practice IRI: :hasRoutingDetails "@en ;
+         owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#routingPreference
@@ -2374,6 +2557,7 @@ TRNS - transfer or transshipment"""@en ;
                    rdfs:comment "Routing details that are part of the request, these details will be used to determine if the offer is a perfect match"@en ;
                    rdfs:label "routingPreference"@en ;
                    owl:comment "Possible RDF good practice IRI: :hasRoutingPreference "@en ;
+                   owl:deprecated "true"@en ;
                    owl:versionInfo "v3. renamed from :hasRoutingPreferences" .
 
 
@@ -2383,7 +2567,8 @@ TRNS - transfer or transshipment"""@en ;
                rdfs:range :ScheduledLegs ;
                rdfs:comment "Scheduled Legs class to be used to identify legs. Can be used with Booking Option Request as an indicator of preferred Routing or with Booking Option when a carrier proposes a specific Routing."@en ;
                rdfs:label "scheduledLegs"@en ;
-               owl:comment "Possible RDF good practice IRI: :hasScheduledLegs "@en .
+               owl:comment "Possible RDF good practice IRI: :hasScheduledLegs "@en ;
+               owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#screeningMethods
@@ -2458,6 +2643,14 @@ AOM - Subjected to any other means: this entry should be followed by free text s
              rdfs:label "serviceCode"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#serviceLevelCode
+:serviceLevelCode rdf:type owl:ObjectProperty ;
+                  rdfs:domain :CarrierProduct ;
+                  rdfs:range :CodeListElement ;
+                  rdfs:comment "Service level code"@en ;
+                  rdfs:label "serviceLevelCode"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#serviceRequest
 :serviceRequest rdf:type owl:ObjectProperty ;
                 rdfs:domain :Piece ;
@@ -2510,7 +2703,8 @@ AOM - Subjected to any other means: this entry should be followed by free text s
                         rdfs:range ccodes:ShipmentSecurityStatus ;
                         rdfs:comment "Indicate the secruty state of the shipment, screened or not"@en ;
                         rdfs:label "shipmentSecurityStatus"@en ;
-                        owl:comment "Possible RDF good practice IRI: :hasShipmentSecurityStatus "@en .
+                        owl:comment "Possible RDF good practice IRI: :hasShipmentSecurityStatus "@en ;
+                        owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#shipper
@@ -2570,7 +2764,7 @@ AOM - Subjected to any other means: this entry should be followed by free text s
 
 ###  https://onerecord.iata.org/ns/cargo#specialHandlingCodes
 :specialHandlingCodes rdf:type owl:ObjectProperty ;
-                      rdfs:domain :Piece ;
+                      rdfs:domain owl:Thing ;
                       rdfs:range ccodes:SpecialHandlingCode ;
                       rdfs:comment "Three-letter special handling code (SPH)"@en ;
                       rdfs:label "specialHandlingCodes"@en .
@@ -2583,6 +2777,30 @@ AOM - Subjected to any other means: this entry should be followed by free text s
                   rdfs:comment "Description of specimens, CITES type code (box 9)"@en ;
                   rdfs:label "specimenTypeCode"@en ;
                   owl:comment "Possible RDF good practice IRI: :hasSpecimenTypeCode "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#station
+:station rdf:type owl:ObjectProperty ;
+         rdfs:domain :StationRemarks ;
+         rdfs:range :Location ;
+         rdfs:comment "Reference to the station (Airport), mandatory "@en ;
+         rdfs:label "station"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#stationRemarks
+:stationRemarks rdf:type owl:ObjectProperty ;
+                rdfs:domain :BookingOption ;
+                rdfs:range :StationRemarks ;
+                rdfs:comment "Remarks related to specific stations in the routing (e.g. Embargo in XXX)"@en ;
+                rdfs:label "stationRemarks"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#statusBookingOption
+:statusBookingOption rdf:type owl:ObjectProperty ;
+                     rdfs:domain :BookingOption ;
+                     rdfs:range :BookingOptionStatus ;
+                     rdfs:comment "Status of the Booking Option"@en ;
+                     rdfs:label "statusBookingOption"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#storedObjects
@@ -2692,6 +2910,22 @@ Condition: At least one of the three elements (Country Code, Information Identif
                owl:comment "Possible RDF good practice IRI: :hasTaxDueAirline "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#temperatureInstructions
+:temperatureInstructions rdf:type owl:ObjectProperty ;
+                         rdfs:domain :BookingShipment ;
+                         rdfs:range :TemperatureInstructions ;
+                         rdfs:comment "Temperature instructions if a specific range"@en ;
+                         rdfs:label "temperatureInstructions"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#temperatureUnit
+:temperatureUnit rdf:type owl:ObjectProperty ;
+                 rdfs:domain :UnitsPreference ;
+                 rdfs:range ccodes:TemperatureUnitCode ;
+                 rdfs:comment "Preferred unit for temperature"@en ;
+                 rdfs:label "temperatureUnit"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#timePreferences
 :timePreferences rdf:type owl:ObjectProperty ;
                  rdfs:domain :BookingOptionRequest ;
@@ -2735,6 +2969,14 @@ Condition: At least one of the three elements (Country Code, Information Identif
                   owl:comment "Possible RDF good practice IRI: :hasTotalGrossWeight "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#totalVolume
+:totalVolume rdf:type owl:ObjectProperty ;
+             rdfs:domain :VolumePieceGroup ;
+             rdfs:range :Value ;
+             rdfs:comment "Total volume fo the volume piece group"@en ;
+             rdfs:label "totalVolume"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#totalVolumetricWeight
 :totalVolumetricWeight rdf:type owl:ObjectProperty ;
                        rdfs:domain owl:Thing ;
@@ -2762,6 +3004,32 @@ Condition: At least one of the three elements (Country Code, Information Identif
                            owl:comment "Possible RDF good practice IRI: :hasTransportContractTypeCode "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#transportLegs
+:transportLegs rdf:type owl:ObjectProperty ;
+               rdfs:domain :BookingOption ,
+                           :BookingOptionRequest ;
+               rdfs:range :TransportLegs ;
+               rdfs:comment "Reference to the Transport legs of the proposed routing"@en ,
+                            "Reference to the transport legs of the routings if any preferences"@en ;
+               rdfs:label "transportLegs"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#transportMeansServiceType
+:transportMeansServiceType rdf:type owl:ObjectProperty ;
+                           rdfs:domain :TransportLegs ;
+                           rdfs:range ccodes:TransportMeansServiceType ;
+                           rdfs:comment "Type of transport means service, e.g. Aircraftor Truck"@en ;
+                           rdfs:label "transportMeansServiceType"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#transportMeansType
+:transportMeansType rdf:type owl:ObjectProperty ;
+                    rdfs:domain :TransportLegs ;
+                    rdfs:range :CodeListElement ;
+                    rdfs:comment "Type of transport means, e.g. 744, RFS"@en ;
+                    rdfs:label "transportMeansType"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#transportMovement
 :transportMovement rdf:type owl:ObjectProperty ;
                    rdfs:domain owl:Thing ;
@@ -2769,7 +3037,8 @@ Condition: At least one of the three elements (Country Code, Information Identif
                    rdfs:comment "Transport segment linked to the offer, including the Departure and Arrival locations"@en ;
                    rdfs:label "transportMovement"@en ;
                    owl:comment "Possible RDF good practice IRI: :refersToTransportMovement "@en ;
-                   owl:deprecated "true"^^xsd:boolean .
+                   owl:deprecated "true"@en ,
+                                  "true"^^xsd:boolean .
 
 
 ###  https://onerecord.iata.org/ns/cargo#transportMovements
@@ -2836,9 +3105,26 @@ Condition: At least one of the three elements (Country Code, Information Identif
                         owl:comment "Possible RDF good practice IRI: :hasFuelConsumption "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#uldContourCode
+:uldContourCode rdf:type owl:ObjectProperty ;
+                rdfs:domain :ULDSpecificPiece ;
+                rdfs:range :CodeListElement ;
+                rdfs:comment "Contour code as per IATA ULD Regulation"@en ;
+                rdfs:label "uldContourCode"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#uldLoadingIndicator
+:uldLoadingIndicator rdf:type owl:ObjectProperty ;
+                     rdfs:domain :ULDBasicPiece ;
+                     rdfs:range ccodes:ULDLoadingIndicator ;
+                     rdfs:comment "Indicator related to ULD loading (e.g. Main deck only)"@en ;
+                     rdfs:label "uldLoadingIndicator"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#uldRateClassType
 :uldRateClassType rdf:type owl:ObjectProperty ;
-                  rdfs:domain :TACTRateDescription ;
+                  rdfs:domain :Ranges ,
+                              :TACTRateDescription ;
                   rdfs:range :CodeListElement ;
                   rdfs:comment "ULD Rate information - ULD Rate Class Type"@en ;
                   rdfs:label "uldRateClassType"@en .
@@ -2852,6 +3138,14 @@ Condition: At least one of the three elements (Country Code, Information Identif
               rdfs:label "uldReference"@en ;
               owl:comment "Possible RDF good practice IRI: :isLoadedOnULD "@en ;
               owl:deprecated "true"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#uldType
+:uldType rdf:type owl:ObjectProperty ;
+         rdfs:domain :ULDSpecificPiece ;
+         rdfs:range :CodeListElement ;
+         rdfs:comment "Type of ULD as per IATA ULD Regulation"@en ;
+         rdfs:label "uldType"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#uldTypeCode
@@ -2874,9 +3168,9 @@ Condition: At least one of the three elements (Country Code, Information Identif
 
 ###  https://onerecord.iata.org/ns/cargo#unitsPreference
 :unitsPreference rdf:type owl:ObjectProperty ;
-                 rdfs:domain :BookingOptionRequest ;
-                 rdfs:range :Value ;
-                 rdfs:comment "Unit preferences of the request (e.g. kg or cm)"@en ;
+                 rdfs:domain owl:Thing ;
+                 rdfs:range :UnitsPreference ;
+                 rdfs:comment "Reference to unit preferences of the request (e.g. kg or cm)"@en ;
                  rdfs:label "unitsPreference"@en ;
                  owl:comment "Possible RDF good practice IRI: :hasUnitsPreference "@en .
 
@@ -2916,6 +3210,14 @@ Condition: At least one of the three elements (Country Code, Information Identif
         owl:comment "Possible RDF good practice IRI: :hasVolume "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#volumeUnit
+:volumeUnit rdf:type owl:ObjectProperty ;
+            rdfs:domain :UnitsPreference ;
+            rdfs:range ccodes:VolumeUnitCode ;
+            rdfs:comment "Preferred unit for volume"@en ;
+            rdfs:label "volumeUnit"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#volumetricWeight
 :volumetricWeight rdf:type owl:ObjectProperty ;
                   rdfs:domain :Piece ;
@@ -2951,6 +3253,14 @@ Condition: At least one of the three elements (Country Code, Information Identif
         rdfs:comment "Weight of the item"@en ;
         rdfs:label "weight"@en ;
         owl:comment "Possible RDF good practice IRI: :hasWeight "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#weightUnit
+:weightUnit rdf:type owl:ObjectProperty ;
+            rdfs:domain :UnitsPreference ;
+            rdfs:range ccodes:WeightUnitCode ;
+            rdfs:comment "Preferred unit for weight"@en ;
+            rdfs:label "weightUnit"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#weightValuationIndicator
@@ -3039,6 +3349,14 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                   owl:comment "Possible RDF good practice IRI: :hasAdditionalHazardClassificationIdentifier "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#additionalInformation
+:additionalInformation rdf:type owl:DatatypeProperty ;
+                       rdfs:domain :BookingOption ;
+                       rdfs:range xsd:string ;
+                       rdfs:comment "Additional infromation related to the Booking Option, e.g. sales details"@en ;
+                       rdfs:label "additionalInformation"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#additionalSecurityInformation
 :additionalSecurityInformation rdf:type owl:DatatypeProperty ;
                                rdfs:domain :SecurityDeclaration ;
@@ -3086,7 +3404,16 @@ Condition: At least one of the three elements (Country Code, Information Identif
            rdfs:range xsd:string ;
            rdfs:comment "Reference to the Allotment as per the contracts between forwarders and carriers"@en ;
            rdfs:label "allotment"@en ;
-           owl:comment "Possible RDF good practice IRI: :hasAllotment "@en .
+           owl:comment "Possible RDF good practice IRI: :hasAllotment "@en ;
+           owl:deprecated "true"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#alternatives
+:alternatives rdf:type owl:DatatypeProperty ;
+              rdfs:domain :BookingOption ;
+              rdfs:range xsd:string ;
+              rdfs:comment "Description of the alternatives proposed that do not match the Booking Option Request"@en ;
+              rdfs:label "alternatives"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#amount
@@ -3095,7 +3422,8 @@ Condition: At least one of the three elements (Country Code, Information Identif
         rdfs:range xsd:double ;
         rdfs:comment "Amount"@en ;
         rdfs:label "amount"@en ;
-        owl:comment "Possible RDF good practice IRI: :hasAmount "@en .
+        owl:comment "Possible RDF good practice IRI: :hasAmount "@en ;
+        owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#annualQuotaQuantity
@@ -3127,7 +3455,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
 
 ###  https://onerecord.iata.org/ns/cargo#arrivalDate
 :arrivalDate rdf:type owl:DatatypeProperty ;
-             rdfs:domain :ScheduledLegs ;
+             rdfs:domain :TransportLegs ;
              rdfs:range xsd:dateTime ;
              rdfs:comment "Arrival date and time of the leg"@en ;
              rdfs:label "arrivalDate"@en ;
@@ -3204,7 +3532,8 @@ Condition: At least one of the three elements (Country Code, Information Identif
                      rdfs:range xsd:string ;
                      rdfs:comment "Status of the Booking Option with regards to the step in the Sales and Booking process. Enumerated values to be defined"@en ;
                      rdfs:label "bookingOptionStatus"@en ;
-                     owl:comment "Possible RDF good practice IRI: :hasBookingOptionStatus "@en .
+                     owl:comment "Possible RDF good practice IRI: :hasBookingOptionStatus "@en ;
+                     owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#branchName
@@ -3443,6 +3772,14 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                owl:comment "Possible RDF good practice IRI: :hasConsignorDeclarationSignature "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#consolidationIndicator
+:consolidationIndicator rdf:type owl:DatatypeProperty ;
+                        rdfs:domain :BookingShipment ;
+                        rdfs:range xsd:boolean ;
+                        rdfs:comment "Indication if the shipment is a consolidation"@en ;
+                        rdfs:label "consolidationIndicator"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#copyIndicator
 :copyIndicator rdf:type owl:DatatypeProperty ;
                rdfs:domain :LiveAnimalsEpermit ;
@@ -3547,7 +3884,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
 
 ###  https://onerecord.iata.org/ns/cargo#departureDate
 :departureDate rdf:type owl:DatatypeProperty ;
-               rdfs:domain :ScheduledLegs ;
+               rdfs:domain :TransportLegs ;
                rdfs:range xsd:dateTime ;
                rdfs:comment "Departure date and time of the leg"@en ;
                rdfs:label "departureDate"@en ;
@@ -3719,6 +4056,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
                      rdfs:comment "Expected commodity for quote request purposes only. To be defined by MCD"@en ;
                      rdfs:label "expectedCommodities"@en ;
                      owl:comment "Possible RDF good practice IRI: :hasExpectedCommodity "@en ;
+                     owl:deprecated "true"@en ;
                      owl:versionInfo "v1.1 renamed to expectedCommodities" .
 
 
@@ -3949,6 +4287,14 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
           owl:comment "Possible RDF good practice IRI: :hasJobTitle "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#knownShipper
+:knownShipper rdf:type owl:DatatypeProperty ;
+              rdfs:domain :BookingOptionRequest ;
+              rdfs:range xsd:boolean ;
+              rdfs:comment "Indication if shipper is a Known Shipper as per TSA grant"@en ;
+              rdfs:label "knownShipper"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#lastName
 :lastName rdf:type owl:DatatypeProperty ;
           rdfs:domain :Person ;
@@ -3973,7 +4319,8 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                        rdfs:range xsd:dateTime ;
                        rdfs:comment "Latest Arrival date time (requested or proposed)"@en ;
                        rdfs:label "latestArrivalDateTime"@en ;
-                       owl:comment "Possible RDF good practice IRI: :hasLatestArrivalDateTime "@en .
+                       owl:comment "Possible RDF good practice IRI: :hasLatestArrivalDateTime "@en ;
+                       owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#latestArrivalTime
@@ -3994,13 +4341,22 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
           owl:comment "Possible RDF good practice IRI: :hasLatitude "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#legNumber
+:legNumber rdf:type owl:DatatypeProperty ;
+           rdfs:domain :TransportLegs ;
+           rdfs:range xsd:integer ;
+           rdfs:comment "Leg number"@en ;
+           rdfs:label "TransportLegs"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#legSequenceNumber
 :legSequenceNumber rdf:type owl:DatatypeProperty ;
                    rdfs:domain :ScheduledLegs ;
                    rdfs:range xsd:integer ;
                    rdfs:comment "Sequence number of the leg"@en ;
                    rdfs:label "legSequenceNumber"@en ;
-                   owl:comment "Possible RDF good practice IRI: :hasLegSequenceNumber "@en .
+                   owl:comment "Possible RDF good practice IRI: :hasLegSequenceNumber "@en ;
+                   owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#loadingIdentifier
@@ -4109,7 +4465,16 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                 rdfs:range xsd:integer ;
                 rdfs:comment "Maximum number of connections of the transport movement (requested or proposed)"@en ;
                 rdfs:label "maxConnections"@en ;
-                owl:comment "Possible RDF good practice IRI: :hasMaxConnections "@en .
+                owl:comment "Possible RDF good practice IRI: :hasMaxConnections "@en ;
+                owl:deprecated "true"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#maxSegments
+:maxSegments rdf:type owl:DatatypeProperty ;
+             rdfs:domain :BookingPreferences ;
+             rdfs:range xsd:integer ;
+             rdfs:comment "Maximum number of segments for the transportation of the goods. 1 means direct flight"@en ;
+             rdfs:label "maxSegments"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#maximumQuantity
@@ -4311,13 +4676,30 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
               owl:deprecated "true"^^xsd:boolean .
 
 
+###  https://onerecord.iata.org/ns/cargo#offerValidFrom
+:offerValidFrom rdf:type owl:DatatypeProperty ;
+                rdfs:domain :BookingOption ;
+                rdfs:range xsd:dateTime ;
+                rdfs:comment "Date and time of beginning of offer validity"@en ;
+                rdfs:label "offerValidFrom"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#offerValidTo
+:offerValidTo rdf:type owl:DatatypeProperty ;
+              rdfs:domain :BookingOption ;
+              rdfs:range xsd:dateTime ;
+              rdfs:comment "Date and time of end of offer validity"@en ;
+              rdfs:label "offerValidTo"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#onlineInd
 :onlineInd rdf:type owl:DatatypeProperty ;
            rdfs:domain :Routing ;
            rdfs:range xsd:boolean ;
            rdfs:comment "Indicates interlining (requested or proposed)"@en ;
            rdfs:label "onlineInd"@en ;
-           owl:comment "Possible RDF good practice IRI: :hasInterlining "@en .
+           owl:comment "Possible RDF good practice IRI: :hasInterlining "@en ;
+           owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#originReferencePermitDateTime
@@ -4447,6 +4829,22 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                    rdfs:label "pieceCountForRate"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#pieceGroupCount
+:pieceGroupCount rdf:type owl:DatatypeProperty ;
+                 rdfs:domain :PieceGroup ;
+                 rdfs:range xsd:integer ;
+                 rdfs:comment "Number of pieces in the piece group"@en ;
+                 rdfs:label "pieceGroupCount"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#pieceGroupId
+:pieceGroupId rdf:type owl:DatatypeProperty ;
+              rdfs:domain :PieceGroup ;
+              rdfs:range xsd:integer ;
+              rdfs:comment "Identifier of the piece group, increasing integers"@en ;
+              rdfs:label "pieceGroupId"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#postOfficeBox
 :postOfficeBox rdf:type owl:DatatypeProperty ;
                rdfs:domain :Address ;
@@ -4459,7 +4857,7 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
 
 ###  https://onerecord.iata.org/ns/cargo#preferredTransportId
 :preferredTransportId rdf:type owl:DatatypeProperty ;
-                      rdfs:domain :BookingSegment ;
+                      rdfs:domain :BookingPreferences ;
                       rdfs:range xsd:string ;
                       rdfs:comment "When part of the Request it refers to the preferred Transport ID from the customer. When part of the BookingOption (offer or actual booking) it refers to the expected Transport ID or flight"@en ;
                       rdfs:label "preferredTransportId"@en ;
@@ -4487,6 +4885,14 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
         owl:versionInfo "v3. renamed from carrier:airlinePrefix"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#priceReferenceId
+:priceReferenceId rdf:type owl:DatatypeProperty ;
+                  rdfs:domain owl:Thing ;
+                  rdfs:range xsd:string ;
+                  rdfs:comment "Reference to a price reference if existing (e.g. Allotment number, contract reference, etc.)"@en ;
+                  rdfs:label "priceReferenceId"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#priceSpecification
 :priceSpecification rdf:type owl:DatatypeProperty ;
                     rdfs:domain :Ratings ;
@@ -4502,7 +4908,8 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                        rdfs:range xsd:string ;
                        rdfs:comment "Reference of price specifications"@en ;
                        rdfs:label "priceSpecificationRef"@en ;
-                       owl:comment "Possible RDF good practice IRI: :hasPriceSpecificationRef "@en .
+                       owl:comment "Possible RDF good practice IRI: :hasPriceSpecificationRef "@en ;
+                       owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#productDescription
@@ -4539,7 +4946,8 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                        rdfs:range xsd:string ;
                        rdfs:comment "String containing the proposed waybill number for the BookingOption"@en ;
                        rdfs:label "proposedWaybillNumber"@en ;
-                       owl:comment "Possible RDF good practice IRI: :hasProposedWaybillNumber "@en .
+                       owl:comment "Possible RDF good practice IRI: :hasProposedWaybillNumber "@en ;
+                       owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#qValueNumeric
@@ -4549,6 +4957,14 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                rdfs:comment "Most instances of all packed in one will require the addition of the Q value which  1. Applies to air transport only. (Air)  "@en ;
                rdfs:label "qValueNumeric"@en ;
                owl:comment "Possible RDF good practice IRI: :hasQValueNumeric "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#quantity
+:quantity rdf:type owl:DatatypeProperty ;
+          rdfs:domain :Ratings ;
+          rdfs:range xsd:double ;
+          rdfs:comment "Quantity for the charge if applicable"@en ;
+          rdfs:label "quantity"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#quantityAnimals
@@ -4593,7 +5009,8 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
               rdfs:range xsd:string ;
               rdfs:comment "Used if there is an applicable quantity to the rate (Usually a Time or a Number)"@en ;
               rdfs:label "rateQuantity"@en ;
-              owl:comment "Possible RDF good practice IRI: :hasRateQuantity "@en .
+              owl:comment "Possible RDF good practice IRI: :hasRateQuantity "@en ;
+              owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#rcp
@@ -4655,6 +5072,14 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
          owl:versionInfo "v3. renamed from loadingUnit:uldRemarks"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#remarksText
+:remarksText rdf:type owl:DatatypeProperty ;
+             rdfs:domain :StationRemarks ;
+             rdfs:range xsd:string ;
+             rdfs:comment "Details of the remarks, mandatory"@en ;
+             rdfs:label "remarksText"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#reportableQuantity
 :reportableQuantity rdf:type owl:DatatypeProperty ;
                     rdfs:domain :ItemDg ;
@@ -4664,13 +5089,22 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                     owl:comment "Possible RDF good practice IRI: :hasReportableQuantity "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#requestMatch
+:requestMatch rdf:type owl:DatatypeProperty ;
+              rdfs:domain :BookingOption ;
+              rdfs:range xsd:boolean ;
+              rdfs:comment "Indicates if the Booking Option is a match to the Booking Option Request preferences"@en ;
+              rdfs:label "requestMatch"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#requestMatchInd
 :requestMatchInd rdf:type owl:DatatypeProperty ;
                  rdfs:domain :BookingOption ;
                  rdfs:range xsd:boolean ;
                  rdfs:comment "Indicates if the offer is a perfect match to the quote request (boolean)"@en ;
                  rdfs:label "requestMatchInd"@en ;
-                 owl:comment "Possible RDF good practice IRI: :isPerfectMatch "@en .
+                 owl:comment "Possible RDF good practice IRI: :isPerfectMatch "@en ;
+                 owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#requestedHandling
@@ -4679,7 +5113,8 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                    rdfs:range xsd:string ;
                    rdfs:comment "Requested handling information for quote request purposes only"@en ;
                    rdfs:label "requestedHandling"@en ;
-                   owl:comment "Possible RDF good practice IRI: :hasRequestedHandling "@en .
+                   owl:comment "Possible RDF good practice IRI: :hasRequestedHandling "@en ;
+                   owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#rfsInd
@@ -4688,27 +5123,14 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
         rdfs:range xsd:boolean ;
         rdfs:comment "Indicates if RFS (Road Feeder Services) is included (requested or proposed)"@en ;
         rdfs:label "rfsInd"@en ;
-        owl:comment "Possible RDF good practice IRI: :hasRoadFeederService "@en .
+        owl:comment "Possible RDF good practice IRI: :hasRoadFeederService "@en ;
+        owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#salutation
 :salutation rdf:type owl:DatatypeProperty ;
             rdfs:domain :Person ;
-            rdfs:range [ rdf:type rdfs:Datatype ;
-                         owl:oneOf [ rdf:type rdf:List ;
-                                     rdf:first "Dr." ;
-                                     rdf:rest [ rdf:type rdf:List ;
-                                                rdf:first "Mr." ;
-                                                rdf:rest [ rdf:type rdf:List ;
-                                                           rdf:first "Ms." ;
-                                                           rdf:rest [ rdf:type rdf:List ;
-                                                                      rdf:first "Pr." ;
-                                                                      rdf:rest rdf:nil
-                                                                    ]
-                                                         ]
-                                              ]
-                                   ]
-                       ] ;
+            rdfs:range xsd:string ;
             rdfs:comment "Salutation "@en ;
             rdfs:label "salutation"@en ;
             owl:comment "Possible RDF good practice IRI: :hasSalutation "@en .
@@ -4720,7 +5142,8 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
      rdfs:range xsd:string ;
      rdfs:comment "Specific commodity rates linked to commodity"@en ;
      rdfs:label "scr"@en ;
-     owl:comment "Possible RDF good practice IRI: :hasSpecificCommodityRate "@en .
+     owl:comment "Possible RDF good practice IRI: :hasSpecificCommodityRate "@en ;
+     owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#seal
@@ -4888,6 +5311,14 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                     owl:comment "Possible RDF good practice IRI: :hasSpecialProvisionIdentifier "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#specialServiceRequests
+:specialServiceRequests rdf:type owl:DatatypeProperty ;
+                        rdfs:domain :BookingShipment ;
+                        rdfs:range xsd:string ;
+                        rdfs:comment "Special service requests"@en ;
+                        rdfs:label "specialServiceRequests"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#speciesCommonName
 :speciesCommonName rdf:type owl:DatatypeProperty ;
                    rdfs:domain :PieceLiveAnimals ;
@@ -4917,7 +5348,7 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
 
 ###  https://onerecord.iata.org/ns/cargo#stackable
 :stackable rdf:type owl:DatatypeProperty ;
-           rdfs:domain :Piece ;
+           rdfs:domain owl:Thing ;
            rdfs:range xsd:boolean ;
            rdfs:comment "Stackable indicator for the pieces (boolean)"@en ;
            rdfs:label "stackable"@en ;
@@ -5008,7 +5439,7 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
 
 ###  https://onerecord.iata.org/ns/cargo#textualHandlingInstructions
 :textualHandlingInstructions rdf:type owl:DatatypeProperty ;
-                             rdfs:domain :Piece ;
+                             rdfs:domain owl:Thing ;
                              rdfs:range xsd:string ;
                              rdfs:comment "Strings to provide free text handling instructions such as SSR and OSI"@en ;
                              rdfs:label "textualHandlingInstructions"@en .
@@ -5038,7 +5469,8 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                  rdfs:range xsd:integer ;
                  rdfs:comment "Total Piece Count"@en ;
                  rdfs:label "totalPieceCount"@en ;
-                 owl:comment "Possible RDF good practice IRI: :hasTotalPieceCount "@en .
+                 owl:comment "Possible RDF good practice IRI: :hasTotalPieceCount "@en ;
+                 owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#totalSLAC
@@ -5099,16 +5531,24 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
 
 ###  https://onerecord.iata.org/ns/cargo#turnable
 :turnable rdf:type owl:DatatypeProperty ;
-          rdfs:domain :Piece ;
+          rdfs:domain owl:Thing ;
           rdfs:range xsd:boolean ;
           rdfs:comment "Turnable indicator for the pieces (boolean)"@en ;
           rdfs:label "turnable"@en ;
           owl:comment "Possible RDF good practice IRI: :isTurnable "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#uldOwnerCode
+:uldOwnerCode rdf:type owl:DatatypeProperty ;
+              rdfs:domain :ULDSpecificPiece ;
+              rdfs:range xsd:string ;
+              rdfs:comment "ULD Owner code"@en ;
+              rdfs:label "uldOwnerCode"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#uldSerialNumber
 :uldSerialNumber rdf:type owl:DatatypeProperty ;
-                 rdfs:domain :LoadingUnit ;
+                 rdfs:domain owl:Thing ;
                  rdfs:range xsd:string ;
                  rdfs:comment "Serial number that allows to uniquely identify the ULD"@en ;
                  rdfs:label "uldSerialNumber"@en ;
@@ -5235,7 +5675,7 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
 
 ###  https://onerecord.iata.org/ns/cargo#waybillNumber
 :waybillNumber rdf:type owl:DatatypeProperty ;
-               rdfs:domain :Waybill ;
+               rdfs:domain owl:Thing ;
                rdfs:range [ rdf:type rdfs:Datatype ;
                             owl:onDatatype xsd:string ;
                             owl:withRestrictions ( [ xsd:pattern "[-9]+"
@@ -5249,7 +5689,7 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
 
 ###  https://onerecord.iata.org/ns/cargo#waybillPrefix
 :waybillPrefix rdf:type owl:DatatypeProperty ;
-               rdfs:domain :Waybill ;
+               rdfs:domain owl:Thing ;
                rdfs:range [ rdf:type rdfs:Datatype ;
                             owl:onDatatype xsd:string ;
                             owl:withRestrictions ( [ xsd:maxLength 3
@@ -5264,179 +5704,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
 #################################################################
 #    Classes
 #################################################################
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#AWBUseIndicator
-ccodes:AWBUseIndicator rdf:type owl:Class ;
-                       rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#AircraftPossibilityCode
-ccodes:AircraftPossibilityCode rdf:type owl:Class ;
-                               rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#BasicRateClassCode
-ccodes:BasicRateClassCode rdf:type owl:Class ;
-                          rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#ChargeCode
-ccodes:ChargeCode rdf:type owl:Class ;
-                  rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#ChargeIdentifier
-ccodes:ChargeIdentifier rdf:type owl:Class ;
-                        rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode
-ccodes:DangerousGoodsCode rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#DemurrageCode
-ccodes:DemurrageCode rdf:type owl:Class ;
-                     rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#EntitlementCode
-ccodes:EntitlementCode rdf:type owl:Class ;
-                       rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#ExplosiveCompatibilityGroupCode
-ccodes:ExplosiveCompatibilityGroupCode rdf:type owl:Class ;
-                                       rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#GoodsTypeCode
-ccodes:GoodsTypeCode rdf:type owl:Class ;
-                     rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#GoodsTypeExtensionCode
-ccodes:GoodsTypeExtensionCode rdf:type owl:Class ;
-                              rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator
-ccodes:MovementIndicator rdf:type owl:Class ;
-                         rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode
-ccodes:OtherChargeCode rdf:type owl:Class ;
-                       rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#PackageMarkCode
-ccodes:PackageMarkCode rdf:type owl:Class ;
-                       rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#PackagingDangerLevelCode
-ccodes:PackagingDangerLevelCode rdf:type owl:Class ;
-                                rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#ParticipantIdentifier
-ccodes:ParticipantIdentifier rdf:type owl:Class ;
-                             rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#PrepaidCollectIndicator
-ccodes:PrepaidCollectIndicator rdf:type owl:Class ;
-                               rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#RaTypeCode
-ccodes:RaTypeCode rdf:type owl:Class ;
-                  rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#RadioActiveMaterialClassicfication
-ccodes:RadioActiveMaterialClassicfication rdf:type owl:Class ;
-                                          rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#RateClassCode
-ccodes:RateClassCode rdf:type owl:Class ;
-                     rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#RatingsType
-ccodes:RatingsType rdf:type owl:Class ;
-                   rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#RegulatedEntityCategoryCode
-ccodes:RegulatedEntityCategoryCode rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#ScreeningExemption
-ccodes:ScreeningExemption rdf:type owl:Class ;
-                          rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#ScreeningMethod
-ccodes:ScreeningMethod rdf:type owl:Class ;
-                       rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#SecurityStatus
-ccodes:SecurityStatus rdf:type owl:Class ;
-                      rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#ServiceCode
-ccodes:ServiceCode rdf:type owl:Class ;
-                   rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#ShipmentSecurityStatus
-ccodes:ShipmentSecurityStatus rdf:type owl:Class ;
-                              rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#SignatoryRole
-ccodes:SignatoryRole rdf:type owl:Class ;
-                     rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#SignatureTypeCode
-ccodes:SignatureTypeCode rdf:type owl:Class ;
-                         rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode
-ccodes:SpecialHandlingCode rdf:type owl:Class ;
-                           rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#StatusCode
-ccodes:StatusCode rdf:type owl:Class ;
-                  rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#TransactionPurposeCode
-ccodes:TransactionPurposeCode rdf:type owl:Class ;
-                              rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#ULDChargeCode
-ccodes:ULDChargeCode rdf:type owl:Class ;
-                     rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#ULDConditionCode
-ccodes:ULDConditionCode rdf:type owl:Class ;
-                        rdfs:subClassOf :CodeListElement .
-
-
-###  <https://onerecord.iata.org/ns/coreCodeLists#ULDLoadingIndicator
-ccodes:ULDLoadingIndicator rdf:type owl:Class ;
-                           rdfs:subClassOf :CodeListElement .
-
 
 ###  https://onerecord.iata.org/ns/cargo#ActionTimeType
 :ActionTimeType rdf:type owl:Class ;
@@ -5779,6 +6046,14 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
 :Booking rdf:type owl:Class ;
          rdfs:subClassOf :LogisticsService ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty :bookingRequestId ;
+                           owl:allValuesFrom :BookingRequest
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :bookingStatus ;
+                           owl:allValuesFrom :BookingStatus
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty :forBookingRequest ;
                            owl:allValuesFrom :BookingRequest
                          ] ,
@@ -5787,11 +6062,35 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                            owl:allValuesFrom :Waybill
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty :bookingRequestId ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :bookingStatus ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty :forBookingRequest ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :issuedForWaybill ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :waybillNumber ;
+                           owl:allValuesFrom xsd:string
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :waybillPrefix ;
+                           owl:allValuesFrom xsd:string
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :waybillNumber ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :waybillPrefix ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ;
          rdfs:comment "Booking object refers to a confirmed booking"@en ;
@@ -5802,12 +6101,24 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
 :BookingOption rdf:type owl:Class ;
                rdfs:subClassOf :LogisticsObject ,
                                [ rdf:type owl:Restriction ;
+                                 owl:onProperty :bookingOptionRequestId ;
+                                 owl:allValuesFrom :BookingOptionRequest
+                               ] ,
+                               [ rdf:type owl:Restriction ;
                                  owl:onProperty :bookingSegment ;
                                  owl:allValuesFrom :BookingSegment
                                ] ,
                                [ rdf:type owl:Restriction ;
                                  owl:onProperty :bookingTimes ;
                                  owl:allValuesFrom :BookingTimes
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :carrier ;
+                                 owl:allValuesFrom :Carrier
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :carrierProduct ;
+                                 owl:allValuesFrom :CarrierProduct
                                ] ,
                                [ rdf:type owl:Restriction ;
                                  owl:onProperty :carrierProductInfo ;
@@ -5820,10 +6131,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                [ rdf:type owl:Restriction ;
                                  owl:onProperty :fromCarrier ;
                                  owl:allValuesFrom :Carrier
-                               ] ,
-                               [ rdf:type owl:Restriction ;
-                                 owl:onProperty :involvedParties ;
-                                 owl:allValuesFrom :Party
                                ] ,
                                [ rdf:type owl:Restriction ;
                                  owl:onProperty :price ;
@@ -5842,8 +6149,28 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                  owl:allValuesFrom ccodes:ShipmentSecurityStatus
                                ] ,
                                [ rdf:type owl:Restriction ;
+                                 owl:onProperty :stationRemarks ;
+                                 owl:allValuesFrom :StationRemarks
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :statusBookingOption ;
+                                 owl:allValuesFrom :BookingOptionStatus
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :transportLegs ;
+                                 owl:allValuesFrom :TransportLegs
+                               ] ,
+                               [ rdf:type owl:Restriction ;
                                  owl:onProperty :transportMovement ;
                                  owl:allValuesFrom :TransportMovement
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :unitsPreference ;
+                                 owl:allValuesFrom :UnitsPreference
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :bookingOptionRequestId ;
+                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                ] ,
                                [ rdf:type owl:Restriction ;
                                  owl:onProperty :bookingSegment ;
@@ -5851,6 +6178,14 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                ] ,
                                [ rdf:type owl:Restriction ;
                                  owl:onProperty :bookingTimes ;
+                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :carrier ;
+                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :carrierProduct ;
                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                ] ,
                                [ rdf:type owl:Restriction ;
@@ -5882,31 +6217,63 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                ] ,
                                [ rdf:type owl:Restriction ;
+                                 owl:onProperty :statusBookingOption ;
+                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                               ] ,
+                               [ rdf:type owl:Restriction ;
                                  owl:onProperty :transportMovement ;
                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :unitsPreference ;
+                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :additionalInformation ;
+                                 owl:allValuesFrom xsd:string
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :alternatives ;
+                                 owl:allValuesFrom xsd:string
                                ] ,
                                [ rdf:type owl:Restriction ;
                                  owl:onProperty :bookingOptionStatus ;
                                  owl:allValuesFrom xsd:string
                                ] ,
                                [ rdf:type owl:Restriction ;
+                                 owl:onProperty :offerValidFrom ;
+                                 owl:allValuesFrom xsd:dateTime
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :offerValidTo ;
+                                 owl:allValuesFrom xsd:dateTime
+                               ] ,
+                               [ rdf:type owl:Restriction ;
                                  owl:onProperty :proposedWaybillNumber ;
                                  owl:allValuesFrom xsd:string
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :requestMatch ;
+                                 owl:allValuesFrom xsd:boolean
                                ] ,
                                [ rdf:type owl:Restriction ;
                                  owl:onProperty :requestMatchInd ;
                                  owl:allValuesFrom xsd:boolean
                                ] ,
                                [ rdf:type owl:Restriction ;
-                                 owl:onProperty :validFrom ;
-                                 owl:allValuesFrom xsd:dateTime
-                               ] ,
-                               [ rdf:type owl:Restriction ;
-                                 owl:onProperty :validUntil ;
-                                 owl:allValuesFrom xsd:dateTime
+                                 owl:onProperty :additionalInformation ;
+                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                ] ,
                                [ rdf:type owl:Restriction ;
                                  owl:onProperty :bookingOptionStatus ;
+                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :offerValidFrom ;
+                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :offerValidTo ;
                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                ] ,
                                [ rdf:type owl:Restriction ;
@@ -5914,15 +6281,11 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                ] ,
                                [ rdf:type owl:Restriction ;
+                                 owl:onProperty :requestMatch ;
+                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                               ] ,
+                               [ rdf:type owl:Restriction ;
                                  owl:onProperty :requestMatchInd ;
-                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                               ] ,
-                               [ rdf:type owl:Restriction ;
-                                 owl:onProperty :validFrom ;
-                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                               ] ,
-                               [ rdf:type owl:Restriction ;
-                                 owl:onProperty :validUntil ;
                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                ] ;
                rdfs:comment "Booking details"@en ;
@@ -5933,8 +6296,12 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
 :BookingOptionRequest rdf:type owl:Class ;
                       rdfs:subClassOf :LogisticsObject ,
                                       [ rdf:type owl:Restriction ;
-                                        owl:onProperty :bookingOption ;
+                                        owl:onProperty :bookingOptions ;
                                         owl:allValuesFrom :BookingOption
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty :bookingPreference ;
+                                        owl:allValuesFrom :BookingPreferences
                                       ] ,
                                       [ rdf:type owl:Restriction ;
                                         owl:onProperty :bookingSegment ;
@@ -5945,16 +6312,24 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                         owl:allValuesFrom :BookingShipment
                                       ] ,
                                       [ rdf:type owl:Restriction ;
+                                        owl:onProperty :bookingToUpdate ;
+                                        owl:allValuesFrom :Booking
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty :carrierProduct ;
+                                        owl:allValuesFrom :CarrierProduct
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty :involvedParties ;
+                                        owl:allValuesFrom :Party
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
                                         owl:onProperty :ratingsPreference ;
                                         owl:allValuesFrom :Ratings
                                       ] ,
                                       [ rdf:type owl:Restriction ;
                                         owl:onProperty :routingPreference ;
                                         owl:allValuesFrom :Routing
-                                      ] ,
-                                      [ rdf:type owl:Restriction ;
-                                        owl:onProperty :shipmentDetails ;
-                                        owl:allValuesFrom :Shipment
                                       ] ,
                                       [ rdf:type owl:Restriction ;
                                         owl:onProperty :shipmentSecurityStatus ;
@@ -5965,12 +6340,20 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                         owl:allValuesFrom :BookingTimes
                                       ] ,
                                       [ rdf:type owl:Restriction ;
+                                        owl:onProperty :transportLegs ;
+                                        owl:allValuesFrom :TransportLegs
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
                                         owl:onProperty :transportMovement ;
                                         owl:allValuesFrom :TransportMovement
                                       ] ,
                                       [ rdf:type owl:Restriction ;
                                         owl:onProperty :unitsPreference ;
-                                        owl:allValuesFrom :Value
+                                        owl:allValuesFrom :UnitsPreference
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty :bookingPreference ;
+                                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                       ] ,
                                       [ rdf:type owl:Restriction ;
                                         owl:onProperty :bookingSegment ;
@@ -5981,15 +6364,19 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                         owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                       ] ,
                                       [ rdf:type owl:Restriction ;
+                                        owl:onProperty :bookingToUpdate ;
+                                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty :carrierProduct ;
+                                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
                                         owl:onProperty :ratingsPreference ;
                                         owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                       ] ,
                                       [ rdf:type owl:Restriction ;
                                         owl:onProperty :routingPreference ;
-                                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                                      ] ,
-                                      [ rdf:type owl:Restriction ;
-                                        owl:onProperty :shipmentDetails ;
                                         owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                       ] ,
                                       [ rdf:type owl:Restriction ;
@@ -6017,15 +6404,87 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                         owl:allValuesFrom xsd:string
                                       ] ,
                                       [ rdf:type owl:Restriction ;
+                                        owl:onProperty :knownShipper ;
+                                        owl:allValuesFrom xsd:boolean
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
                                         owl:onProperty :requestedHandling ;
                                         owl:allValuesFrom xsd:string
                                       ] ,
                                       [ rdf:type owl:Restriction ;
                                         owl:onProperty :allotment ;
                                         owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty :knownShipper ;
+                                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                       ] ;
                       rdfs:comment "Request object, refers to the Quote request or Booking request "@en ;
                       rdfs:label "BookingOptionRequest"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#BookingOptionStatus
+:BookingOptionStatus rdf:type owl:Class ;
+                     owl:equivalentClass [ rdf:type owl:Class ;
+                                           owl:oneOf ( :BOOKABLE
+                                                       :BOOKED
+                                                       :EXPIRED
+                                                       :NONBOOKABLE
+                                                       :NOT_BOOKABLE
+                                                       :ON_REQUEST
+                                                       :QUEUED
+                                                     )
+                                         ] ;
+                     rdfs:subClassOf :CodeListElement ;
+                     rdfs:comment "Restricted code list containing the statuses of a booking option"@en ;
+                     rdfs:label "BookingOptionStatus"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#BookingPreferences
+:BookingPreferences rdf:type owl:Class ;
+                    rdfs:subClassOf :LogisticsObject ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty :aircraftPossibilityCode ;
+                                      owl:allValuesFrom ccodes:AircraftPossibilityCode
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty :excludedViaPoints ;
+                                      owl:allValuesFrom :Location
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty :includedViaPoints ;
+                                      owl:allValuesFrom :Location
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty :aircraftPossibilityCode ;
+                                      owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty :maxSegments ;
+                                      owl:allValuesFrom xsd:integer
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty :preferredTransportId ;
+                                      owl:allValuesFrom xsd:string
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty :priceReferenceId ;
+                                      owl:allValuesFrom xsd:string
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty :maxSegments ;
+                                      owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty :preferredTransportId ;
+                                      owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty :priceReferenceId ;
+                                      owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                    ] ;
+                    rdfs:comment "BookingPreferences details"@en ;
+                    rdfs:label "BookingPreferences"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#BookingRequest
@@ -6045,6 +6504,22 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                 ] ,
                                 [ rdf:type owl:Restriction ;
                                   owl:onProperty :bookingOption ;
+                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty :waybillNumber ;
+                                  owl:allValuesFrom xsd:string
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty :waybillPrefix ;
+                                  owl:allValuesFrom xsd:string
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty :waybillNumber ;
+                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty :waybillPrefix ;
                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                 ] ;
                 rdfs:comment "A party, ususally the freight forwarder, creates the BookingRequest in order to inform the Carrier that h wants to confirm a Booking"@en ;
@@ -6087,7 +6562,8 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                 ] ;
                 rdfs:comment "Booking Segment refers to the arrival and location details of a Booking Option Request or a Booking Option (offer or actual booking)"@en ;
-                rdfs:label "BookingSegment"@en .
+                rdfs:label "BookingSegment"@en ;
+                owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#BookingShipment
@@ -6098,43 +6574,55 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                    owl:allValuesFrom :BookingOptionRequest
                                  ] ,
                                  [ rdf:type owl:Restriction ;
-                                   owl:onProperty :loadType ;
-                                   owl:allValuesFrom :LoadType
+                                   owl:onProperty :expectedCommodity ;
+                                   owl:allValuesFrom ccodes:CommodityCode
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty :expectedHScode ;
+                                   owl:allValuesFrom :CodeListElement
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty :handlingInstructions ;
+                                   owl:allValuesFrom :HandlingInstructions
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty :pieceGroups ;
+                                   owl:allValuesFrom :PieceGroup
                                  ] ,
                                  [ rdf:type owl:Restriction ;
                                    owl:onProperty :preferredHandling ;
                                    owl:allValuesFrom :HandlingInstructions
                                  ] ,
                                  [ rdf:type owl:Restriction ;
-                                   owl:onProperty :totalDimensions ;
-                                   owl:allValuesFrom :Dimensions
+                                   owl:onProperty :specialHandlingCodes ;
+                                   owl:allValuesFrom ccodes:SpecialHandlingCode
                                  ] ,
                                  [ rdf:type owl:Restriction ;
-                                   owl:onProperty :totalGrossWeight ;
-                                   owl:allValuesFrom :Value
+                                   owl:onProperty :temperatureInstructions ;
+                                   owl:allValuesFrom :TemperatureInstructions
                                  ] ,
                                  [ rdf:type owl:Restriction ;
-                                   owl:onProperty :totalVolumetricWeight ;
-                                   owl:allValuesFrom :VolumetricWeight
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty :loadType ;
+                                   owl:onProperty :bookingOptionRequest ;
                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                  ] ,
                                  [ rdf:type owl:Restriction ;
-                                   owl:onProperty :totalDimensions ;
+                                   owl:onProperty :expectedCommodity ;
                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                  ] ,
                                  [ rdf:type owl:Restriction ;
-                                   owl:onProperty :totalGrossWeight ;
+                                   owl:onProperty :expectedHScode ;
                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                  ] ,
                                  [ rdf:type owl:Restriction ;
-                                   owl:onProperty :totalVolumetricWeight ;
+                                   owl:onProperty :temperatureInstructions ;
                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                  ] ,
                                  [ rdf:type owl:Restriction ;
-                                   owl:onProperty :goodsDescription ;
+                                   owl:onProperty :consolidationIndicator ;
+                                   owl:allValuesFrom xsd:boolean
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty :specialServiceRequests ;
                                    owl:allValuesFrom xsd:string
                                  ] ,
                                  [ rdf:type owl:Restriction ;
@@ -6146,7 +6634,7 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                    owl:allValuesFrom xsd:integer
                                  ] ,
                                  [ rdf:type owl:Restriction ;
-                                   owl:onProperty :goodsDescription ;
+                                   owl:onProperty :consolidationIndicator ;
                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                  ] ,
                                  [ rdf:type owl:Restriction ;
@@ -6155,6 +6643,20 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                  ] ;
                  rdfs:comment "Simplified shipment object that is to be used only for the distribution scope where only a subset of data is known priori to operational phase."@en ;
                  rdfs:label "BookingShipment"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#BookingStatus
+:BookingStatus rdf:type owl:Class ;
+               owl:equivalentClass [ rdf:type owl:Class ;
+                                     owl:oneOf ( :CONFIRMED
+                                                 :DELETED
+                                                 :QUEUED
+                                                 :REJECTED
+                                               )
+                                   ] ;
+               rdfs:subClassOf :CodeListElement ;
+               rdfs:comment "Restricted code list containing the possible statuses of a booking"@en ;
+               rdfs:label "BookingStatus"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#BookingTimes
@@ -6310,11 +6812,19 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                   owl:allValuesFrom :CodeListElement
                                 ] ,
                                 [ rdf:type owl:Restriction ;
+                                  owl:onProperty :serviceLevelCode ;
+                                  owl:allValuesFrom :CodeListElement
+                                ] ,
+                                [ rdf:type owl:Restriction ;
                                   owl:onProperty :forBookingOption ;
                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                 ] ,
                                 [ rdf:type owl:Restriction ;
                                   owl:onProperty :productCode ;
+                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty :serviceLevelCode ;
                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                 ] ,
                                 [ rdf:type owl:Restriction ;
@@ -8218,6 +8728,61 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                   rdfs:label "LogisticsService"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#LoosePiece
+:LoosePiece rdf:type owl:Class ;
+            rdfs:subClassOf :PieceGroup ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty :pieceHeight ;
+                              owl:allValuesFrom :Value
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty :pieceLength ;
+                              owl:allValuesFrom :Value
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty :pieceWeight ;
+                              owl:allValuesFrom :Value
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty :pieceWidth ;
+                              owl:allValuesFrom :Value
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty :pieceHeight ;
+                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty :pieceLength ;
+                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty :pieceWeight ;
+                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty :pieceWidth ;
+                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty :stackable ;
+                              owl:allValuesFrom xsd:boolean
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty :turnable ;
+                              owl:allValuesFrom xsd:boolean
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty :stackable ;
+                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty :turnable ;
+                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                            ] ;
+            rdfs:comment "LoosePiece details"@en ;
+            rdfs:label "LoosePiece"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#Measurement
 :Measurement rdf:type owl:Class ;
              rdfs:subClassOf [ rdf:type owl:Restriction ;
@@ -8276,8 +8841,7 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
 ###  https://onerecord.iata.org/ns/cargo#ModeCode
 :ModeCode rdf:type owl:Class ;
           owl:equivalentClass [ rdf:type owl:Class ;
-                                owl:oneOf ( ccodes:ScreeningExemption_MAIL
-                                            :AIR_TRANSPORT
+                                owl:oneOf ( :AIR_TRANSPORT
                                             :FIXED_TRANSPORT_INSTALLATION
                                             :INLAND_WATER_TRANSPORT
                                             :MARITIME_TRANSPORT
@@ -8286,6 +8850,7 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                             :ROAD_TRANSPORT
                                             :TRANSPORT_MODE_NOT_APPLICABLE
                                             :TRANSPORT_MODE_NOT_SPECIFIED
+                                            ccodes:ScreeningExemption_MAIL
                                           )
                               ] ;
           rdfs:subClassOf :CodeListElement ;
@@ -8875,7 +9440,7 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :overpackTypeCode ;
-                           owl:allValuesFrom xsd:boolean
+                           owl:allValuesFrom :CodeListElement
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :dgDeclaration ;
@@ -8927,6 +9492,45 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                          ] ;
          rdfs:comment "Dangerous Goods subtype of Piece"@en ;
          rdfs:label "PieceDg"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#PieceGroup
+:PieceGroup rdf:type owl:Class ;
+            rdfs:subClassOf :LogisticsObject ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty :dryIceWeight ;
+                              owl:allValuesFrom :Value
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty :pieceGroupGrossWeight ;
+                              owl:allValuesFrom :Value
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty :dryIceWeight ;
+                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty :pieceGroupGrossWeight ;
+                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty :pieceGroupCount ;
+                              owl:allValuesFrom xsd:integer
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty :pieceGroupId ;
+                              owl:allValuesFrom xsd:integer
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty :pieceGroupCount ;
+                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty :pieceGroupId ;
+                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                            ] ;
+            rdfs:comment "PieceGroup details"@en ;
+            rdfs:label "PieceGroup"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#PieceLiveAnimals
@@ -9056,7 +9660,11 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
 :Price rdf:type owl:Class ;
        rdfs:subClassOf :LogisticsObject ,
                        [ rdf:type owl:Restriction ;
-                         owl:onProperty :carrierChargeCode ;
+                         owl:onProperty :bookingOption ;
+                         owl:allValuesFrom :BookingOption
+                       ] ,
+                       [ rdf:type owl:Restriction ;
+                         owl:onProperty :chargeCode ;
                          owl:allValuesFrom ccodes:ChargeCode
                        ] ,
                        [ rdf:type owl:Restriction ;
@@ -9072,7 +9680,11 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                          owl:allValuesFrom :Ratings
                        ] ,
                        [ rdf:type owl:Restriction ;
-                         owl:onProperty :carrierChargeCode ;
+                         owl:onProperty :bookingOption ;
+                         owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                       ] ,
+                       [ rdf:type owl:Restriction ;
+                         owl:onProperty :chargeCode ;
                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
                        ] ,
                        [ rdf:type owl:Restriction ;
@@ -9086,10 +9698,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                        [ rdf:type owl:Restriction ;
                          owl:onProperty :grandTotal ;
                          owl:allValuesFrom xsd:double
-                       ] ,
-                       [ rdf:type owl:Restriction ;
-                         owl:onProperty :validUntil ;
-                         owl:allValuesFrom xsd:dateTime
                        ] ,
                        [ rdf:type owl:Restriction ;
                          owl:onProperty :grandTotal ;
@@ -9370,11 +9978,19 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                           owl:allValuesFrom ccodes:ULDChargeCode
                         ] ,
                         [ rdf:type owl:Restriction ;
+                          owl:onProperty :uldRateClassType ;
+                          owl:allValuesFrom :CodeListElement
+                        ] ,
+                        [ rdf:type owl:Restriction ;
                           owl:onProperty :rateClassCode ;
                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
                         ] ,
                         [ rdf:type owl:Restriction ;
                           owl:onProperty :ratingType ;
+                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty :uldRateClassType ;
                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
                         ] ,
                         [ rdf:type owl:Restriction ;
@@ -9429,10 +10045,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                            owl:allValuesFrom ccodes:ChargeIdentifier
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty :chargeCode ;
-                           owl:allValuesFrom ccodes:ChargeCode
-                         ] ,
-                         [ rdf:type owl:Restriction ;
                            owl:onProperty :chargePaymentType ;
                            owl:allValuesFrom ccodes:PrepaidCollectIndicator
                          ] ,
@@ -9453,10 +10065,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                            owl:allValuesFrom ccodes:OtherChargeCode
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty :preferenceOfRequests ;
-                           owl:allValuesFrom :BookingOptionRequest
-                         ] ,
-                         [ rdf:type owl:Restriction ;
                            owl:onProperty :ranges ;
                            owl:allValuesFrom :Ranges
                          ] ,
@@ -9466,10 +10074,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :billingChargeIdentifier ;
-                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :chargeCode ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
@@ -9497,12 +10101,20 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                            owl:allValuesFrom xsd:string
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty :priceReferenceId ;
+                           owl:allValuesFrom xsd:string
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty :priceSpecification ;
                            owl:allValuesFrom xsd:string
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :priceSpecificationRef ;
                            owl:allValuesFrom xsd:string
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :quantity ;
+                           owl:allValuesFrom xsd:double
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :rateQuantity ;
@@ -9521,11 +10133,19 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty :priceReferenceId ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty :priceSpecification ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :priceSpecificationRef ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :quantity ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
@@ -9594,10 +10214,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
 :Routing rdf:type owl:Class ;
          rdfs:subClassOf :LogisticsObject ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty :aircraftPossibilityCode ;
-                           owl:allValuesFrom ccodes:AircraftPossibilityCode
-                         ] ,
-                         [ rdf:type owl:Restriction ;
                            owl:onProperty :excludedViaPoints ;
                            owl:allValuesFrom :Location
                          ] ,
@@ -9612,10 +10228,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :scheduledLegs ;
                            owl:allValuesFrom :ScheduledLegs
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :aircraftPossibilityCode ;
-                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :forBookingOption ;
@@ -9658,7 +10270,8 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ;
          rdfs:comment "Routing details"@en ;
-         rdfs:label "Routing"@en .
+         rdfs:label "Routing"@en ;
+         owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#ScheduledLegs
@@ -9712,7 +10325,8 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                ] ;
                rdfs:comment "Scheduled Legs class to be used to identify legs. Can be used with Booking Option Request as an indicator of preferred Routing or with Booking Option when a carrier proposes a specific Routing."@en ;
-               rdfs:label "ScheduledLegs" .
+               rdfs:label "ScheduledLegs" ;
+               owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#SecurityDeclaration
@@ -9979,6 +10593,29 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
           rdfs:label "Shipment"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#StationRemarks
+:StationRemarks rdf:type owl:Class ;
+                rdfs:subClassOf :LogisticsObject ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty :station ;
+                                  owl:allValuesFrom :Location
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty :station ;
+                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty :remarksText ;
+                                  owl:allValuesFrom xsd:string
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty :remarksText ;
+                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                ] ;
+                rdfs:comment "StationRemarks details"@en ;
+                rdfs:label "StationRemarks"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#Storage
 :Storage rdf:type owl:Class ;
          rdfs:subClassOf :LogisticsActivity ,
@@ -10069,7 +10706,7 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                      ] ,
                                      [ rdf:type owl:Restriction ;
                                        owl:onProperty :uldRateClassType ;
-                                       owl:allValuesFrom xsd:integer
+                                       owl:allValuesFrom :CodeListElement
                                      ] ,
                                      [ rdf:type owl:Restriction ;
                                        owl:onProperty :chargeableWeightForRate ;
@@ -10129,6 +10766,28 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                      ] ;
                      rdfs:comment "Information from AWB Rate Description section as per bullet point 18 - data elements 22A - 22Z from AWB"@en ;
                      rdfs:label "TACTRateDescription"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#TemperatureInstructions
+:TemperatureInstructions rdf:type owl:Class ;
+                         rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                           owl:onProperty :maxTemperature ;
+                                           owl:allValuesFrom :Value
+                                         ] ,
+                                         [ rdf:type owl:Restriction ;
+                                           owl:onProperty :minTemperature ;
+                                           owl:allValuesFrom :Value
+                                         ] ,
+                                         [ rdf:type owl:Restriction ;
+                                           owl:onProperty :maxTemperature ;
+                                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                         ] ,
+                                         [ rdf:type owl:Restriction ;
+                                           owl:onProperty :minTemperature ;
+                                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                         ] ;
+                         rdfs:comment "TemperatureInstructions details"@en ;
+                         rdfs:label "TemperatureInstructions"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#TotalCharge
@@ -10191,6 +10850,85 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                              ] ;
              rdfs:comment "Prepaid and Collect charge totals from AWB"@en ;
              rdfs:label "TotalCharge"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#TransportLegs
+:TransportLegs rdf:type owl:Class ;
+               rdfs:subClassOf :LogisticsObject ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :arrivalLocation ;
+                                 owl:allValuesFrom :Location
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :co2Emissions ;
+                                 owl:allValuesFrom :CO2Emissions
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :departureLocation ;
+                                 owl:allValuesFrom :Location
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :transportMeansServiceType ;
+                                 owl:allValuesFrom ccodes:TransportMeansServiceType
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :transportMeansType ;
+                                 owl:allValuesFrom :CodeListElement
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :arrivalLocation ;
+                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :co2Emissions ;
+                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :departureLocation ;
+                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :transportMeansServiceType ;
+                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :transportMeansType ;
+                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :arrivalDate ;
+                                 owl:allValuesFrom xsd:dateTime
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :departureDate ;
+                                 owl:allValuesFrom xsd:dateTime
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :legNumber ;
+                                 owl:allValuesFrom xsd:integer
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :transportIdentifier ;
+                                 owl:allValuesFrom xsd:string
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :arrivalDate ;
+                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :departureDate ;
+                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :legNumber ;
+                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :transportIdentifier ;
+                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                               ] ;
+               rdfs:comment "TransportLegs details"@en ;
+               rdfs:label "TransportLegs"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#TransportMeans
@@ -10379,6 +11117,76 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                    rdfs:label "TransportMovement"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#ULDBasicPiece
+:ULDBasicPiece rdf:type owl:Class ;
+               rdfs:subClassOf :PieceGroup ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :uldLoadingIndicator ;
+                                 owl:allValuesFrom ccodes:ULDLoadingIndicator
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :uldLoadingIndicator ;
+                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :slac ;
+                                 owl:allValuesFrom xsd:integer
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :slac ;
+                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                               ] ;
+               rdfs:comment "ULDBasicPiece details"@en ;
+               rdfs:label "ULDBasicPiece"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#ULDSpecificPiece
+:ULDSpecificPiece rdf:type owl:Class ;
+                  rdfs:subClassOf :PieceGroup ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty :uldContourCode ;
+                                    owl:allValuesFrom :CodeListElement
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty :uldType ;
+                                    owl:allValuesFrom :CodeListElement
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty :uldContourCode ;
+                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty :uldType ;
+                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty :slac ;
+                                    owl:allValuesFrom xsd:integer
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty :uldOwnerCode ;
+                                    owl:allValuesFrom xsd:string
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty :uldSerialNumber ;
+                                    owl:allValuesFrom xsd:string
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty :slac ;
+                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty :uldOwnerCode ;
+                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty :uldSerialNumber ;
+                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                  ] ;
+                  rdfs:comment "ULDSpecificPiece details"@en ;
+                  rdfs:label "ULDSpecificPiece"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#Uld
 :Uld rdf:type owl:Class ;
      rdfs:subClassOf :LoadingUnit ,
@@ -10533,6 +11341,53 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                  rdfs:label "UnitComposition"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#UnitsPreference
+:UnitsPreference rdf:type owl:Class ;
+                 rdfs:subClassOf :LogisticsObject ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty :currency ;
+                                   owl:allValuesFrom ccodes:CurrencyCode
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty :dimensionsUnit ;
+                                   owl:allValuesFrom ccodes:DimensionsUnitCode
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty :temperatureUnit ;
+                                   owl:allValuesFrom ccodes:TemperatureUnitCode
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty :volumeUnit ;
+                                   owl:allValuesFrom ccodes:VolumeUnitCode
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty :weightUnit ;
+                                   owl:allValuesFrom ccodes:WeightUnitCode
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty :currency ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty :dimensionsUnit ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty :temperatureUnit ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty :volumeUnit ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty :weightUnit ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ;
+                 rdfs:comment "UnitsPreference details"@en ;
+                 rdfs:label "UnitsPreference"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#Value
 :Value rdf:type owl:Class ;
        rdfs:subClassOf [ rdf:type owl:Restriction ;
@@ -10553,6 +11408,29 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                        ] ;
        rdfs:comment "Unit of measurement details"@en ;
        rdfs:label "Value"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#VolumePieceGroup
+:VolumePieceGroup rdf:type owl:Class ;
+                  rdfs:subClassOf :PieceGroup ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty :totalVolume ;
+                                    owl:allValuesFrom :Value
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty :totalVolume ;
+                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty :stackable ;
+                                    owl:allValuesFrom xsd:boolean
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty :stackable ;
+                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                  ] ;
+                  rdfs:comment "VolumePieceGroup details"@en ;
+                  rdfs:label "VolumePieceGroup"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#VolumetricWeight
@@ -10845,6 +11723,221 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
              rdfs:label "WaybillType"@en .
 
 
+###  https://onerecord.iata.org/ns/coreCodeLists#AWBUseIndicator
+ccodes:AWBUseIndicator rdf:type owl:Class ;
+                       rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#AircraftPossibilityCode
+ccodes:AircraftPossibilityCode rdf:type owl:Class ;
+                               rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#BasicRateClassCode
+ccodes:BasicRateClassCode rdf:type owl:Class ;
+                          rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeCode
+ccodes:ChargeCode rdf:type owl:Class ;
+                  rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ChargeIdentifier
+ccodes:ChargeIdentifier rdf:type owl:Class ;
+                        rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CommodityCode
+ccodes:CommodityCode rdf:type owl:Class ;
+                     rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#CurrencyCode
+ccodes:CurrencyCode rdf:type owl:Class ;
+                    rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode
+ccodes:DangerousGoodsCode rdf:type owl:Class ;
+                          rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DemurrageCode
+ccodes:DemurrageCode rdf:type owl:Class ;
+                     rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#DimensionsUnitCode
+ccodes:DimensionsUnitCode rdf:type owl:Class ;
+                          rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#EntitlementCode
+ccodes:EntitlementCode rdf:type owl:Class ;
+                       rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ExplosiveCompatibilityGroupCode
+ccodes:ExplosiveCompatibilityGroupCode rdf:type owl:Class ;
+                                       rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#GoodsTypeCode
+ccodes:GoodsTypeCode rdf:type owl:Class ;
+                     rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#GoodsTypeExtensionCode
+ccodes:GoodsTypeExtensionCode rdf:type owl:Class ;
+                              rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MeasurementUnitCode
+ccodes:MeasurementUnitCode rdf:type owl:Class ;
+                           rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator
+ccodes:MovementIndicator rdf:type owl:Class ;
+                         rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode
+ccodes:OtherChargeCode rdf:type owl:Class ;
+                       rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#PackageMarkCode
+ccodes:PackageMarkCode rdf:type owl:Class ;
+                       rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#PackagingDangerLevelCode
+ccodes:PackagingDangerLevelCode rdf:type owl:Class ;
+                                rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ParticipantIdentifier
+ccodes:ParticipantIdentifier rdf:type owl:Class ;
+                             rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#PrepaidCollectIndicator
+ccodes:PrepaidCollectIndicator rdf:type owl:Class ;
+                               rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RaTypeCode
+ccodes:RaTypeCode rdf:type owl:Class ;
+                  rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RadioActiveMaterialClassicfication
+ccodes:RadioActiveMaterialClassicfication rdf:type owl:Class ;
+                                          rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RateClassCode
+ccodes:RateClassCode rdf:type owl:Class ;
+                     rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RatingsType
+ccodes:RatingsType rdf:type owl:Class ;
+                   rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#RegulatedEntityCategoryCode
+ccodes:RegulatedEntityCategoryCode rdf:type owl:Class ;
+                                   rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ScreeningExemption
+ccodes:ScreeningExemption rdf:type owl:Class ;
+                          rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ScreeningMethod
+ccodes:ScreeningMethod rdf:type owl:Class ;
+                       rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SecurityStatus
+ccodes:SecurityStatus rdf:type owl:Class ;
+                      rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ServiceCode
+ccodes:ServiceCode rdf:type owl:Class ;
+                   rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ShipmentSecurityStatus
+ccodes:ShipmentSecurityStatus rdf:type owl:Class ;
+                              rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SignatoryRole
+ccodes:SignatoryRole rdf:type owl:Class ;
+                     rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SignatureTypeCode
+ccodes:SignatureTypeCode rdf:type owl:Class ;
+                         rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode
+ccodes:SpecialHandlingCode rdf:type owl:Class ;
+                           rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#StatusCode
+ccodes:StatusCode rdf:type owl:Class ;
+                  rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#TemperatureUnitCode
+ccodes:TemperatureUnitCode rdf:type owl:Class ;
+                           rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#TransactionPurposeCode
+ccodes:TransactionPurposeCode rdf:type owl:Class ;
+                              rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#TransportMeansServiceType
+ccodes:TransportMeansServiceType rdf:type owl:Class ;
+                                 rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ULDChargeCode
+ccodes:ULDChargeCode rdf:type owl:Class ;
+                     rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ULDConditionCode
+ccodes:ULDConditionCode rdf:type owl:Class ;
+                        rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#ULDLoadingIndicator
+ccodes:ULDLoadingIndicator rdf:type owl:Class ;
+                           rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#VolumeUnitCode
+ccodes:VolumeUnitCode rdf:type owl:Class ;
+                      rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/coreCodeLists#WeightUnitCode
+ccodes:WeightUnitCode rdf:type owl:Class ;
+                      rdfs:subClassOf :CodeListElement .
+
+
 #################################################################
 #    Individuals
 #################################################################
@@ -10893,6 +11986,20 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                         rdfs:label "ALTERNATE_PHONE_NUMBER"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#BOOKABLE
+:BOOKABLE rdf:type owl:NamedIndividual ,
+                   :BookingOptionStatus ;
+          rdfs:comment "Used when a booking option (or proposal) is bookable"@en ;
+          rdfs:label "BOOKABLE"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#BOOKED
+:BOOKED rdf:type owl:NamedIndividual ,
+                 :BookingOptionStatus ;
+        rdfs:comment "Used when a booking option proposal is booked"@en ;
+        rdfs:label "BOOKED"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#BULK
 :BULK rdf:type owl:NamedIndividual ,
                :LoadType ;
@@ -10921,6 +12028,13 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
              rdfs:label "COMPOSITION"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#CONFIRMED
+:CONFIRMED rdf:type owl:NamedIndividual ,
+                    :BookingStatus ;
+           rdfs:comment "Used when a booking is confirmed"@en ;
+           rdfs:label "CONFIRMED"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#CUSTOMER_CONTACT
 :CUSTOMER_CONTACT rdf:type owl:NamedIndividual ,
                            :ContactRole ;
@@ -10940,6 +12054,13 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                         :CompositionType ;
                rdfs:comment "Describes a decomposition, for example the unloading of a container or the break-down of an ULD"@en ;
                rdfs:label "DECOMPOSITION"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#DELETED
+:DELETED rdf:type owl:NamedIndividual ,
+                  :BookingStatus ;
+         rdfs:comment "Used when a booking is deleted"@en ;
+         rdfs:label "DELETED"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#DIRECT
@@ -10976,6 +12097,13 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                    :EventTimeType ;
           rdfs:comment "Used when a time is expected"@en ;
           rdfs:label "EXPECTED"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#EXPIRED
+:EXPIRED rdf:type owl:NamedIndividual ,
+                  :BookingOptionStatus ;
+         rdfs:comment "Used when a booking option proposal is expired"@en ;
+         rdfs:label "EXPIRED"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#FAX_NUMBER
@@ -11083,11 +12211,32 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                       rdfs:label "MULTIMODAL_TRANSPORT"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#NONBOOKABLE
+:NONBOOKABLE rdf:type owl:NamedIndividual ,
+                      :BookingOptionStatus ;
+             rdfs:comment "Used when a booking option is nonbookable"@en ;
+             rdfs:label "NONBOOKABLE"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#NOT_BOOKABLE
+:NOT_BOOKABLE rdf:type owl:NamedIndividual ,
+                       :BookingOptionStatus ;
+              rdfs:comment "Used when a booking option proposal is not bookable"@en ;
+              rdfs:label "NOT_BOOKABLE"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#ON_CARRIAGE
 :ON_CARRIAGE rdf:type owl:NamedIndividual ,
                       :ModeQualifier ;
              rdfs:comment "Indicates the mode qualifier as on carriage"@en ;
              rdfs:label "ON_CARRIAGE"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#ON_REQUEST
+:ON_REQUEST rdf:type owl:NamedIndividual ,
+                     :BookingOptionStatus ;
+            rdfs:comment "Used when a booking option proposal is on request"@en ;
+            rdfs:label "ON_REQUEST"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#OUTBOUND
@@ -11140,11 +12289,26 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
               rdfs:label "PRE_CARRIAGE"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#QUEUED
+:QUEUED rdf:type owl:NamedIndividual ,
+                 :BookingOptionStatus ,
+                 :BookingStatus ;
+        rdfs:comment "Used when a booking or booking option is queued or pending"@en ;
+        rdfs:label "QUEUED"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#RAIL_TRANSPORT
 :RAIL_TRANSPORT rdf:type owl:NamedIndividual ,
                          :ModeCode ;
                 rdfs:comment "Indicates the transport mode to be Rail Transport (2)"@en ;
                 rdfs:label "RAIL_TRANSPORT"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#REJECTED
+:REJECTED rdf:type owl:NamedIndividual ,
+                   :BookingStatus ;
+          rdfs:comment "Used when a booking is rejected"@en ;
+          rdfs:label "REJECTED"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#REQUESTED
@@ -11253,14 +12417,19 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
          rdfs:label "WEBSITE"@en .
 
 
+###  https://onerecord.iata.org/ns/coreCodeLists#ScreeningExemption_MAIL
+ccodes:ScreeningExemption_MAIL rdf:type owl:NamedIndividual .
+
+
 #################################################################
 #    Annotations
 #################################################################
 
 :regulatedEntityCategory owl:versionInfo "v3. renamed from regulatedEntity:regulatedEntityCategory"@en ;
+                         owl:deprecated "true"@en ;
                          rdfs:comment "Party type, should be one of the following RA - Regulated Agent, KC - Known Consignor, AO - Aircraft Operator, RC - Regulated Carrier"@en ;
-                         owl:comment "Possible RDF good practice IRI: :isOfRegulatedAgentCategory "@en ;
-                         rdfs:label "regulatedEntityCategory"@en .
+                         rdfs:label "regulatedEntityCategory"@en ;
+                         owl:comment "Possible RDF good practice IRI: :isOfRegulatedAgentCategory "@en .
 
 
 ###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi

--- a/working_draft/ontology/IATA-1R-DM-Ontology.ttl
+++ b/working_draft/ontology/IATA-1R-DM-Ontology.ttl
@@ -9,11 +9,11 @@
 @base <https://onerecord.iata.org/ns/cargo> .
 
 <https://onerecord.iata.org/ns/cargo> rdf:type owl:Ontology ;
-                                       owl:versionIRI <https://onerecord.iata.org/ns/cargo/3.0.0-RC5c> ;
+                                       owl:versionIRI <https://onerecord.iata.org/ns/cargo/3.0.0-RC5d> ;
                                        dc:description "The ONE Record vocabulary, described using W3C RDF Schema and the Web Ontology Language."@en ;
                                        dc:title "ONE Record Ontology"@en ;
                                        terms:abstract "The ontology of the ONE Record standard is the core data model underlying the Linked Data solution drafted by the ONE Record standard: https://github.com/IATA-Cargo/ONE-Record. ONE Record is a standard for data sharing and creates a single record view of the shipment. This standard defines a common data model for the data that is shared via standardized and secured web API."@en ;
-                                       terms:modified "12-07-2023" ;
+                                       terms:modified "02-08-2023" ;
                                        terms:title "ONE Record Ontology"@en ;
                                        rdfs:comment """Details availalble on GitHub https://github.com/IATA-Cargo/ONE-Record
 Version 2.0.0
@@ -74,10 +74,19 @@ Version 3.0.0 RC5b
 - Moved chargesAtDestination from Waybill to TotalCharge
 - Added object property totalCollectCharges with Range Value and added it to TotalCharge
 Version 3.0.0 RC5c
-- Moved CustomsInformation from Piece to Shipment"""@en ;
+- Moved CustomsInformation from Piece to Shipment
+Version 3.0.0 RC5d
+- Renamed property operatedTransportMovements in operatedTransportMovement
+- Added max 1 cardinality restriction to operatedTransportMovement in TransportMeans
+- Redesigned UnitComposition, Composing and LoadingUnit to be consistent with TransportMovement, Loading and TransportMeans and to enhance ability to query data (for orchestration) 
+- Renamed loadingUnit property to onLoadingUnit, changed Domain to owl:Thing
+- Added onLoadingUnit property to UnitComposition
+- Added property inUnitComposition to LoadingUnit (inverse)
+- Added properties subLocations and subLocationOf to model hierarchical relationships between Locations
+- Renamed forActions to performedActions to better reflect its inverse property performedAtLocation"""@en ;
                                        rdfs:isDefinedBy "https://www.iata.org/one-record/"^^xsd:anyURI ;
                                        rdfs:label "ONE Record Ontology"@en ;
-                                       owl:versionInfo "3.0.0 RC 5c"@en .
+                                       owl:versionInfo "3.0.0 RC 5d"@en .
 
 #################################################################
 #    Annotation properties
@@ -966,15 +975,6 @@ owl:thing rdf:type rdfs:Datatype .
                     owl:versionInfo "v1.1 renamed to externalReferences"@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#forActions
-:forActions rdf:type owl:ObjectProperty ;
-            rdfs:domain :Location ;
-            rdfs:range :LogisticsAction ;
-            rdfs:comment "References to the Actions happening at the Location"@en ;
-            rdfs:label "forActions"@en ;
-            owl:comment "Possible RDF good practice IRI: :isLocationOfAction "@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#forBookingOption
 :forBookingOption rdf:type owl:ObjectProperty ;
                   rdfs:domain owl:Thing ;
@@ -1139,6 +1139,14 @@ owl:thing rdf:type rdfs:Datatype .
             owl:comment "Possible RDF good practice IRI: :hasRegulatedEntityIdentifier "@en ;
             owl:deprecated "true"@en ;
             owl:versionInfo "v3.0 renamed from regulatedEntity:regulatedEntityIdentifier"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#inUnitComposition
+:inUnitComposition rdf:type owl:ObjectProperty ;
+                   rdfs:domain :LoadingUnit ;
+                   rdfs:range :UnitComposition ;
+                   dc:description "Reference to the Unit Composition the LoadingUnit is in"@en ;
+                   rdfs:label "inUnitComposition"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#insurance
@@ -1317,10 +1325,10 @@ owl:thing rdf:type rdfs:Datatype .
 
 ###  https://onerecord.iata.org/ns/cargo#loadingUnit
 :loadingUnit rdf:type owl:ObjectProperty ;
-             rdfs:domain :Composing ;
+             rdfs:domain owl:Thing ;
              rdfs:range :LoadingUnit ;
-             rdfs:comment "Reference to the LoadingUnit being built-up or broken-down"@en ;
-             rdfs:label "loadingUnit"@en ;
+             rdfs:comment "Reference to the LoadingUnit composed in the Unit Composition or referenced in Composing actions"@en ;
+             rdfs:label "onLoadingUnit"@en ;
              owl:comment "Possible RDF good practice IRI: :composesOnLoadingUnit "@en .
 
 
@@ -1420,13 +1428,13 @@ owl:thing rdf:type rdfs:Datatype .
                   owl:comment "Possible RDF good practice IRI: :loadsOnTransportMeans "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#operatedTransportMovements
-:operatedTransportMovements rdf:type owl:ObjectProperty ;
-                            rdfs:domain :TransportMeans ;
-                            rdfs:range :TransportMovement ;
-                            rdfs:comment "Transport Movement on which the Transport Means is used"@en ;
-                            rdfs:label "operatedTransportMovements"@en ;
-                            owl:comment "Possible RDF good practice IRI: :operatesTransportMovement "@en .
+###  https://onerecord.iata.org/ns/cargo#operatedTransportMovement
+:operatedTransportMovement rdf:type owl:ObjectProperty ;
+                           rdfs:domain :TransportMeans ;
+                           rdfs:range :TransportMovement ;
+                           rdfs:comment "Transport Movement on which the Transport Means is used"@en ;
+                           rdfs:label "operatedTransportMovement"@en ;
+                           owl:comment "Possible RDF good practice IRI: :operatesTransportMovement "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#operatingTransportMeans
@@ -1587,6 +1595,15 @@ owl:thing rdf:type rdfs:Datatype .
          rdfs:label "payload"@en ;
          owl:comment "Possible RDF good practice IRI: :hasPayload "@en ;
          owl:deprecated "true"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#perfomedActions
+:perfomedActions rdf:type owl:ObjectProperty ;
+                 rdfs:domain :Location ;
+                 rdfs:range :LogisticsAction ;
+                 rdfs:comment "References to the Actions happening at the Location"@en ;
+                 rdfs:label "performedActions"@en ;
+                 owl:comment "Possible RDF good practice IRI: :isLocationOfAction "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#performedAtLocation
@@ -1940,6 +1957,22 @@ owl:thing rdf:type rdfs:Datatype .
                 rdfs:comment "References to all StoringActions performed for the Storing Activity"@en ;
                 rdfs:label "storingActions"@en ;
                 owl:comment "Possible RDF good practice IRI: :hasStoringActions "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#subLocationOf
+:subLocationOf rdf:type owl:ObjectProperty ;
+               rdfs:domain :Location ;
+               rdfs:range :Location ;
+               dc:title "subLocationOf"@en ;
+               owl:comment "Reference to the Location this Location is a part of, for example the warehouse if the Location describes a specific truckdeck"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#subLocations
+:subLocations rdf:type owl:ObjectProperty ;
+              rdfs:domain :Location ;
+              rdfs:range :Location ;
+              dc:title "subLocations"@en ;
+              owl:comment "References to all Locations which are part of this Location, for example separate truck decks of a warehouse"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#subOrganization
@@ -7953,7 +7986,8 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                  ] ;
                  rdfs:comment "Activity to describe onloading and offloading processes"@en ;
-                 rdfs:label "LoadingActivity"@en .
+                 rdfs:label "LoadingActivity"@en ;
+                 owl:deprecated "true"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#LoadingMaterial
@@ -8011,12 +8045,20 @@ Condition: At least one of the three elements (Country Code, Information Identif
 :LoadingUnit rdf:type owl:Class ;
              rdfs:subClassOf :PhysicalLogisticsObject ,
                              [ rdf:type owl:Restriction ;
+                               owl:onProperty :inUnitComposition ;
+                               owl:allValuesFrom :UnitComposition
+                             ] ,
+                             [ rdf:type owl:Restriction ;
                                owl:onProperty :loadedPiecesOnLoadingUnit ;
                                owl:allValuesFrom :Piece
                              ] ,
                              [ rdf:type owl:Restriction ;
                                owl:onProperty :tareWeight ;
                                owl:allValuesFrom :Value
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty :inUnitComposition ;
+                               owl:maxCardinality "1"^^xsd:nonNegativeInteger
                              ] ,
                              [ rdf:type owl:Restriction ;
                                owl:onProperty :tareWeight ;
@@ -8050,12 +8092,20 @@ Condition: At least one of the three elements (Country Code, Information Identif
                             owl:allValuesFrom :Address
                           ] ,
                           [ rdf:type owl:Restriction ;
-                            owl:onProperty :forActions ;
+                            owl:onProperty :geolocation ;
+                            owl:allValuesFrom :Geolocation
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty :perfomedActions ;
                             owl:allValuesFrom :LogisticsAction
                           ] ,
                           [ rdf:type owl:Restriction ;
-                            owl:onProperty :geolocation ;
-                            owl:allValuesFrom :Geolocation
+                            owl:onProperty :subLocationOf ;
+                            owl:allValuesFrom :Location
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty :subLocations ;
+                            owl:allValuesFrom :Location
                           ] ,
                           [ rdf:type owl:Restriction ;
                             owl:onProperty :address ;
@@ -8063,6 +8113,10 @@ Condition: At least one of the three elements (Country Code, Information Identif
                           ] ,
                           [ rdf:type owl:Restriction ;
                             owl:onProperty :geolocation ;
+                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty :subLocationOf ;
                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
                           ] ,
                           [ rdf:type owl:Restriction ;
@@ -8089,7 +8143,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
                             owl:onProperty :locationType ;
                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
                           ] ;
-          rdfs:comment "Loading location details"@en ;
+          rdfs:comment "Location describes a physical location, e.g. an airport, a warehouse or a truck deck"@en ;
           rdfs:label "Location"@en .
 
 
@@ -10236,7 +10290,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
 :TransportMeans rdf:type owl:Class ;
                 rdfs:subClassOf :PhysicalLogisticsObject ,
                                 [ rdf:type owl:Restriction ;
-                                  owl:onProperty :operatedTransportMovements ;
+                                  owl:onProperty :operatedTransportMovement ;
                                   owl:allValuesFrom :TransportMovement
                                 ] ,
                                 [ rdf:type owl:Restriction ;
@@ -10250,6 +10304,10 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                 [ rdf:type owl:Restriction ;
                                   owl:onProperty :typicalFuelConsumption ;
                                   owl:allValuesFrom :Value
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty :operatedTransportMovement ;
+                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                 ] ,
                                 [ rdf:type owl:Restriction ;
                                   owl:onProperty :transportOrganization ;
@@ -10541,6 +10599,14 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                    owl:allValuesFrom :Composing
                                  ] ,
                                  [ rdf:type owl:Restriction ;
+                                   owl:onProperty :loadingUnit ;
+                                   owl:allValuesFrom :LoadingUnit
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty :loadingUnit ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
                                    owl:onProperty :compositionIdentifier ;
                                    owl:allValuesFrom xsd:string
                                  ] ,
@@ -10548,7 +10614,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                    owl:onProperty :compositionIdentifier ;
                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                  ] ;
-                 rdfs:comment "Activity to describe build-up and break-down processes"@en ;
+                 rdfs:comment "Activity to describe composition and decomposition of LoadingUnits"@en ;
                  rdfs:label "UnitComposition"@en .
 
 

--- a/working_draft/ontology/IATA-1R-DM-Ontology.ttl
+++ b/working_draft/ontology/IATA-1R-DM-Ontology.ttl
@@ -10,12 +10,12 @@
 @base <https://onerecord.iata.org/ns/cargo> .
 
 <https://onerecord.iata.org/ns/cargo> rdf:type owl:Ontology ;
-                                       owl:versionIRI <https://onerecord.iata.org/ns/cargo/3.0.0-RC5f> ;
-                                       owl:imports <https://onerecord.iata.org/ns/coreCodeLists/0.0.1> ;
+                                       owl:versionIRI <https://onerecord.iata.org/ns/cargo/3.0.0-RC5g> ;
+                                       owl:imports <https://onerecord.iata.org/ns/coreCodeLists/0.0.2> ;
                                        dc:description "The ONE Record vocabulary, described using W3C RDF Schema and the Web Ontology Language."@en ;
                                        dc:title "ONE Record Ontology"@en ;
                                        terms:abstract "The ontology of the ONE Record standard is the core data model underlying the Linked Data solution drafted by the ONE Record standard: https://github.com/IATA-Cargo/ONE-Record. ONE Record is a standard for data sharing and creates a single record view of the shipment. This standard defines a common data model for the data that is shared via standardized and secured web API."@en ;
-                                       terms:modified "23-08-2023" ;
+                                       terms:modified "28-08-2023" ;
                                        terms:title "ONE Record Ontology"@en ;
                                        rdfs:comment """Details availalble on GitHub https://github.com/IATA-Cargo/ONE-Record
 Version 2.0.0
@@ -96,10 +96,13 @@ Version 3.0.0 RC5f - Code list integration part I - Integration playbook pending
 - Renamed code to locationCode
 - Moved slac from LoadingUnit to UnitComposition; changed Domain to owl:Thing
 - Added partialEventIndicator to LogisticsEvent for part events
-- Added otherIdentifier to LogisticActions to be able to transmit custom identifiers such as Loading/Unloading lists in trucking/milk runs"""@en ;
+- Added otherIdentifier to LogisticActions to be able to transmit custom identifiers such as Loading/Unloading lists in trucking/milk runs
+Version 3.0.0 RC5g - Code list integration part II - Integration playbook pending
+- Converted the remaning enums into code lists
+- Aligned with core code lists ontology 0.0.2"""@en ;
                                        rdfs:isDefinedBy "https://www.iata.org/one-record/"^^xsd:anyURI ;
                                        rdfs:label "ONE Record Ontology"@en ;
-                                       owl:versionInfo "3.0.0 RC 5f"@en .
+                                       owl:versionInfo "3.0.0 RC 5g"@en .
 
 #################################################################
 #    Annotation properties
@@ -242,7 +245,7 @@ owl:thing rdf:type rdfs:Datatype .
 :amountTotal rdf:type owl:ObjectProperty ;
              rdfs:domain :TotalCharge ;
              rdfs:range :Value ;
-             rdfs:comment "Total amount prepaid or collect as per bullet points 20/21 - data elements 24A - 30B  from AWB"@en ;
+             rdfs:comment "Total amount prepaid or collect as per bullet points 2/21 - data elements 24A - 3B  from AWB"@en ;
              rdfs:label "amountTotal"@en .
 
 
@@ -336,6 +339,15 @@ owl:thing rdf:type rdfs:Datatype .
                   rdfs:comment "Reference to the PhysicalLogisticsObject the IotDevice is attached to"@en ;
                   rdfs:label "attachedToObject"@en ;
                   owl:comment "Possible RDF good practice IRI: :isAttachedToObject "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#awbUseIndicator
+:awbUseIndicator rdf:type owl:ObjectProperty ;
+                 rdfs:domain :BillingDetails ;
+                 rdfs:range ccodes:AWBUseIndicator ;
+                 rdfs:comment "It must either contain the values of R for Revenue AWB, V for Void AWB or S for Service AWB."@en ;
+                 rdfs:label "awbUseIndicator"@en ;
+                 owl:comment "Possible RDF good practice IRI: :hasAwbUseIndicator "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#basedAtLocation
@@ -534,7 +546,7 @@ owl:thing rdf:type rdfs:Datatype .
 :chargeType rdf:type owl:ObjectProperty ;
             rdfs:domain owl:Thing ;
             rdfs:range ccodes:ChargeIdentifier ;
-            rdfs:comment "Charge type related to amount total as per bullet points 20/21 - data elements 24A - 30B  from AWB"@en ;
+            rdfs:comment "Charge type related to amount total as per bullet points 2/21 - data elements 24A - 3B  from AWB"@en ;
             rdfs:label "chargeType"@en ;
             owl:comment "Possible RDF good practice IRI: :hasChargeType "@en .
 
@@ -616,6 +628,15 @@ owl:thing rdf:type rdfs:Datatype .
         rdfs:comment "References to the CheckActions performed on the object"@en ;
         rdfs:label "checks"@en ;
         owl:comment "Possible RDF good practice IRI: :hasCheck "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#cityCode
+:cityCode rdf:type owl:ObjectProperty ;
+          rdfs:domain :Address ;
+          rdfs:range :CodeListElement ;
+          rdfs:comment "UN/LOCODE city code (5 letter) or IATA city code (3 letter)"@en ;
+          rdfs:label "cityCode"@en ;
+          owl:comment "Possible RDF good practice IRI: :hasCityCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#co2Emissions
@@ -898,6 +919,16 @@ Condition: At least one of the three elements (Country Code, Information Identif
                               rdfs:label "customsInformationOfShipment"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#customsOriginCode
+:customsOriginCode rdf:type owl:ObjectProperty ;
+                   rdfs:domain :Waybill ;
+                   rdfs:range :CodeListElement ;
+                   rdfs:comment """Code indicating the origin of goods for Customs purposes (e.g. For goods in free circulation in the EU) 
+List to be provided by local authorities"""@en ;
+                   rdfs:label "customsOriginCode"@en ;
+                   owl:comment "Possible RDF good practice IRI: :hasCustomsOriginCode "@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#declaredValueForCarriage
 :declaredValueForCarriage rdf:type owl:ObjectProperty ;
                           rdfs:domain :Waybill ;
@@ -922,6 +953,15 @@ Condition: At least one of the three elements (Country Code, Information Identif
                   rdfs:label "deliveryLocation"@en ;
                   owl:comment "Possible RDF good practice IRI: :hasDeliveryLocation "@en ;
                   owl:deprecated "true"^^xsd:boolean .
+
+
+###  https://onerecord.iata.org/ns/cargo#demurrageCode
+:demurrageCode rdf:type owl:ObjectProperty ;
+               rdfs:domain :LoadingUnit ;
+               rdfs:range ccodes:DemurrageCode ;
+               rdfs:comment "Contains three designator of demurrage code, refer to RP 1654 (BCC, HHH, XXX, ZZZ)"@en ;
+               rdfs:label "demurrageCode"@en ;
+               owl:comment "Possible RDF good practice IRI: :hasDemurrageCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#departureLocation
@@ -963,6 +1003,15 @@ Condition: At least one of the three elements (Country Code, Information Identif
                      owl:versionInfo "v3. renamed from product:isInItems"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#destinationCurrencyCode
+:destinationCurrencyCode rdf:type owl:ObjectProperty ;
+                         rdfs:domain :Waybill ;
+                         rdfs:range :CodeListElement ;
+                         rdfs:comment "ISO 3-letter currency code of destination. Refer to ISO 4217"@en ;
+                         rdfs:label "destinationCurrencyCode"@en ;
+                         owl:comment "Possible RDF good practice IRI: :hasDestinationCurrencyCode "@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#detailedWaybill
 :detailedWaybill rdf:type owl:ObjectProperty ;
                  rdfs:domain :BillingDetails ;
@@ -979,6 +1028,15 @@ Condition: At least one of the three elements (Country Code, Information Identif
                rdfs:comment "Reference to the Dangerous Goods declaration"@en ;
                rdfs:label "dgDeclaration"@en ;
                owl:comment "Possible RDF good practice IRI: :hasDgDeclaration "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#dgRaTypeCode
+:dgRaTypeCode rdf:type owl:ObjectProperty ;
+              rdfs:domain :DgProductRadioactive ;
+              rdfs:range ccodes:RaTypeCode ;
+              rdfs:comment "The category of the package or all packed in one. Complete text to be transmitted: I-White, II-Yellow, III-Yellow instead of I, II, III"@en ;
+              rdfs:label "dgRaTypeCode"@en ;
+              owl:comment "Possible RDF good practice IRI: :hasDgRaTypeCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#dgRadioactiveMaterial
@@ -1137,6 +1195,15 @@ Condition: At least one of the three elements (Country Code, Information Identif
                  owl:comment "Possible RDF good practice IRI: :hasExecutionStatus "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#explosiveCompatibilityGroupCode
+:explosiveCompatibilityGroupCode rdf:type owl:ObjectProperty ;
+                                 rdfs:domain :ProductDg ;
+                                 rdfs:range ccodes:ExplosiveCompatibilityGroupCode ;
+                                 rdfs:comment "Specifies the reference to the group which identifies the kind of substances and articles that are deemed to be compatible. Mandatory field in case of transport of explosive articles or substances"@en ;
+                                 rdfs:label "explosiveCompatibilityGroupCode"@en ;
+                                 owl:comment "Possible RDF good practice IRI: :hasExplosiveCompatibilityGroupCode "@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#exportTradeCountry
 :exportTradeCountry rdf:type owl:ObjectProperty ;
                     rdfs:domain :PieceLiveAnimals ;
@@ -1247,6 +1314,15 @@ Condition: At least one of the three elements (Country Code, Information Identif
                     owl:comment "Possible RDF good practice IRI: :hasMeasuredFuelAmount "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#fulfillsUldTypeCode
+:fulfillsUldTypeCode rdf:type owl:ObjectProperty ;
+                     rdfs:domain :Piece ;
+                     rdfs:range :CodeListElement ;
+                     rdfs:comment "Text holding an ULD Type Code if the Piece fulfills it before UnitComposition"@en ;
+                     rdfs:label "fulfillsUldTypeCode"@en ;
+                     owl:comment "Possible RDF good practice IRI: :fulfillsUldTypeCode "@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#geolocation
 :geolocation rdf:type owl:ObjectProperty ;
              rdfs:domain :Location ;
@@ -1263,6 +1339,24 @@ Condition: At least one of the three elements (Country Code, Information Identif
                  rdfs:comment "Reference to the Location from which the Question was answered, relevant for split checks with documentary and physical elements"@en ;
                  rdfs:label "givenAtLocation"@en ;
                  owl:comment "Possible RDF good practice IRI: :isGivenAt "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#goodsTypeCode
+:goodsTypeCode rdf:type owl:ObjectProperty ;
+               rdfs:domain :PieceLiveAnimals ;
+               rdfs:range ccodes:GoodsTypeCode ;
+               rdfs:comment "Appendix number of the convention (I, II or III) (box 1)"@en ;
+               rdfs:label "goodsTypeCode"@en ;
+               owl:comment "Possible RDF good practice IRI: :hasGoodsTypeCode "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#goodsTypeExtensionCode
+:goodsTypeExtensionCode rdf:type owl:ObjectProperty ;
+                        rdfs:domain :PieceLiveAnimals ;
+                        rdfs:range ccodes:GoodsTypeExtensionCode ;
+                        rdfs:comment "Appendix number of the convention (I, II or III) (box 1)"@en ;
+                        rdfs:label "goodsTypeExtensionCode"@en ;
+                        owl:comment "Possible RDF good practice IRI: :hasGoodsTypeExtensionCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#grossWeight
@@ -1351,6 +1445,15 @@ TRNS - transfer or transshipment"""@en ;
                    rdfs:range :UnitComposition ;
                    dc:description "Reference to the Unit Composition the LoadingUnit is in"@en ;
                    rdfs:label "inUnitComposition"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#incoterms
+:incoterms rdf:type owl:ObjectProperty ;
+           rdfs:domain :Shipment ;
+           rdfs:range :CodeListElement ;
+           rdfs:comment "Standard codes as defined by UNCEFACT and ICC that correspond to international rules for the interpretation of the most commonly used trade terms in different countries. UNECE recommendation n. 5 Incoterms 2."@en ;
+           rdfs:label "incoterms"@en ;
+           owl:comment "Possible RDF good practice IRI: :hasIncoterms "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#insurance
@@ -1563,6 +1666,15 @@ TRNS - transfer or transshipment"""@en ;
              owl:comment "Possible RDF good practice IRI: :composesOnLoadingUnit "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#locationCode
+:locationCode rdf:type owl:ObjectProperty ;
+              rdfs:domain :Location ;
+              rdfs:range :CodeListElement ;
+              rdfs:comment "Location code of airport, freight terminal, seaport, rail station. UN/LOCODE city code (5 letter) or IATA airport code (3 letter)"@en ;
+              rdfs:label "locationCode"@en ;
+              owl:comment "Possible RDF good practice IRI: :hasLocationCode "@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#manufacturer
 :manufacturer rdf:type owl:ObjectProperty ;
               rdfs:domain :PhysicalLogisticsObject ;
@@ -1621,6 +1733,15 @@ TRNS - transfer or transshipment"""@en ;
                    owl:versionInfo "v3. renamed from sensorOther:val"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#modeCode
+:modeCode rdf:type owl:ObjectProperty ;
+          rdfs:domain :TransportMovement ;
+          rdfs:range :ModeCode ;
+          rdfs:comment "Mode of transport code, refer to UNECE Rec. 19 https://unece.org/fileadmin/DAM/cefact/recommendations/rec19/rec19_1cf19e.pdf"@en ;
+          rdfs:label "modeCode"@en ;
+          owl:comment "Possible RDF good practice IRI: :hasModeCode "@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#modeQualifier
 :modeQualifier rdf:type owl:ObjectProperty ;
                rdfs:domain :TransportMovement ;
@@ -1664,6 +1785,15 @@ TRNS - transfer or transshipment"""@en ;
                   rdfs:comment "The total net weight of dangerous goods transported of this line item. For air transport the value must be the volume or mass in each package."@en ;
                   rdfs:label "netWeightMeasure"@en ;
                   owl:comment "Possible RDF good practice IRI: :hasNetWeightMeasure "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#odlnCode
+:odlnCode rdf:type owl:ObjectProperty ;
+          rdfs:domain :LoadingUnit ;
+          rdfs:range :CodeListElement ;
+          rdfs:comment "Contains two designator codes of ODLN or Operational Damage Limit Notices. ODLN code is used to define type of damage after visually check the serviceability of ULDs section 7, Standard Specifications 4/3 or 4/4 in ULD Regulations"@en ;
+          rdfs:label "odlnCode"@en ;
+          owl:comment "Possible RDF good practice IRI: :hasOdlnCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#ofProduct
@@ -1711,6 +1841,24 @@ TRNS - transfer or transshipment"""@en ;
               rdfs:comment "Reference to the Organization acting in the role of this Party"@en ;
               rdfs:label "organization"@en ;
               owl:comment "Possible RDF good practice IRI: :describesRoleOfOrganization "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#originCurrency
+:originCurrency rdf:type owl:ObjectProperty ;
+                rdfs:domain :Waybill ;
+                rdfs:range :CodeListElement ;
+                rdfs:comment "ISO alpha 3 Code used to indicate the Origin Currency, refer to ISO 4217 currency codes"@en ;
+                rdfs:label "originCurrency" ;
+                owl:comment "Possible RDF good practice IRI: :hasOriginCurrencyCode "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#originReferencePermitTypeCode
+:originReferencePermitTypeCode rdf:type owl:ObjectProperty ;
+                               rdfs:domain :PieceLiveAnimals ;
+                               rdfs:range :CodeListElement ;
+                               rdfs:comment "Document type code of origin reference permit or re-export reference Certificate (box 12/12a)"@en ;
+                               rdfs:label "originReferencePermitTypeCode"@en ;
+                               owl:comment "Possible RDF good practice IRI: :hasOriginReferencePermitTypeCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#originTradeCountry
@@ -1807,6 +1955,24 @@ TRNS - transfer or transshipment"""@en ;
                         owl:versionInfo "v3. renamed from securityDeclaration:otherRegulatedEntity"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#overpackTypeCode
+:overpackTypeCode rdf:type owl:ObjectProperty ;
+                  rdfs:domain :PieceDg ;
+                  rdfs:range :CodeListElement ;
+                  rdfs:comment "Identifies the Logistic Unit package type. UN Recommendation on Transport of Dangerous Goods, Model Regulations "@en ;
+                  rdfs:label "overpackTypeCode"@en ;
+                  owl:comment "Possible RDF good practice IRI: :hasOverpackTypeCode "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#ownerCode
+:ownerCode rdf:type owl:ObjectProperty ;
+           rdfs:domain :LoadingUnit ;
+           rdfs:range :CodeListElement ;
+           rdfs:comment "Owner code of the ULD in aa, an or na format - owner can be an airline or leasing company"@en ;
+           rdfs:label "ownerCode"@en ;
+           owl:comment "Possible RDF good practice IRI: :hasOwnerCode "@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#owningOrganization
 :owningOrganization rdf:type owl:ObjectProperty ;
                     rdfs:domain :RegulatedEntity ;
@@ -1814,6 +1980,24 @@ TRNS - transfer or transshipment"""@en ;
                     rdfs:comment "Reference to the Organization for which the RegulatedEntity information is valid"@en ;
                     rdfs:label "owningOrganization"@en ;
                     owl:comment "Possible RDF good practice IRI: :belongsToOrganization "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#packageMarkCoded
+:packageMarkCoded rdf:type owl:ObjectProperty ;
+                  rdfs:domain :Piece ;
+                  rdfs:range ccodes:PackageMarkCode ;
+                  rdfs:comment "Reference identifying how the package is marked. Field is hardcode to \"SSCC-18\", \"UPC\" or \"Other\""@en ;
+                  rdfs:label "packageMarkCoded"@en ;
+                  owl:comment "Possible RDF good practice IRI: :hasPackageMarkCode "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#packagingDangerLevelCode
+:packagingDangerLevelCode rdf:type owl:ObjectProperty ;
+                          rdfs:domain :ProductDg ;
+                          rdfs:range ccodes:PackagingDangerLevelCode ;
+                          rdfs:comment "Packing group, If used must reference I, II or III"@en ;
+                          rdfs:label "packagingDangerLevelCode"@en ;
+                          owl:comment "Possible RDF good practice IRI: :hasPackagingDangerLevelCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#packagingType
@@ -1889,6 +2073,24 @@ TRNS - transfer or transshipment"""@en ;
              rdfs:comment "Reference to the Location the Action was performed at"@en ;
              rdfs:label "perfomedAt"@en ;
              owl:comment "Possible RDF good practice IRI: :isPerformedAt "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#permitTypeCode
+:permitTypeCode rdf:type owl:ObjectProperty ;
+                rdfs:domain :LiveAnimalsEpermit ;
+                rdfs:range :CodeListElement ;
+                rdfs:comment "Code specifying the document name. (box 1)"@en ;
+                rdfs:label "permitTypeCode"@en ;
+                owl:comment "Possible RDF good practice IRI: :hasPermitTypeCode "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#physicalChemicalForm
+:physicalChemicalForm rdf:type owl:ObjectProperty ;
+                      rdfs:domain :DgRadioactiveIsotope ;
+                      rdfs:range :CodeListElement ;
+                      rdfs:comment "A description of the physical and chemical form of the material."@en ;
+                      rdfs:label "physicalChemicalForm"@en ;
+                      owl:comment "Possible RDF good practice IRI: :hasPhysicalChemicalForm "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#postalCode
@@ -2030,6 +2232,15 @@ TRNS - transfer or transshipment"""@en ;
                    rdfs:comment "Ratings preferences of the request"@en ;
                    rdfs:label "ratingsPreference"@en ;
                    owl:comment "Possible RDF good practice IRI: :hasRatingsPreference "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#ratingsType
+:ratingsType rdf:type owl:ObjectProperty ;
+             rdfs:domain :Ratings ;
+             rdfs:range ccodes:RatingsType ;
+             rdfs:comment "Used to identify if the Ratings are Face, Published or Actual ratings. Expected values are F, A, C."@en ;
+             rdfs:label "ratingsType" ;
+             owl:comment "Possible RDF good practice IRI: :hasRatingsType "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#receivedFrom
@@ -2321,6 +2532,24 @@ AOM - Subjected to any other means: this entry should be followed by free text s
                   owl:comment "Possible RDF good practice IRI: :hasSignatoryCompany "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#signatoryRole
+:signatoryRole rdf:type owl:ObjectProperty ;
+               rdfs:domain :EpermitSignature ;
+               rdfs:range ccodes:SignatoryRole ;
+               rdfs:comment "Role of the signatory with regards to the ePermit: Applicant, Permit issuer, Issuing Authority or Examining authority"@en ;
+               rdfs:label "signatoryRole"@en ;
+               owl:comment "Possible RDF good practice IRI: :hasSignatoryRole "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#signatureTypeCode
+:signatureTypeCode rdf:type owl:ObjectProperty ;
+                   rdfs:domain :EpermitSignature ;
+                   rdfs:range ccodes:SignatureTypeCode ;
+                   rdfs:comment "Code specifying a type of government action such as inspection, detention, fumigation, security."@en ;
+                   rdfs:label "signatureTypeCode"@en ;
+                   owl:comment "Possible RDF good practice IRI: :hasSignatureTypeCode "@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#signatures
 :signatures rdf:type owl:ObjectProperty ;
             rdfs:domain :LiveAnimalsEpermit ;
@@ -2345,6 +2574,15 @@ AOM - Subjected to any other means: this entry should be followed by free text s
                       rdfs:range ccodes:SpecialHandlingCode ;
                       rdfs:comment "Three-letter special handling code (SPH)"@en ;
                       rdfs:label "specialHandlingCodes"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#specimenTypeCode
+:specimenTypeCode rdf:type owl:ObjectProperty ;
+                  rdfs:domain :PieceLiveAnimals ;
+                  rdfs:range :CodeListElement ;
+                  rdfs:comment "Description of specimens, CITES type code (box 9)"@en ;
+                  rdfs:label "specimenTypeCode"@en ;
+                  owl:comment "Possible RDF good practice IRI: :hasSpecimenTypeCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#storedObjects
@@ -2506,6 +2744,24 @@ Condition: At least one of the three elements (Country Code, Information Identif
                        owl:comment "Possible RDF good practice IRI: :hasTotalVolumetricWeight "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#transactionPurposeCode
+:transactionPurposeCode rdf:type owl:ObjectProperty ;
+                        rdfs:domain :LiveAnimalsEpermit ;
+                        rdfs:range ccodes:TransactionPurposeCode ;
+                        rdfs:comment "Code indicating the purpose of the transaction (box 5a)"@en ;
+                        rdfs:label "transactionPurposeCode"@en ;
+                        owl:comment "Possible RDF good practice IRI: :hasTransactionPurposeCode "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#transportContractTypeCode
+:transportContractTypeCode rdf:type owl:ObjectProperty ;
+                           rdfs:domain :LiveAnimalsEpermit ;
+                           rdfs:range :CodeListElement ;
+                           rdfs:comment "Code specifying the transport document name (box 15)"@en ;
+                           rdfs:label "transportContractTypeCode"@en ;
+                           owl:comment "Possible RDF good practice IRI: :hasTransportContractTypeCode "@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#transportMovement
 :transportMovement rdf:type owl:ObjectProperty ;
                    rdfs:domain owl:Thing ;
@@ -2553,6 +2809,15 @@ Condition: At least one of the three elements (Country Code, Information Identif
                  owl:deprecated "true"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#typeCode
+:typeCode rdf:type owl:ObjectProperty ;
+          rdfs:domain :PackagingType ;
+          rdfs:range :CodeListElement ;
+          rdfs:comment "Packaging type identifier as per UNECE Rec 21 Annex V and VI e.g. 1A - Drum, steel - Packaging material code. Identifies the Logistic Unit package type. UN Recommendation on Transport of Dangerous Goods, Model Regulations "@en ;
+          rdfs:label "typeCode"@en ;
+          owl:comment "Possible RDF good practice IRI: :hasTypeCode "@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#typicalCo2Coefficient
 :typicalCo2Coefficient rdf:type owl:ObjectProperty ;
                        rdfs:domain :TransportMeans ;
@@ -2571,6 +2836,14 @@ Condition: At least one of the three elements (Country Code, Information Identif
                         owl:comment "Possible RDF good practice IRI: :hasFuelConsumption "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#uldRateClassType
+:uldRateClassType rdf:type owl:ObjectProperty ;
+                  rdfs:domain :TACTRateDescription ;
+                  rdfs:range :CodeListElement ;
+                  rdfs:comment "ULD Rate information - ULD Rate Class Type"@en ;
+                  rdfs:label "uldRateClassType"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#uldReference
 :uldReference rdf:type owl:ObjectProperty ;
               rdfs:domain :Piece ;
@@ -2579,6 +2852,15 @@ Condition: At least one of the three elements (Country Code, Information Identif
               rdfs:label "uldReference"@en ;
               owl:comment "Possible RDF good practice IRI: :isLoadedOnULD "@en ;
               owl:deprecated "true"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#uldTypeCode
+:uldTypeCode rdf:type owl:ObjectProperty ;
+             rdfs:domain :LoadingUnit ;
+             rdfs:range :CodeListElement ;
+             rdfs:comment "Standard Unit Load Device type code e.g. AKE - Certified Container - Contoured. Refer to IATA ULD Technical Manual"@en ;
+             rdfs:label "uldTypeCode"@en ;
+             owl:comment "Possible RDF good practice IRI: :hasULDTypeCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#unitPrice
@@ -2614,6 +2896,15 @@ Condition: At least one of the three elements (Country Code, Information Identif
               rdfs:comment "Reference to the Template used in the Check"@en ;
               rdfs:label "usedTemplate"@en ;
               owl:comment "Possible RDF good practice IRI: :usesTemplate "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#vehicleType
+:vehicleType rdf:type owl:ObjectProperty ;
+             rdfs:domain :TransportMeans ;
+             rdfs:range :CodeListElement ;
+             rdfs:comment "Vehicle or container type. Refer UNECE28, e.g. 4.. - Aircraft, type unknown.For Air refer to IATA Standard Schedules Information Manua in section ATA/IATA Aircraft Types"@en ;
+             rdfs:label "vehicleType"@en ;
+             owl:comment "Possible RDF good practice IRI: :isOfVehicleType "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#volume
@@ -2898,26 +3189,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                   owl:comment "Possible RDF good practice IRI: :hasAwbExecutionDate "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#awbUseIndicator
-:awbUseIndicator rdf:type owl:DatatypeProperty ;
-                 rdfs:domain :BillingDetails ;
-                 rdfs:range [ rdf:type rdfs:Datatype ;
-                              owl:oneOf [ rdf:type rdf:List ;
-                                          rdf:first "R" ;
-                                          rdf:rest [ rdf:type rdf:List ;
-                                                     rdf:first "S" ;
-                                                     rdf:rest [ rdf:type rdf:List ;
-                                                                rdf:first "V" ;
-                                                                rdf:rest rdf:nil
-                                                              ]
-                                                   ]
-                                        ]
-                            ] ;
-                 rdfs:comment "It must either contain the values of R for Revenue AWB, V for Void AWB or S for Service AWB."@en ;
-                 rdfs:label "awbUseIndicator"@en ;
-                 owl:comment "Possible RDF good practice IRI: :hasAwbUseIndicator "@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#batchNumber
 :batchNumber rdf:type owl:DatatypeProperty ;
              rdfs:domain :Item ;
@@ -3029,15 +3300,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
           rdfs:label "checksum"@en ;
           owl:comment "Possible RDF good practice IRI: :hasChecksum "@en ;
           owl:versionInfo "v3. renamed from externalReference:documentChecksum"@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#cityCode
-:cityCode rdf:type owl:DatatypeProperty ;
-          rdfs:domain :Address ;
-          rdfs:range xsd:string ;
-          rdfs:comment "UN/LOCODE city code (5 letter) or IATA city code (3 letter)"@en ;
-          rdfs:label "cityCode"@en ;
-          owl:comment "Possible RDF good practice IRI: :hasCityCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#cityName
@@ -3246,16 +3508,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                owl:comment "Possible RDF good practice IRI: :hasCriticalitySafetyIndex "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#customsOriginCode
-:customsOriginCode rdf:type owl:DatatypeProperty ;
-                   rdfs:domain :Waybill ;
-                   rdfs:range xsd:string ;
-                   rdfs:comment """Code indicating the origin of goods for Customs purposes (e.g. For goods in free circulation in the EU) 
-List to be provided by local authorities"""@en ;
-                   rdfs:label "customsOriginCode"@en ;
-                   owl:comment "Possible RDF good practice IRI: :hasCustomsOriginCode "@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#damageFlag
 :damageFlag rdf:type owl:DatatypeProperty ;
             rdfs:domain :LoadingUnit ;
@@ -3282,15 +3534,6 @@ List to be provided by local authorities"""@en ;
               rdfs:label "deliveryDate"@en ;
               owl:comment "Possible RDF good practice IRI: :hasDeliveryDate "@en ;
               owl:deprecated "true"@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#demurrageCode
-:demurrageCode rdf:type owl:DatatypeProperty ;
-               rdfs:domain :LoadingUnit ;
-               rdfs:range xsd:string ;
-               rdfs:comment "Contains three designator of demurrage code, refer to RP 1654 (BCC, HHH, XXX, ZZZ)"@en ;
-               rdfs:label "demurrageCode"@en ;
-               owl:comment "Possible RDF good practice IRI: :hasDemurrageCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#department
@@ -3329,15 +3572,6 @@ List to be provided by local authorities"""@en ;
                     owl:comment "Possible RDF good practice IRI: :hasDestinationCharges "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#destinationCurrencyCode
-:destinationCurrencyCode rdf:type owl:DatatypeProperty ;
-                         rdfs:domain :Waybill ;
-                         rdfs:range xsd:string ;
-                         rdfs:comment "ISO 3-letter currency code of destination. Refer to ISO 4217"@en ;
-                         rdfs:label "destinationCurrencyCode"@en ;
-                         owl:comment "Possible RDF good practice IRI: :hasDestinationCurrencyCode "@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#destinationCurrencyRate
 :destinationCurrencyRate rdf:type owl:DatatypeProperty ;
                          rdfs:domain :Waybill ;
@@ -3355,26 +3589,6 @@ List to be provided by local authorities"""@en ;
              rdfs:label "deviceModel"@en ;
              owl:comment "Possible RDF good practice IRI: :isOfDeviceModel "@en ;
              owl:versionInfo "v3. renamed from iotDevice:deviceModel"@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#dgRaTypeCode
-:dgRaTypeCode rdf:type owl:DatatypeProperty ;
-              rdfs:domain :DgProductRadioactive ;
-              rdfs:range [ rdf:type rdfs:Datatype ;
-                           owl:oneOf [ rdf:type rdf:List ;
-                                       rdf:first "I-White" ;
-                                       rdf:rest [ rdf:type rdf:List ;
-                                                  rdf:first "II-Yellow" ;
-                                                  rdf:rest [ rdf:type rdf:List ;
-                                                             rdf:first "III-Yellow" ;
-                                                             rdf:rest rdf:nil
-                                                           ]
-                                                ]
-                                     ]
-                         ] ;
-              rdfs:comment "The category of the package or all packed in one. Complete text to be transmitted: I-White, II-Yellow, III-Yellow instead of I, II, III"@en ;
-              rdfs:label "dgRaTypeCode"@en ;
-              owl:comment "Possible RDF good practice IRI: :hasDgRaTypeCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#discount
@@ -3518,15 +3732,6 @@ List to be provided by local authorities"""@en ;
             owl:versionInfo "v3. renamed from item:productExpiryDate"@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#explosiveCompatibilityGroupCode
-:explosiveCompatibilityGroupCode rdf:type owl:DatatypeProperty ;
-                                 rdfs:domain :ProductDg ;
-                                 rdfs:range xsd:string ;
-                                 rdfs:comment "Specifies the reference to the group which identifies the kind of substances and articles that are deemed to be compatible. Mandatory field in case of transport of explosive articles or substances"@en ;
-                                 rdfs:label "explosiveCompatibilityGroupCode"@en ;
-                                 owl:comment "Possible RDF good practice IRI: :hasExplosiveCompatibilityGroupCode "@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#firstName
 :firstName rdf:type owl:DatatypeProperty ;
            rdfs:domain :Person ;
@@ -3563,15 +3768,6 @@ List to be provided by local authorities"""@en ;
           owl:comment "Possible RDF good practice IRI: :hasFuelType "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#fulfillsUldTypeCode
-:fulfillsUldTypeCode rdf:type owl:DatatypeProperty ;
-                     rdfs:domain :Piece ;
-                     rdfs:range xsd:string ;
-                     rdfs:comment "Text holding an ULD Type Code if the Piece fulfills it before UnitComposition"@en ;
-                     rdfs:label "fulfillsUldTypeCode"@en ;
-                     owl:comment "Possible RDF good practice IRI: :fulfillsUldTypeCode "@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#geolocationUnit
 :geolocationUnit rdf:type owl:DatatypeProperty ;
                  rdfs:domain :Geolocation ;
@@ -3588,64 +3784,6 @@ List to be provided by local authorities"""@en ;
                   rdfs:comment "Description of goods, for the BookingShipment the commodity list defined by Modernizing Cargo Distribution MCD working group can be used as a referential."@en ;
                   rdfs:label "goodsDescription"@en ;
                   owl:comment "Possible RDF good practice IRI: :hasGoodsDescription "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#goodsTypeCode
-:goodsTypeCode rdf:type owl:DatatypeProperty ;
-               rdfs:domain :PieceLiveAnimals ;
-               rdfs:range [ rdf:type rdfs:Datatype ;
-                            owl:oneOf [ rdf:type rdf:List ;
-                                        rdf:first "I" ;
-                                        rdf:rest [ rdf:type rdf:List ;
-                                                   rdf:first "II" ;
-                                                   rdf:rest [ rdf:type rdf:List ;
-                                                              rdf:first "III" ;
-                                                              rdf:rest rdf:nil
-                                                            ]
-                                                 ]
-                                      ]
-                          ] ;
-               rdfs:comment "Appendix number of the convention (I, II or III) (box 1)"@en ;
-               rdfs:label "goodsTypeCode"@en ;
-               owl:comment "Possible RDF good practice IRI: :hasGoodsTypeCode "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#goodsTypeExtensionCode
-:goodsTypeExtensionCode rdf:type owl:DatatypeProperty ;
-                        rdfs:domain :PieceLiveAnimals ;
-                        rdfs:range [ rdf:type rdfs:Datatype ;
-                                     owl:oneOf [ rdf:type rdf:List ;
-                                                 rdf:first "A" ;
-                                                 rdf:rest [ rdf:type rdf:List ;
-                                                            rdf:first "C" ;
-                                                            rdf:rest [ rdf:type rdf:List ;
-                                                                       rdf:first "D" ;
-                                                                       rdf:rest [ rdf:type rdf:List ;
-                                                                                  rdf:first "F" ;
-                                                                                  rdf:rest [ rdf:type rdf:List ;
-                                                                                             rdf:first "I" ;
-                                                                                             rdf:rest [ rdf:type rdf:List ;
-                                                                                                        rdf:first "O" ;
-                                                                                                        rdf:rest [ rdf:type rdf:List ;
-                                                                                                                   rdf:first "R" ;
-                                                                                                                   rdf:rest [ rdf:type rdf:List ;
-                                                                                                                              rdf:first "U" ;
-                                                                                                                              rdf:rest [ rdf:type rdf:List ;
-                                                                                                                                         rdf:first "W" ;
-                                                                                                                                         rdf:rest rdf:nil
-                                                                                                                                       ]
-                                                                                                                            ]
-                                                                                                                 ]
-                                                                                                      ]
-                                                                                           ]
-                                                                                ]
-                                                                     ]
-                                                          ]
-                                               ]
-                                   ] ;
-                        rdfs:comment "Appendix number of the convention (I, II or III) (box 1)"@en ;
-                        rdfs:label "goodsTypeExtensionCode"@en ;
-                        owl:comment "Possible RDF good practice IRI: :hasGoodsTypeExtensionCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#grandTotal
@@ -3775,15 +3913,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                                   owl:comment "Possible RDF good practice IRI: :hasIataCargoAgentLocationIdentifier "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#incoterms
-:incoterms rdf:type owl:DatatypeProperty ;
-           rdfs:domain :Shipment ;
-           rdfs:range xsd:string ;
-           rdfs:comment "Standard codes as defined by UNCEFACT and ICC that correspond to international rules for the interpretation of the most commonly used trade terms in different countries. UNECE recommendation n. 5 Incoterms 2."@en ;
-           rdfs:label "incoterms"@en ;
-           owl:comment "Possible RDF good practice IRI: :hasIncoterms "@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#isotopeId
 :isotopeId rdf:type owl:DatatypeProperty ;
            rdfs:domain :DgRadioactiveIsotope ;
@@ -3900,15 +4029,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                            rdfs:comment "Short text stating the loading position in the TransportMeans"@en ;
                            rdfs:label "loadingPositionIdentifier"@en ;
                            owl:comment "Possible RDF good practice IRI: :hasLoadingPositionIdentifier "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#locationCode
-:locationCode rdf:type owl:DatatypeProperty ;
-              rdfs:domain :Location ;
-              rdfs:range xsd:string ;
-              rdfs:comment "Location code of airport, freight terminal, seaport, rail station. UN/LOCODE city code (5 letter) or IATA airport code (3 letter)"@en ;
-              rdfs:label "locationCode"@en ;
-              owl:comment "Possible RDF good practice IRI: :hasLocationCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#locationName
@@ -4045,47 +4165,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                  rdfs:comment "Minimum quantity"@en ;
                  rdfs:label "minimumQuantity"@en ;
                  owl:comment "Possible RDF good practice IRI: :hasMinimumQuantity "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#modeCode
-:modeCode rdf:type owl:DatatypeProperty ;
-          rdfs:domain :TransportMovement ;
-          rdfs:range [ rdf:type rdfs:Datatype ;
-                       owl:oneOf [ rdf:type rdf:List ;
-                                   rdf:first "" ;
-                                   rdf:rest [ rdf:type rdf:List ;
-                                              rdf:first "1" ;
-                                              rdf:rest [ rdf:type rdf:List ;
-                                                         rdf:first "2" ;
-                                                         rdf:rest [ rdf:type rdf:List ;
-                                                                    rdf:first "3" ;
-                                                                    rdf:rest [ rdf:type rdf:List ;
-                                                                               rdf:first "4" ;
-                                                                               rdf:rest [ rdf:type rdf:List ;
-                                                                                          rdf:first "5" ;
-                                                                                          rdf:rest [ rdf:type rdf:List ;
-                                                                                                     rdf:first "6" ;
-                                                                                                     rdf:rest [ rdf:type rdf:List ;
-                                                                                                                rdf:first "7" ;
-                                                                                                                rdf:rest [ rdf:type rdf:List ;
-                                                                                                                           rdf:first "8" ;
-                                                                                                                           rdf:rest [ rdf:type rdf:List ;
-                                                                                                                                      rdf:first "9" ;
-                                                                                                                                      rdf:rest rdf:nil
-                                                                                                                                    ]
-                                                                                                                         ]
-                                                                                                              ]
-                                                                                                   ]
-                                                                                        ]
-                                                                             ]
-                                                                  ]
-                                                       ]
-                                            ]
-                                 ]
-                     ] ;
-          rdfs:comment "Mode of transport code, refer to UNECE Rec. 19 https://unece.org/fileadmin/DAM/cefact/recommendations/rec19/rec19_1cf19e.pdf"@en ;
-          rdfs:label "modeCode"@en ;
-          owl:comment "Possible RDF good practice IRI: :hasModeCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#modularCheckNumber
@@ -4232,15 +4311,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
               owl:deprecated "true"^^xsd:boolean .
 
 
-###  https://onerecord.iata.org/ns/cargo#odlnCode
-:odlnCode rdf:type owl:DatatypeProperty ;
-          rdfs:domain :LoadingUnit ;
-          rdfs:range xsd:string ;
-          rdfs:comment "Contains two designator codes of ODLN or Operational Damage Limit Notices. ODLN code is used to define type of damage after visually check the serviceability of ULDs section 7, Standard Specifications 4/3 or 4/4 in ULD Regulations"@en ;
-          rdfs:label "odlnCode"@en ;
-          owl:comment "Possible RDF good practice IRI: :hasOdlnCode "@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#onlineInd
 :onlineInd rdf:type owl:DatatypeProperty ;
            rdfs:domain :Routing ;
@@ -4248,15 +4318,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
            rdfs:comment "Indicates interlining (requested or proposed)"@en ;
            rdfs:label "onlineInd"@en ;
            owl:comment "Possible RDF good practice IRI: :hasInterlining "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#originCurrency
-:originCurrency rdf:type owl:DatatypeProperty ;
-                rdfs:domain :Waybill ;
-                rdfs:range xsd:string ;
-                rdfs:comment "ISO alpha 3 Code used to indicate the Origin Currency, refer to ISO 4217 currency codes"@en ;
-                rdfs:label "originCurrency" ;
-                owl:comment "Possible RDF good practice IRI: :hasOriginCurrencyCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#originReferencePermitDateTime
@@ -4276,15 +4337,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                          rdfs:comment "identifier of Origin reference permit or re-export reference Certificate (box 12/12a)"@en ;
                          rdfs:label "originReferencePermitId"@en ;
                          owl:comment "Possible RDF good practice IRI: :hasOriginReferencePermitIdentifier "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#originReferencePermitTypeCode
-:originReferencePermitTypeCode rdf:type owl:DatatypeProperty ;
-                               rdfs:domain :PieceLiveAnimals ;
-                               rdfs:range xsd:string ;
-                               rdfs:comment "Document type code of origin reference permit or re-export reference Certificate (box 12/12a)"@en ;
-                               rdfs:label "originReferencePermitTypeCode"@en ;
-                               owl:comment "Possible RDF good practice IRI: :hasOriginReferencePermitTypeCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#otherCustomsInformation
@@ -4342,44 +4394,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
             owl:comment "Possible RDF good practice IRI: :hasOverpackT1 "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#overpackTypeCode
-:overpackTypeCode rdf:type owl:DatatypeProperty ;
-                  rdfs:domain :PieceDg ;
-                  rdfs:range xsd:boolean ;
-                  rdfs:comment "Identifies the Logistic Unit package type. UN Recommendation on Transport of Dangerous Goods, Model Regulations "@en ;
-                  rdfs:label "overpackTypeCode"@en ;
-                  owl:comment "Possible RDF good practice IRI: :hasOverpackTypeCode "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#ownerCode
-:ownerCode rdf:type owl:DatatypeProperty ;
-           rdfs:domain :LoadingUnit ;
-           rdfs:range xsd:string ;
-           rdfs:comment "Owner code of the ULD in aa, an or na format - owner can be an airline or leasing company"@en ;
-           rdfs:label "ownerCode"@en ;
-           owl:comment "Possible RDF good practice IRI: :hasOwnerCode "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#packageMarkCoded
-:packageMarkCoded rdf:type owl:DatatypeProperty ;
-                  rdfs:domain :Piece ;
-                  rdfs:range [ rdf:type rdfs:Datatype ;
-                               owl:oneOf [ rdf:type rdf:List ;
-                                           rdf:first "Other" ;
-                                           rdf:rest [ rdf:type rdf:List ;
-                                                      rdf:first "SSCC-18" ;
-                                                      rdf:rest [ rdf:type rdf:List ;
-                                                                 rdf:first "UPC" ;
-                                                                 rdf:rest rdf:nil
-                                                               ]
-                                                    ]
-                                         ]
-                             ] ;
-                  rdfs:comment "Reference identifying how the package is marked. Field is hardcode to \"SSCC-18\", \"UPC\" or \"Other\""@en ;
-                  rdfs:label "packageMarkCoded"@en ;
-                  owl:comment "Possible RDF good practice IRI: :hasPackageMarkCode "@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#packagedeIdentifier
 :packagedeIdentifier rdf:type owl:DatatypeProperty ;
                      rdfs:domain :Piece ;
@@ -4387,15 +4401,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                      rdfs:comment "SSCC-18 code for the value of the package mark, company or bar code, free text, pallet code, etc."@en ;
                      rdfs:label "packagedeIdentifier"@en ;
                      owl:comment "Possible RDF good practice IRI: :hasPackageIdentifier "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#packagingDangerLevelCode
-:packagingDangerLevelCode rdf:type owl:DatatypeProperty ;
-                          rdfs:domain :ProductDg ;
-                          rdfs:range xsd:string ;
-                          rdfs:comment "Packing group, If used must reference I, II or III"@en ;
-                          rdfs:label "packagingDangerLevelCode"@en ;
-                          owl:comment "Possible RDF good practice IRI: :hasPackagingDangerLevelCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#packingInstructionNumber
@@ -4424,15 +4429,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
         owl:comment "Possible RDF good practice IRI: :isPassed "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#permitTypeCode
-:permitTypeCode rdf:type owl:DatatypeProperty ;
-                rdfs:domain :LiveAnimalsEpermit ;
-                rdfs:range xsd:string ;
-                rdfs:comment "Code specifying the document name. (box 1)"@en ;
-                rdfs:label "permitTypeCode"@en ;
-                owl:comment "Possible RDF good practice IRI: :hasPermitTypeCode "@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#permitTypeOtherDescription
 :permitTypeOtherDescription rdf:type owl:DatatypeProperty ;
                             rdfs:domain :LiveAnimalsEpermit ;
@@ -4441,26 +4437,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                             rdfs:label "permitTypeOtherDescription"@en ;
                             owl:comment "Possible RDF good practice IRI: :hasPermitTypeOtherDescription "@en ;
                             owl:versionInfo "v3. renamed from liveAnimalsEpermit:permitTypeOther"@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#physicalChemicalForm
-:physicalChemicalForm rdf:type owl:DatatypeProperty ;
-                      rdfs:domain :DgRadioactiveIsotope ;
-                      rdfs:range [ rdf:type rdfs:Datatype ;
-                                   owl:oneOf [ rdf:type rdf:List ;
-                                               rdf:first "LowDispersible" ;
-                                               rdf:rest [ rdf:type rdf:List ;
-                                                          rdf:first "PhysicalChemicalForm" ;
-                                                          rdf:rest [ rdf:type rdf:List ;
-                                                                     rdf:first "SpecialForm" ;
-                                                                     rdf:rest rdf:nil
-                                                                   ]
-                                                        ]
-                                             ]
-                                 ] ;
-                      rdfs:comment "A description of the physical and chemical form of the material."@en ;
-                      rdfs:label "physicalChemicalForm"@en ;
-                      owl:comment "Possible RDF good practice IRI: :hasPhysicalChemicalForm "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#pieceCountForRate
@@ -4618,26 +4594,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
               rdfs:comment "Used if there is an applicable quantity to the rate (Usually a Time or a Number)"@en ;
               rdfs:label "rateQuantity"@en ;
               owl:comment "Possible RDF good practice IRI: :hasRateQuantity "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#ratingsType
-:ratingsType rdf:type owl:DatatypeProperty ;
-             rdfs:domain :Ratings ;
-             rdfs:range [ rdf:type rdfs:Datatype ;
-                          owl:oneOf [ rdf:type rdf:List ;
-                                      rdf:first "A" ;
-                                      rdf:rest [ rdf:type rdf:List ;
-                                                 rdf:first "C" ;
-                                                 rdf:rest [ rdf:type rdf:List ;
-                                                            rdf:first "F" ;
-                                                            rdf:rest rdf:nil
-                                                          ]
-                                               ]
-                                    ]
-                        ] ;
-             rdfs:comment "Used to identify if the Ratings are Face, Published or Actual ratings. Expected values are F, A, C."@en ;
-             rdfs:label "ratingsType" ;
-             owl:comment "Possible RDF good practice IRI: :hasRatingsType "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#rcp
@@ -4869,32 +4825,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
            owl:comment "Possible RDF good practice IRI: :hasShortText "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#signatoryRole
-:signatoryRole rdf:type owl:DatatypeProperty ;
-               rdfs:domain :EpermitSignature ;
-               rdfs:range [ rdf:type rdfs:Datatype ;
-                            owl:oneOf [ rdf:type rdf:List ;
-                                        rdf:first "Applicant" ;
-                                        rdf:rest [ rdf:type rdf:List ;
-                                                   rdf:first "Examining Authority" ;
-                                                   rdf:rest [ rdf:type rdf:List ;
-                                                              rdf:first "Issuing Authority" ;
-                                                              rdf:rest [ rdf:type rdf:List ;
-                                                                         rdf:first "Management Authority" ;
-                                                                         rdf:rest [ rdf:type rdf:List ;
-                                                                                    rdf:first "Permit issuer" ;
-                                                                                    rdf:rest rdf:nil
-                                                                                  ]
-                                                                       ]
-                                                            ]
-                                                 ]
-                                      ]
-                          ] ;
-               rdfs:comment "Role of the signatory with regards to the ePermit: Applicant, Permit issuer, Issuing Authority or Examining authority"@en ;
-               rdfs:label "signatoryRole"@en ;
-               owl:comment "Possible RDF good practice IRI: :hasSignatoryRole "@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#signatureDate
 :signatureDate rdf:type owl:DatatypeProperty ;
                rdfs:domain :EpermitSignature ;
@@ -4911,29 +4841,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                     rdfs:comment "Signatory signature authentication text"@en ;
                     rdfs:label "signatureStatement"@en ;
                     owl:comment "Possible RDF good practice IRI: :hasSignatureStatement "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#signatureTypeCode
-:signatureTypeCode rdf:type owl:DatatypeProperty ;
-                   rdfs:domain :EpermitSignature ;
-                   rdfs:range [ rdf:type rdfs:Datatype ;
-                                owl:oneOf [ rdf:type rdf:List ;
-                                            rdf:first "Detention" ;
-                                            rdf:rest [ rdf:type rdf:List ;
-                                                       rdf:first "Fumigaton" ;
-                                                       rdf:rest [ rdf:type rdf:List ;
-                                                                  rdf:first "Inspection" ;
-                                                                  rdf:rest [ rdf:type rdf:List ;
-                                                                             rdf:first "Security" ;
-                                                                             rdf:rest rdf:nil
-                                                                           ]
-                                                                ]
-                                                     ]
-                                          ]
-                              ] ;
-                   rdfs:comment "Code specifying a type of government action such as inspection, detention, fumigation, security."@en ;
-                   rdfs:label "signatureTypeCode"@en ;
-                   owl:comment "Possible RDF good practice IRI: :hasSignatureTypeCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#skeletonIndicator
@@ -5006,15 +4913,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                      rdfs:comment "Description of specimens, including age and sex if LA (box 9)"@en ;
                      rdfs:label "specimenDescription"@en ;
                      owl:comment "Possible RDF good practice IRI: :hasSpecimenDescription "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#specimenTypeCode
-:specimenTypeCode rdf:type owl:DatatypeProperty ;
-                  rdfs:domain :PieceLiveAnimals ;
-                  rdfs:range xsd:string ;
-                  rdfs:comment "Description of specimens, CITES type code (box 9)"@en ;
-                  rdfs:label "specimenTypeCode"@en ;
-                  owl:comment "Possible RDF good practice IRI: :hasSpecimenTypeCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#stackable
@@ -5172,53 +5070,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                     owl:versionInfo "v3. renamed from :hasTransactionPurposeText"@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#transactionPurposeCode
-:transactionPurposeCode rdf:type owl:DatatypeProperty ;
-                        rdfs:domain :LiveAnimalsEpermit ;
-                        rdfs:range [ rdf:type rdfs:Datatype ;
-                                     owl:oneOf [ rdf:type rdf:List ;
-                                                 rdf:first "B" ;
-                                                 rdf:rest [ rdf:type rdf:List ;
-                                                            rdf:first "E" ;
-                                                            rdf:rest [ rdf:type rdf:List ;
-                                                                       rdf:first "G" ;
-                                                                       rdf:rest [ rdf:type rdf:List ;
-                                                                                  rdf:first "H" ;
-                                                                                  rdf:rest [ rdf:type rdf:List ;
-                                                                                             rdf:first "L" ;
-                                                                                             rdf:rest [ rdf:type rdf:List ;
-                                                                                                        rdf:first "M" ;
-                                                                                                        rdf:rest [ rdf:type rdf:List ;
-                                                                                                                   rdf:first "N" ;
-                                                                                                                   rdf:rest [ rdf:type rdf:List ;
-                                                                                                                              rdf:first "P" ;
-                                                                                                                              rdf:rest [ rdf:type rdf:List ;
-                                                                                                                                         rdf:first "Q" ;
-                                                                                                                                         rdf:rest [ rdf:type rdf:List ;
-                                                                                                                                                    rdf:first "S" ;
-                                                                                                                                                    rdf:rest [ rdf:type rdf:List ;
-                                                                                                                                                               rdf:first "T" ;
-                                                                                                                                                               rdf:rest [ rdf:type rdf:List ;
-                                                                                                                                                                          rdf:first "Z" ;
-                                                                                                                                                                          rdf:rest rdf:nil
-                                                                                                                                                                        ]
-                                                                                                                                                             ]
-                                                                                                                                                  ]
-                                                                                                                                       ]
-                                                                                                                            ]
-                                                                                                                 ]
-                                                                                                      ]
-                                                                                           ]
-                                                                                ]
-                                                                     ]
-                                                          ]
-                                               ]
-                                   ] ;
-                        rdfs:comment "Code indicating the purpose of the transaction (box 5a)"@en ;
-                        rdfs:label "transactionPurposeCode"@en ;
-                        owl:comment "Possible RDF good practice IRI: :hasTransactionPurposeCode "@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#transportContractId
 :transportContractId rdf:type owl:DatatypeProperty ;
                      rdfs:domain :LiveAnimalsEpermit ;
@@ -5226,15 +5077,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                      rdfs:comment "Reference to the Air Waybill or other transport contract document (box 15)"@en ;
                      rdfs:label "transportContractId"@en ;
                      owl:comment "Possible RDF good practice IRI: :hasTransportContractReference "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#transportContractTypeCode
-:transportContractTypeCode rdf:type owl:DatatypeProperty ;
-                           rdfs:domain :LiveAnimalsEpermit ;
-                           rdfs:range xsd:string ;
-                           rdfs:comment "Code specifying the transport document name (box 15)"@en ;
-                           rdfs:label "transportContractTypeCode"@en ;
-                           owl:comment "Possible RDF good practice IRI: :hasTransportContractTypeCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#transportIdentifier
@@ -5264,23 +5106,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
           owl:comment "Possible RDF good practice IRI: :isTurnable "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#typeCode
-:typeCode rdf:type owl:DatatypeProperty ;
-          rdfs:domain :PackagingType ;
-          rdfs:range xsd:string ;
-          rdfs:comment "Packaging type identifier as per UNECE Rec 21 Annex V and VI e.g. 1A - Drum, steel - Packaging material code. Identifies the Logistic Unit package type. UN Recommendation on Transport of Dangerous Goods, Model Regulations "@en ;
-          rdfs:label "typeCode"@en ;
-          owl:comment "Possible RDF good practice IRI: :hasTypeCode "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#uldRateClassType
-:uldRateClassType rdf:type owl:DatatypeProperty ;
-                  rdfs:domain :TACTRateDescription ;
-                  rdfs:range xsd:integer ;
-                  rdfs:comment "ULD Rate information - ULD Rate Class Type"@en ;
-                  rdfs:label "uldRateClassType"@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#uldSerialNumber
 :uldSerialNumber rdf:type owl:DatatypeProperty ;
                  rdfs:domain :LoadingUnit ;
@@ -5288,15 +5113,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                  rdfs:comment "Serial number that allows to uniquely identify the ULD"@en ;
                  rdfs:label "uldSerialNumber"@en ;
                  owl:comment "Possible RDF good practice IRI: :hasULDSerialNumber "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#uldTypeCode
-:uldTypeCode rdf:type owl:DatatypeProperty ;
-             rdfs:domain :LoadingUnit ;
-             rdfs:range xsd:string ;
-             rdfs:comment "Standard Unit Load Device type code e.g. AKE - Certified Container - Contoured. Refer to IATA ULD Technical Manual"@en ;
-             rdfs:label "uldTypeCode"@en ;
-             owl:comment "Possible RDF good practice IRI: :hasULDTypeCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#unNumber
@@ -5408,15 +5224,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
              owl:comment "Possible RDF good practice IRI: :hasVehicleSize "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#vehicleType
-:vehicleType rdf:type owl:DatatypeProperty ;
-             rdfs:domain :TransportMeans ;
-             rdfs:range xsd:string ;
-             rdfs:comment "Vehicle or container type. Refer UNECE28, e.g. 4.. - Aircraft, type unknown.For Air refer to IATA Standard Schedules Information Manua in section ATA/IATA Aircraft Types"@en ;
-             rdfs:label "vehicleType"@en ;
-             owl:comment "Possible RDF good practice IRI: :isOfVehicleType "@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#version
 :version rdf:type owl:DatatypeProperty ;
          rdfs:domain :CheckTemplate ;
@@ -5458,6 +5265,11 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
 #    Classes
 #################################################################
 
+###  <https://onerecord.iata.org/ns/coreCodeLists#AWBUseIndicator
+ccodes:AWBUseIndicator rdf:type owl:Class ;
+                       rdfs:subClassOf :CodeListElement .
+
+
 ###  <https://onerecord.iata.org/ns/coreCodeLists#AircraftPossibilityCode
 ccodes:AircraftPossibilityCode rdf:type owl:Class ;
                                rdfs:subClassOf :CodeListElement .
@@ -5482,9 +5294,29 @@ ccodes:ChargeIdentifier rdf:type owl:Class ;
 ccodes:DangerousGoodsCode rdfs:subClassOf :CodeListElement .
 
 
+###  <https://onerecord.iata.org/ns/coreCodeLists#DemurrageCode
+ccodes:DemurrageCode rdf:type owl:Class ;
+                     rdfs:subClassOf :CodeListElement .
+
+
 ###  <https://onerecord.iata.org/ns/coreCodeLists#EntitlementCode
 ccodes:EntitlementCode rdf:type owl:Class ;
                        rdfs:subClassOf :CodeListElement .
+
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#ExplosiveCompatibilityGroupCode
+ccodes:ExplosiveCompatibilityGroupCode rdf:type owl:Class ;
+                                       rdfs:subClassOf :CodeListElement .
+
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#GoodsTypeCode
+ccodes:GoodsTypeCode rdf:type owl:Class ;
+                     rdfs:subClassOf :CodeListElement .
+
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#GoodsTypeExtensionCode
+ccodes:GoodsTypeExtensionCode rdf:type owl:Class ;
+                              rdfs:subClassOf :CodeListElement .
 
 
 ###  <https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator
@@ -5497,6 +5329,16 @@ ccodes:OtherChargeCode rdf:type owl:Class ;
                        rdfs:subClassOf :CodeListElement .
 
 
+###  <https://onerecord.iata.org/ns/coreCodeLists#PackageMarkCode
+ccodes:PackageMarkCode rdf:type owl:Class ;
+                       rdfs:subClassOf :CodeListElement .
+
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#PackagingDangerLevelCode
+ccodes:PackagingDangerLevelCode rdf:type owl:Class ;
+                                rdfs:subClassOf :CodeListElement .
+
+
 ###  <https://onerecord.iata.org/ns/coreCodeLists#ParticipantIdentifier
 ccodes:ParticipantIdentifier rdf:type owl:Class ;
                              rdfs:subClassOf :CodeListElement .
@@ -5507,9 +5349,24 @@ ccodes:PrepaidCollectIndicator rdf:type owl:Class ;
                                rdfs:subClassOf :CodeListElement .
 
 
+###  <https://onerecord.iata.org/ns/coreCodeLists#RaTypeCode
+ccodes:RaTypeCode rdf:type owl:Class ;
+                  rdfs:subClassOf :CodeListElement .
+
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#RadioActiveMaterialClassicfication
+ccodes:RadioActiveMaterialClassicfication rdf:type owl:Class ;
+                                          rdfs:subClassOf :CodeListElement .
+
+
 ###  <https://onerecord.iata.org/ns/coreCodeLists#RateClassCode
 ccodes:RateClassCode rdf:type owl:Class ;
                      rdfs:subClassOf :CodeListElement .
+
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#RatingsType
+ccodes:RatingsType rdf:type owl:Class ;
+                   rdfs:subClassOf :CodeListElement .
 
 
 ###  <https://onerecord.iata.org/ns/coreCodeLists#RegulatedEntityCategoryCode
@@ -5541,6 +5398,16 @@ ccodes:ShipmentSecurityStatus rdf:type owl:Class ;
                               rdfs:subClassOf :CodeListElement .
 
 
+###  <https://onerecord.iata.org/ns/coreCodeLists#SignatoryRole
+ccodes:SignatoryRole rdf:type owl:Class ;
+                     rdfs:subClassOf :CodeListElement .
+
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#SignatureTypeCode
+ccodes:SignatureTypeCode rdf:type owl:Class ;
+                         rdfs:subClassOf :CodeListElement .
+
+
 ###  <https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode
 ccodes:SpecialHandlingCode rdf:type owl:Class ;
                            rdfs:subClassOf :CodeListElement .
@@ -5549,6 +5416,11 @@ ccodes:SpecialHandlingCode rdf:type owl:Class ;
 ###  <https://onerecord.iata.org/ns/coreCodeLists#StatusCode
 ccodes:StatusCode rdf:type owl:Class ;
                   rdfs:subClassOf :CodeListElement .
+
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#TransactionPurposeCode
+ccodes:TransactionPurposeCode rdf:type owl:Class ;
+                              rdfs:subClassOf :CodeListElement .
 
 
 ###  <https://onerecord.iata.org/ns/coreCodeLists#ULDChargeCode
@@ -5627,6 +5499,10 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                            owl:allValuesFrom :CodeListElement
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty :cityCode ;
+                           owl:allValuesFrom :CodeListElement
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty :country ;
                            owl:allValuesFrom :Country
                          ] ,
@@ -5643,16 +5519,16 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty :cityCode ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty :country ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :postalCode ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :cityCode ;
-                           owl:allValuesFrom xsd:string
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :cityName ;
@@ -5673,10 +5549,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :streetAddressLines ;
                            owl:allValuesFrom xsd:string
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :cityCode ;
-                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :cityName ;
@@ -5788,6 +5660,10 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                   owl:allValuesFrom :Adjustments
                                 ] ,
                                 [ rdf:type owl:Restriction ;
+                                  owl:onProperty :awbUseIndicator ;
+                                  owl:allValuesFrom ccodes:AWBUseIndicator
+                                ] ,
+                                [ rdf:type owl:Restriction ;
                                   owl:onProperty :detailedWaybill ;
                                   owl:allValuesFrom :Waybill
                                 ] ,
@@ -5798,6 +5674,10 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                 [ rdf:type owl:Restriction ;
                                   owl:onProperty :taxDueAirline ;
                                   owl:allValuesFrom :Value
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty :awbUseIndicator ;
+                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                 ] ,
                                 [ rdf:type owl:Restriction ;
                                   owl:onProperty :detailedWaybill ;
@@ -5822,10 +5702,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                 [ rdf:type owl:Restriction ;
                                   owl:onProperty :awbExecutionDate ;
                                   owl:allValuesFrom xsd:dateTime
-                                ] ,
-                                [ rdf:type owl:Restriction ;
-                                  owl:onProperty :awbUseIndicator ;
-                                  owl:allValuesFrom xsd:boolean
                                 ] ,
                                 [ rdf:type owl:Restriction ;
                                   owl:onProperty :commission ;
@@ -5865,10 +5741,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                 ] ,
                                 [ rdf:type owl:Restriction ;
                                   owl:onProperty :awbExecutionDate ;
-                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                                ] ,
-                                [ rdf:type owl:Restriction ;
-                                  owl:onProperty :awbUseIndicator ;
                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                 ] ,
                                 [ rdf:type owl:Restriction ;
@@ -6993,6 +6865,10 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
 :DgProductRadioactive rdf:type owl:Class ;
                       rdfs:subClassOf :LogisticsObject ,
                                       [ rdf:type owl:Restriction ;
+                                        owl:onProperty :dgRaTypeCode ;
+                                        owl:allValuesFrom ccodes:RaTypeCode
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
                                         owl:onProperty :forProductDg ;
                                         owl:allValuesFrom :ProductDg
                                       ] ,
@@ -7001,12 +6877,12 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                         owl:allValuesFrom :DgRadioactiveIsotope
                                       ] ,
                                       [ rdf:type owl:Restriction ;
-                                        owl:onProperty :forProductDg ;
+                                        owl:onProperty :dgRaTypeCode ;
                                         owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                       ] ,
                                       [ rdf:type owl:Restriction ;
-                                        owl:onProperty :dgRaTypeCode ;
-                                        owl:allValuesFrom xsd:string
+                                        owl:onProperty :forProductDg ;
+                                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                       ] ,
                                       [ rdf:type owl:Restriction ;
                                         owl:onProperty :fissileExceptionIndicator ;
@@ -7019,10 +6895,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                       [ rdf:type owl:Restriction ;
                                         owl:onProperty :transportIndexNumeric ;
                                         owl:allValuesFrom xsd:integer
-                                      ] ,
-                                      [ rdf:type owl:Restriction ;
-                                        owl:onProperty :dgRaTypeCode ;
-                                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                       ] ,
                                       [ rdf:type owl:Restriction ;
                                         owl:onProperty :fissileExceptionIndicator ;
@@ -7048,7 +6920,15 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                         owl:allValuesFrom :DgProductRadioactive
                                       ] ,
                                       [ rdf:type owl:Restriction ;
+                                        owl:onProperty :physicalChemicalForm ;
+                                        owl:allValuesFrom ccodes:RadioActiveMaterialClassicfication
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
                                         owl:onProperty :contentOfDgProductRadioactive ;
+                                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty :physicalChemicalForm ;
                                         owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                       ] ,
                                       [ rdf:type owl:Restriction ;
@@ -7070,10 +6950,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                       [ rdf:type owl:Restriction ;
                                         owl:onProperty :lowDispersibleIndicator ;
                                         owl:allValuesFrom xsd:boolean
-                                      ] ,
-                                      [ rdf:type owl:Restriction ;
-                                        owl:onProperty :physicalChemicalForm ;
-                                        owl:allValuesFrom xsd:string
                                       ] ,
                                       [ rdf:type owl:Restriction ;
                                         owl:onProperty :specialFormIndicator ;
@@ -7097,10 +6973,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                       ] ,
                                       [ rdf:type owl:Restriction ;
                                         owl:onProperty :lowDispersibleIndicator ;
-                                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                                      ] ,
-                                      [ rdf:type owl:Restriction ;
-                                        owl:onProperty :physicalChemicalForm ;
                                         owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                       ] ,
                                       [ rdf:type owl:Restriction ;
@@ -7228,6 +7100,14 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                     owl:allValuesFrom :Company
                                   ] ,
                                   [ rdf:type owl:Restriction ;
+                                    owl:onProperty :signatoryRole ;
+                                    owl:allValuesFrom ccodes:SignatoryRole
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty :signatureTypeCode ;
+                                    owl:allValuesFrom ccodes:SignatureTypeCode
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
                                     owl:onProperty :forEpermit ;
                                     owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                   ] ,
@@ -7236,11 +7116,15 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                     owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                   ] ,
                                   [ rdf:type owl:Restriction ;
-                                    owl:onProperty :securityStampId ;
-                                    owl:allValuesFrom xsd:string
+                                    owl:onProperty :signatoryRole ;
+                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                   ] ,
                                   [ rdf:type owl:Restriction ;
-                                    owl:onProperty :signatoryRole ;
+                                    owl:onProperty :signatureTypeCode ;
+                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty :securityStampId ;
                                     owl:allValuesFrom xsd:string
                                   ] ,
                                   [ rdf:type owl:Restriction ;
@@ -7252,15 +7136,7 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                     owl:allValuesFrom xsd:string
                                   ] ,
                                   [ rdf:type owl:Restriction ;
-                                    owl:onProperty :signatureTypeCode ;
-                                    owl:allValuesFrom xsd:string
-                                  ] ,
-                                  [ rdf:type owl:Restriction ;
                                     owl:onProperty :securityStampId ;
-                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                                  ] ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty :signatoryRole ;
                                     owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                   ] ,
                                   [ rdf:type owl:Restriction ;
@@ -7269,10 +7145,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                   ] ,
                                   [ rdf:type owl:Restriction ;
                                     owl:onProperty :signatureStatement ;
-                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                                  ] ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty :signatureTypeCode ;
                                     owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                   ] ;
                   rdfs:comment "Signature details of the Epermit for Live Animals"@en ;
@@ -7768,11 +7640,35 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                       owl:allValuesFrom :EpermitConsignment
                                     ] ,
                                     [ rdf:type owl:Restriction ;
+                                      owl:onProperty :permitTypeCode ;
+                                      owl:allValuesFrom :CodeListElement
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
                                       owl:onProperty :signatures ;
                                       owl:allValuesFrom :EpermitSignature
                                     ] ,
                                     [ rdf:type owl:Restriction ;
+                                      owl:onProperty :transactionPurposeCode ;
+                                      owl:allValuesFrom ccodes:TransactionPurposeCode
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty :transportContractTypeCode ;
+                                      owl:allValuesFrom :CodeListElement
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
                                       owl:onProperty :consignee ;
+                                      owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty :permitTypeCode ;
+                                      owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty :transactionPurposeCode ;
+                                      owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty :transportContractTypeCode ;
                                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                     ] ,
                                     [ rdf:type owl:Restriction ;
@@ -7781,10 +7677,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                     ] ,
                                     [ rdf:type owl:Restriction ;
                                       owl:onProperty :epermitNumber ;
-                                      owl:allValuesFrom xsd:string
-                                    ] ,
-                                    [ rdf:type owl:Restriction ;
-                                      owl:onProperty :permitTypeCode ;
                                       owl:allValuesFrom xsd:string
                                     ] ,
                                     [ rdf:type owl:Restriction ;
@@ -7800,15 +7692,7 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                       owl:allValuesFrom xsd:string
                                     ] ,
                                     [ rdf:type owl:Restriction ;
-                                      owl:onProperty :transactionPurposeCode ;
-                                      owl:allValuesFrom xsd:string
-                                    ] ,
-                                    [ rdf:type owl:Restriction ;
                                       owl:onProperty :transportContractId ;
-                                      owl:allValuesFrom xsd:string
-                                    ] ,
-                                    [ rdf:type owl:Restriction ;
-                                      owl:onProperty :transportContractTypeCode ;
                                       owl:allValuesFrom xsd:string
                                     ] ,
                                     [ rdf:type owl:Restriction ;
@@ -7828,10 +7712,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                     ] ,
                                     [ rdf:type owl:Restriction ;
-                                      owl:onProperty :permitTypeCode ;
-                                      owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                                    ] ,
-                                    [ rdf:type owl:Restriction ;
                                       owl:onProperty :permitTypeOtherDescription ;
                                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                     ] ,
@@ -7844,15 +7724,7 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                     ] ,
                                     [ rdf:type owl:Restriction ;
-                                      owl:onProperty :transactionPurposeCode ;
-                                      owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                                    ] ,
-                                    [ rdf:type owl:Restriction ;
                                       owl:onProperty :transportContractId ;
-                                      owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                                    ] ,
-                                    [ rdf:type owl:Restriction ;
-                                      owl:onProperty :transportContractTypeCode ;
                                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                     ] ,
                                     [ rdf:type owl:Restriction ;
@@ -8054,6 +7926,10 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                             owl:allValuesFrom :Geolocation
                           ] ,
                           [ rdf:type owl:Restriction ;
+                            owl:onProperty :locationCode ;
+                            owl:allValuesFrom :CodeListElement
+                          ] ,
+                          [ rdf:type owl:Restriction ;
                             owl:onProperty :perfomedActions ;
                             owl:allValuesFrom :LogisticsAction
                           ] ,
@@ -8074,12 +7950,12 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
                           ] ,
                           [ rdf:type owl:Restriction ;
-                            owl:onProperty :subLocationOf ;
+                            owl:onProperty :locationCode ;
                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
                           ] ,
                           [ rdf:type owl:Restriction ;
-                            owl:onProperty :locationCode ;
-                            owl:allValuesFrom xsd:string
+                            owl:onProperty :subLocationOf ;
+                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                           ] ,
                           [ rdf:type owl:Restriction ;
                             owl:onProperty :locationName ;
@@ -8088,10 +7964,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                           [ rdf:type owl:Restriction ;
                             owl:onProperty :locationType ;
                             owl:allValuesFrom xsd:string
-                          ] ,
-                          [ rdf:type owl:Restriction ;
-                            owl:onProperty :locationCode ;
-                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                           ] ,
                           [ rdf:type owl:Restriction ;
                             owl:onProperty :locationName ;
@@ -8401,6 +8273,26 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                    owl:deprecated "true"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#ModeCode
+:ModeCode rdf:type owl:Class ;
+          owl:equivalentClass [ rdf:type owl:Class ;
+                                owl:oneOf ( ccodes:ScreeningExemption_MAIL
+                                            :AIR_TRANSPORT
+                                            :FIXED_TRANSPORT_INSTALLATION
+                                            :INLAND_WATER_TRANSPORT
+                                            :MARITIME_TRANSPORT
+                                            :MULTIMODAL_TRANSPORT
+                                            :RAIL_TRANSPORT
+                                            :ROAD_TRANSPORT
+                                            :TRANSPORT_MODE_NOT_APPLICABLE
+                                            :TRANSPORT_MODE_NOT_SPECIFIED
+                                          )
+                              ] ;
+          rdfs:subClassOf :CodeListElement ;
+          rdfs:comment "Restricted Code List of mode codes, UNECE Recommendation No. 19"@en ,
+                       "Source: TRADE/CEFACT/21/19"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#ModeQualifier
 :ModeQualifier rdf:type owl:Class ;
                owl:equivalentClass [ rdf:type owl:Class ;
@@ -8607,19 +8499,19 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                  owl:allValuesFrom :Piece
                                ] ,
                                [ rdf:type owl:Restriction ;
-                                 owl:onProperty :description ;
-                                 owl:allValuesFrom xsd:string
+                                 owl:onProperty :typeCode ;
+                                 owl:allValuesFrom :CodeListElement
                                ] ,
                                [ rdf:type owl:Restriction ;
                                  owl:onProperty :typeCode ;
-                                 owl:allValuesFrom xsd:string
-                               ] ,
-                               [ rdf:type owl:Restriction ;
-                                 owl:onProperty :description ;
                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                ] ,
                                [ rdf:type owl:Restriction ;
-                                 owl:onProperty :typeCode ;
+                                 owl:onProperty :description ;
+                                 owl:allValuesFrom xsd:string
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :description ;
                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                ] ;
                rdfs:comment "Packaging details "@en ;
@@ -8790,6 +8682,10 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                          owl:allValuesFrom :Dimensions
                        ] ,
                        [ rdf:type owl:Restriction ;
+                         owl:onProperty :fulfillsUldTypeCode ;
+                         owl:allValuesFrom :CodeListElement
+                       ] ,
+                       [ rdf:type owl:Restriction ;
                          owl:onProperty :grossWeight ;
                          owl:allValuesFrom :Value
                        ] ,
@@ -8808,6 +8704,10 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                        [ rdf:type owl:Restriction ;
                          owl:onProperty :otherIdentifiers ;
                          owl:allValuesFrom :OtherIdentifier
+                       ] ,
+                       [ rdf:type owl:Restriction ;
+                         owl:onProperty :packageMarkCoded ;
+                         owl:allValuesFrom ccodes:PackageMarkCode
                        ] ,
                        [ rdf:type owl:Restriction ;
                          owl:onProperty :packagingType ;
@@ -8846,11 +8746,19 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
                        ] ,
                        [ rdf:type owl:Restriction ;
+                         owl:onProperty :fulfillsUldTypeCode ;
+                         owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                       ] ,
+                       [ rdf:type owl:Restriction ;
                          owl:onProperty :grossWeight ;
                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
                        ] ,
                        [ rdf:type owl:Restriction ;
                          owl:onProperty :loadType ;
+                         owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                       ] ,
+                       [ rdf:type owl:Restriction ;
+                         owl:onProperty :packageMarkCoded ;
                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
                        ] ,
                        [ rdf:type owl:Restriction ;
@@ -8878,10 +8786,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                          owl:allValuesFrom xsd:boolean
                        ] ,
                        [ rdf:type owl:Restriction ;
-                         owl:onProperty :fulfillsUldTypeCode ;
-                         owl:allValuesFrom xsd:string
-                       ] ,
-                       [ rdf:type owl:Restriction ;
                          owl:onProperty :goodsDescription ;
                          owl:allValuesFrom xsd:string
                        ] ,
@@ -8892,10 +8796,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                        [ rdf:type owl:Restriction ;
                          owl:onProperty :nvdForCustoms ;
                          owl:allValuesFrom xsd:boolean
-                       ] ,
-                       [ rdf:type owl:Restriction ;
-                         owl:onProperty :packageMarkCoded ;
-                         owl:allValuesFrom xsd:string
                        ] ,
                        [ rdf:type owl:Restriction ;
                          owl:onProperty :packagedeIdentifier ;
@@ -8930,10 +8830,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
                        ] ,
                        [ rdf:type owl:Restriction ;
-                         owl:onProperty :fulfillsUldTypeCode ;
-                         owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                       ] ,
-                       [ rdf:type owl:Restriction ;
                          owl:onProperty :goodsDescription ;
                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
                        ] ,
@@ -8943,10 +8839,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                        ] ,
                        [ rdf:type owl:Restriction ;
                          owl:onProperty :nvdForCustoms ;
-                         owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                       ] ,
-                       [ rdf:type owl:Restriction ;
-                         owl:onProperty :packageMarkCoded ;
                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
                        ] ,
                        [ rdf:type owl:Restriction ;
@@ -8982,7 +8874,15 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                            owl:allValuesFrom :DgDeclaration
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty :overpackTypeCode ;
+                           owl:allValuesFrom xsd:boolean
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty :dgDeclaration ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :overpackTypeCode ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
@@ -8999,10 +8899,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :overpackT1 ;
-                           owl:allValuesFrom xsd:boolean
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :overpackTypeCode ;
                            owl:allValuesFrom xsd:boolean
                          ] ,
                          [ rdf:type owl:Restriction ;
@@ -9026,10 +8922,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty :overpackTypeCode ;
-                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                         ] ,
-                         [ rdf:type owl:Restriction ;
                            owl:onProperty :qValueNumeric ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ;
@@ -9049,8 +8941,24 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                     owl:allValuesFrom :Country
                                   ] ,
                                   [ rdf:type owl:Restriction ;
+                                    owl:onProperty :goodsTypeCode ;
+                                    owl:allValuesFrom ccodes:GoodsTypeCode
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty :goodsTypeExtensionCode ;
+                                    owl:allValuesFrom ccodes:GoodsTypeExtensionCode
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty :originReferencePermitTypeCode ;
+                                    owl:allValuesFrom :CodeListElement
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
                                     owl:onProperty :originTradeCountry ;
                                     owl:allValuesFrom :Country
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty :specimenTypeCode ;
+                                    owl:allValuesFrom :CodeListElement
                                   ] ,
                                   [ rdf:type owl:Restriction ;
                                     owl:onProperty :associatedEpermit ;
@@ -9061,7 +8969,23 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                     owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                   ] ,
                                   [ rdf:type owl:Restriction ;
+                                    owl:onProperty :goodsTypeCode ;
+                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty :goodsTypeExtensionCode ;
+                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty :originReferencePermitTypeCode ;
+                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
                                     owl:onProperty :originTradeCountry ;
+                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty :specimenTypeCode ;
                                     owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                   ] ,
                                   [ rdf:type owl:Restriction ;
@@ -9077,23 +9001,11 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                     owl:allValuesFrom xsd:string
                                   ] ,
                                   [ rdf:type owl:Restriction ;
-                                    owl:onProperty :goodsTypeCode ;
-                                    owl:allValuesFrom xsd:string
-                                  ] ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty :goodsTypeExtensionCode ;
-                                    owl:allValuesFrom xsd:string
-                                  ] ,
-                                  [ rdf:type owl:Restriction ;
                                     owl:onProperty :originReferencePermitDateTime ;
                                     owl:allValuesFrom xsd:dateTime
                                   ] ,
                                   [ rdf:type owl:Restriction ;
                                     owl:onProperty :originReferencePermitId ;
-                                    owl:allValuesFrom xsd:string
-                                  ] ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty :originReferencePermitTypeCode ;
                                     owl:allValuesFrom xsd:string
                                   ] ,
                                   [ rdf:type owl:Restriction ;
@@ -9113,23 +9025,11 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                     owl:allValuesFrom xsd:string
                                   ] ,
                                   [ rdf:type owl:Restriction ;
-                                    owl:onProperty :specimenTypeCode ;
-                                    owl:allValuesFrom xsd:string
-                                  ] ,
-                                  [ rdf:type owl:Restriction ;
                                     owl:onProperty :acquisitionDateTime ;
                                     owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                   ] ,
                                   [ rdf:type owl:Restriction ;
                                     owl:onProperty :annualQuotaQuantity ;
-                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                                  ] ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty :goodsTypeCode ;
-                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                                  ] ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty :goodsTypeExtensionCode ;
                                     owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                   ] ,
                                   [ rdf:type owl:Restriction ;
@@ -9141,19 +9041,11 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                     owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                   ] ,
                                   [ rdf:type owl:Restriction ;
-                                    owl:onProperty :originReferencePermitTypeCode ;
-                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                                  ] ,
-                                  [ rdf:type owl:Restriction ;
                                     owl:onProperty :quantityAnimals ;
                                     owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                   ] ,
                                   [ rdf:type owl:Restriction ;
                                     owl:onProperty :specimenDescription ;
-                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                                  ] ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty :specimenTypeCode ;
                                     owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                   ] ;
                   rdfs:comment "LiveAnimals subclass of Piece"@en ;
@@ -9302,7 +9194,23 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                              owl:allValuesFrom :DgProductRadioactive
                            ] ,
                            [ rdf:type owl:Restriction ;
+                             owl:onProperty :explosiveCompatibilityGroupCode ;
+                             owl:allValuesFrom ccodes:ExplosiveCompatibilityGroupCode
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty :packagingDangerLevelCode ;
+                             owl:allValuesFrom ccodes:PackagingDangerLevelCode
+                           ] ,
+                           [ rdf:type owl:Restriction ;
                              owl:onProperty :dgRadioactiveMaterial ;
+                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty :explosiveCompatibilityGroupCode ;
+                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty :packagingDangerLevelCode ;
                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
                            ] ,
                            [ rdf:type owl:Restriction ;
@@ -9314,15 +9222,7 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                              owl:allValuesFrom xsd:string
                            ] ,
                            [ rdf:type owl:Restriction ;
-                             owl:onProperty :explosiveCompatibilityGroupCode ;
-                             owl:allValuesFrom xsd:string
-                           ] ,
-                           [ rdf:type owl:Restriction ;
                              owl:onProperty :hazardClassificationId ;
-                             owl:allValuesFrom xsd:string
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty :packagingDangerLevelCode ;
                              owl:allValuesFrom xsd:string
                            ] ,
                            [ rdf:type owl:Restriction ;
@@ -9354,15 +9254,7 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
                            ] ,
                            [ rdf:type owl:Restriction ;
-                             owl:onProperty :explosiveCompatibilityGroupCode ;
-                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                           ] ,
-                           [ rdf:type owl:Restriction ;
                              owl:onProperty :hazardClassificationId ;
-                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty :packagingDangerLevelCode ;
                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
                            ] ,
                            [ rdf:type owl:Restriction ;
@@ -9569,6 +9461,10 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                            owl:allValuesFrom :Ranges
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty :ratingsType ;
+                           owl:allValuesFrom ccodes:RatingsType
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty :billingChargeIdentifier ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
@@ -9593,6 +9489,10 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty :ratingsType ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty :chargeDescription ;
                            owl:allValuesFrom xsd:string
                          ] ,
@@ -9606,10 +9506,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :rateQuantity ;
-                           owl:allValuesFrom xsd:string
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :ratingsType ;
                            owl:allValuesFrom xsd:string
                          ] ,
                          [ rdf:type owl:Restriction ;
@@ -9634,10 +9530,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :rateQuantity ;
-                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :ratingsType ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
@@ -9996,6 +9888,10 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                             owl:allValuesFrom :Location
                           ] ,
                           [ rdf:type owl:Restriction ;
+                            owl:onProperty :incoterms ;
+                            owl:allValuesFrom :CodeListElement
+                          ] ,
+                          [ rdf:type owl:Restriction ;
                             owl:onProperty :insurance ;
                             owl:allValuesFrom :Insurance
                           ] ,
@@ -10032,6 +9928,10 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
                           ] ,
                           [ rdf:type owl:Restriction ;
+                            owl:onProperty :incoterms ;
+                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                          ] ,
+                          [ rdf:type owl:Restriction ;
                             owl:onProperty :insurance ;
                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
                           ] ,
@@ -10056,10 +9956,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                             owl:allValuesFrom xsd:string
                           ] ,
                           [ rdf:type owl:Restriction ;
-                            owl:onProperty :incoterms ;
-                            owl:allValuesFrom xsd:string
-                          ] ,
-                          [ rdf:type owl:Restriction ;
                             owl:onProperty :textualHandlingInstructions ;
                             owl:allValuesFrom xsd:string
                           ] ,
@@ -10073,10 +9969,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                           ] ,
                           [ rdf:type owl:Restriction ;
                             owl:onProperty :goodsDescription ;
-                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                          ] ,
-                          [ rdf:type owl:Restriction ;
-                            owl:onProperty :incoterms ;
                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
                           ] ,
                           [ rdf:type owl:Restriction ;
@@ -10176,6 +10068,10 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                        owl:allValuesFrom :Value
                                      ] ,
                                      [ rdf:type owl:Restriction ;
+                                       owl:onProperty :uldRateClassType ;
+                                       owl:allValuesFrom xsd:integer
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
                                        owl:onProperty :chargeableWeightForRate ;
                                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                      ] ,
@@ -10204,6 +10100,10 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                      ] ,
                                      [ rdf:type owl:Restriction ;
+                                       owl:onProperty :uldRateClassType ;
+                                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
                                        owl:onProperty :commodityItemNumber ;
                                        owl:allValuesFrom xsd:string
                                      ] ,
@@ -10216,10 +10116,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                        owl:allValuesFrom xsd:string
                                      ] ,
                                      [ rdf:type owl:Restriction ;
-                                       owl:onProperty :uldRateClassType ;
-                                       owl:allValuesFrom xsd:integer
-                                     ] ,
-                                     [ rdf:type owl:Restriction ;
                                        owl:onProperty :commodityItemNumber ;
                                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                      ] ,
@@ -10229,10 +10125,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                      ] ,
                                      [ rdf:type owl:Restriction ;
                                        owl:onProperty :rcp ;
-                                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                                     ] ,
-                                     [ rdf:type owl:Restriction ;
-                                       owl:onProperty :uldRateClassType ;
                                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                      ] ;
                      rdfs:comment "Information from AWB Rate Description section as per bullet point 18 - data elements 22A - 22Z from AWB"@en ;
@@ -10321,6 +10213,10 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                   owl:allValuesFrom :Value
                                 ] ,
                                 [ rdf:type owl:Restriction ;
+                                  owl:onProperty :vehicleType ;
+                                  owl:allValuesFrom :CodeListElement
+                                ] ,
+                                [ rdf:type owl:Restriction ;
                                   owl:onProperty :operatedTransportMovement ;
                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                 ] ,
@@ -10337,6 +10233,10 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                 ] ,
                                 [ rdf:type owl:Restriction ;
+                                  owl:onProperty :vehicleType ;
+                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                ] ,
+                                [ rdf:type owl:Restriction ;
                                   owl:onProperty :vehicleModel ;
                                   owl:allValuesFrom xsd:string
                                 ] ,
@@ -10349,10 +10249,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                   owl:allValuesFrom xsd:string
                                 ] ,
                                 [ rdf:type owl:Restriction ;
-                                  owl:onProperty :vehicleType ;
-                                  owl:allValuesFrom xsd:string
-                                ] ,
-                                [ rdf:type owl:Restriction ;
                                   owl:onProperty :vehicleModel ;
                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                 ] ,
@@ -10362,10 +10258,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                 ] ,
                                 [ rdf:type owl:Restriction ;
                                   owl:onProperty :vehicleSize ;
-                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                                ] ,
-                                [ rdf:type owl:Restriction ;
-                                  owl:onProperty :vehicleType ;
                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                 ] ;
                 rdfs:comment "Transport means details"@en ;
@@ -10408,6 +10300,10 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                      owl:allValuesFrom :Value
                                    ] ,
                                    [ rdf:type owl:Restriction ;
+                                     owl:onProperty :modeCode ;
+                                     owl:allValuesFrom :ModeCode
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
                                      owl:onProperty :modeQualifier ;
                                      owl:allValuesFrom :ModeQualifier
                                    ] ,
@@ -10444,6 +10340,10 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                      owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                    ] ,
                                    [ rdf:type owl:Restriction ;
+                                     owl:onProperty :modeCode ;
+                                     owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
                                      owl:onProperty :modeQualifier ;
                                      owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                    ] ,
@@ -10456,10 +10356,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                      owl:allValuesFrom xsd:string
                                    ] ,
                                    [ rdf:type owl:Restriction ;
-                                     owl:onProperty :modeCode ;
-                                     owl:allValuesFrom xsd:string
-                                   ] ,
-                                   [ rdf:type owl:Restriction ;
                                      owl:onProperty :seal ;
                                      owl:allValuesFrom xsd:string
                                    ] ,
@@ -10469,10 +10365,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                                    ] ,
                                    [ rdf:type owl:Restriction ;
                                      owl:onProperty :fuelType ;
-                                     owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                                   ] ,
-                                   [ rdf:type owl:Restriction ;
-                                     owl:onProperty :modeCode ;
                                      owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                    ] ,
                                    [ rdf:type owl:Restriction ;
@@ -10491,19 +10383,51 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
 :Uld rdf:type owl:Class ;
      rdfs:subClassOf :LoadingUnit ,
                      [ rdf:type owl:Restriction ;
+                       owl:onProperty :demurrageCode ;
+                       owl:allValuesFrom ccodes:DemurrageCode
+                     ] ,
+                     [ rdf:type owl:Restriction ;
                        owl:onProperty :loadingIndicator ;
                        owl:allValuesFrom ccodes:ULDLoadingIndicator
+                     ] ,
+                     [ rdf:type owl:Restriction ;
+                       owl:onProperty :odlnCode ;
+                       owl:allValuesFrom :CodeListElement
+                     ] ,
+                     [ rdf:type owl:Restriction ;
+                       owl:onProperty :ownerCode ;
+                       owl:allValuesFrom :CodeListElement
                      ] ,
                      [ rdf:type owl:Restriction ;
                        owl:onProperty :serviceabilityCode ;
                        owl:allValuesFrom ccodes:ULDConditionCode
                      ] ,
                      [ rdf:type owl:Restriction ;
+                       owl:onProperty :uldTypeCode ;
+                       owl:allValuesFrom :CodeListElement
+                     ] ,
+                     [ rdf:type owl:Restriction ;
+                       owl:onProperty :demurrageCode ;
+                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                     ] ,
+                     [ rdf:type owl:Restriction ;
                        owl:onProperty :loadingIndicator ;
                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
                      ] ,
                      [ rdf:type owl:Restriction ;
+                       owl:onProperty :odlnCode ;
+                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                     ] ,
+                     [ rdf:type owl:Restriction ;
+                       owl:onProperty :ownerCode ;
+                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                     ] ,
+                     [ rdf:type owl:Restriction ;
                        owl:onProperty :serviceabilityCode ;
+                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                     ] ,
+                     [ rdf:type owl:Restriction ;
+                       owl:onProperty :uldTypeCode ;
                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
                      ] ,
                      [ rdf:type owl:Restriction ;
@@ -10515,10 +10439,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                        owl:allValuesFrom xsd:boolean
                      ] ,
                      [ rdf:type owl:Restriction ;
-                       owl:onProperty :demurrageCode ;
-                       owl:allValuesFrom xsd:string
-                     ] ,
-                     [ rdf:type owl:Restriction ;
                        owl:onProperty :numberOfDoors ;
                        owl:allValuesFrom xsd:integer
                      ] ,
@@ -10535,23 +10455,11 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                        owl:allValuesFrom xsd:integer
                      ] ,
                      [ rdf:type owl:Restriction ;
-                       owl:onProperty :odlnCode ;
-                       owl:allValuesFrom xsd:string
-                     ] ,
-                     [ rdf:type owl:Restriction ;
-                       owl:onProperty :ownerCode ;
-                       owl:allValuesFrom xsd:string
-                     ] ,
-                     [ rdf:type owl:Restriction ;
                        owl:onProperty :sealNumber ;
                        owl:allValuesFrom xsd:string
                      ] ,
                      [ rdf:type owl:Restriction ;
                        owl:onProperty :uldSerialNumber ;
-                       owl:allValuesFrom xsd:string
-                     ] ,
-                     [ rdf:type owl:Restriction ;
-                       owl:onProperty :uldTypeCode ;
                        owl:allValuesFrom xsd:string
                      ] ,
                      [ rdf:type owl:Restriction ;
@@ -10563,10 +10471,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
                      ] ,
                      [ rdf:type owl:Restriction ;
-                       owl:onProperty :demurrageCode ;
-                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                     ] ,
-                     [ rdf:type owl:Restriction ;
                        owl:onProperty :numberOfDoors ;
                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
                      ] ,
@@ -10583,23 +10487,11 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
                      ] ,
                      [ rdf:type owl:Restriction ;
-                       owl:onProperty :odlnCode ;
-                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                     ] ,
-                     [ rdf:type owl:Restriction ;
-                       owl:onProperty :ownerCode ;
-                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                     ] ,
-                     [ rdf:type owl:Restriction ;
                        owl:onProperty :sealNumber ;
                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
                      ] ,
                      [ rdf:type owl:Restriction ;
                        owl:onProperty :uldSerialNumber ;
-                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                     ] ,
-                     [ rdf:type owl:Restriction ;
-                       owl:onProperty :uldTypeCode ;
                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
                      ] ;
      rdfs:comment "Unit Load Device details"@en ;
@@ -10713,6 +10605,10 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                            owl:allValuesFrom :Value
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty :customsOriginCode ;
+                           owl:allValuesFrom :CodeListElement
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty :declaredValueForCarriage ;
                            owl:allValuesFrom :Value
                          ] ,
@@ -10725,6 +10621,10 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                            owl:allValuesFrom :Location
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty :destinationCurrencyCode ;
+                           owl:allValuesFrom :CodeListElement
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty :houseWaybills ;
                            owl:allValuesFrom :Waybill
                          ] ,
@@ -10735,6 +10635,10 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :masterWaybill ;
                            owl:allValuesFrom :Waybill
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :originCurrency ;
+                           owl:allValuesFrom :CodeListElement
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :otherCharges ;
@@ -10789,6 +10693,10 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty :customsOriginCode ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty :declaredValueForCarriage ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
@@ -10801,7 +10709,15 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty :destinationCurrencyCode ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty :masterWaybill ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :originCurrency ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
@@ -10845,16 +10761,8 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                            owl:allValuesFrom xsd:string
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty :customsOriginCode ;
-                           owl:allValuesFrom xsd:string
-                         ] ,
-                         [ rdf:type owl:Restriction ;
                            owl:onProperty :destinationCharges ;
                            owl:allValuesFrom xsd:double
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :destinationCurrencyCode ;
-                           owl:allValuesFrom xsd:string
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :destinationCurrencyRate ;
@@ -10863,10 +10771,6 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :modularCheckNumber ;
                            owl:allValuesFrom xsd:boolean
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :originCurrency ;
-                           owl:allValuesFrom xsd:string
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :shippingInfo ;
@@ -10901,23 +10805,11 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty :customsOriginCode ;
-                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :destinationCurrencyCode ;
-                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                         ] ,
-                         [ rdf:type owl:Restriction ;
                            owl:onProperty :destinationCurrencyRate ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :modularCheckNumber ;
-                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :originCurrency ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
@@ -10978,6 +10870,13 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                  :MovementTimeType ;
         rdfs:comment "Used when a time is actual"@en ;
         rdfs:label "ACTUAL"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#AIR_TRANSPORT
+:AIR_TRANSPORT rdf:type owl:NamedIndividual ,
+                        :ModeCode ;
+               rdfs:comment "Indicates the transport mode to be Air Transport (4)"@en ;
+               rdfs:label "AIR_TRANSPORT"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#ALTERNATE_EMAIL_ADDRESS
@@ -11086,6 +10985,13 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
             rdfs:label "FAX_NUMBER"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#FIXED_TRANSPORT_INSTALLATION
+:FIXED_TRANSPORT_INSTALLATION rdf:type owl:NamedIndividual ,
+                                       :ModeCode ;
+                              rdfs:comment "Indicates that the transport mode is a Fixed Transport Installation (7)"@en ;
+                              rdfs:label "FIXED_TRANSPORT_INSTALLATION"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#GEOLOCATION
 :GEOLOCATION rdf:type owl:NamedIndividual ,
                       :SensorType ;
@@ -11114,6 +11020,13 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
          rdfs:label "INBOUND"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#INLAND_WATER_TRANSPORT
+:INLAND_WATER_TRANSPORT rdf:type owl:NamedIndividual ,
+                                 :ModeCode ;
+                        rdfs:comment "Indicates that the transport mode to be Inland Water Transport (8)"@en ;
+                        rdfs:label "INLAND_WATER_TRANSPORT"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#LIGHT
 :LIGHT rdf:type owl:NamedIndividual ,
                 :SensorType ;
@@ -11135,6 +11048,13 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
        rdfs:label "LOOSE"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#MAIL
+:MAIL rdf:type owl:NamedIndividual ,
+               :ModeCode ;
+      rdfs:comment "Indicates the transport mode to be Mail (5)"@en ;
+      rdfs:label "MAIL"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#MAIN_CARRIAGE
 :MAIN_CARRIAGE rdf:type owl:NamedIndividual ,
                         :ModeQualifier ;
@@ -11142,11 +11062,25 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                rdfs:label "MAIN_CARRIAGE"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#MARITIME_TRANSPORT
+:MARITIME_TRANSPORT rdf:type owl:NamedIndividual ,
+                             :ModeCode ;
+                    rdfs:comment "Indicates the transport mode to be Maritime Transport (1)"@en ;
+                    rdfs:label "MARITIME_TRANSPORT"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#MASTER
 :MASTER rdf:type owl:NamedIndividual ,
                  :WaybillType ;
         rdfs:comment "Indicates a Master Waybill"@en ;
         rdfs:label "MASTER"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#MULTIMODAL_TRANSPORT
+:MULTIMODAL_TRANSPORT rdf:type owl:NamedIndividual ,
+                               :ModeCode ;
+                      rdfs:comment "Indicates a Multimodal Transport (6)"@en ;
+                      rdfs:label "MULTIMODAL_TRANSPORT"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#ON_CARRIAGE
@@ -11206,12 +11140,26 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
               rdfs:label "PRE_CARRIAGE"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#RAIL_TRANSPORT
+:RAIL_TRANSPORT rdf:type owl:NamedIndividual ,
+                         :ModeCode ;
+                rdfs:comment "Indicates the transport mode to be Rail Transport (2)"@en ;
+                rdfs:label "RAIL_TRANSPORT"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#REQUESTED
 :REQUESTED rdf:type owl:NamedIndividual ,
                     :ActionTimeType ,
                     :EventTimeType ;
            rdfs:comment "Used when a time is requested"@en ;
            rdfs:label "REQUESTED"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#ROAD_TRANSPORT
+:ROAD_TRANSPORT rdf:type owl:NamedIndividual ,
+                         :ModeCode ;
+                rdfs:comment "Indicates the transport mode to be Road Transport (3)"@en ;
+                rdfs:label "ROAD_TRANSPORT"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#SCHEDULED
@@ -11254,6 +11202,20 @@ ccodes:ULDLoadingIndicator rdf:type owl:Class ;
                :SensorType ;
       rdfs:comment "Indicates the sensor type as tilt"@en ;
       rdfs:label "TILT"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#TRANSPORT_MODE_NOT_APPLICABLE
+:TRANSPORT_MODE_NOT_APPLICABLE rdf:type owl:NamedIndividual ,
+                                        :ModeCode ;
+                               rdfs:comment "Indicates that no transport mode is applicable (9)"@en ;
+                               rdfs:label "TRANSPORT_MODE_NOT_APPLICABLE"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#TRANSPORT_MODE_NOT_SPECIFIED
+:TRANSPORT_MODE_NOT_SPECIFIED rdf:type owl:NamedIndividual ,
+                                       :ModeCode ;
+                              rdfs:comment "Indicates that the Transport Mode is not specified ()"@en ;
+                              rdfs:label "TRANSPORT_MODE_NOT_SPECIFIED"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#ULD

--- a/working_draft/ontology/IATA-1R-DM-Ontology.ttl
+++ b/working_draft/ontology/IATA-1R-DM-Ontology.ttl
@@ -9,7 +9,7 @@
 @base <https://onerecord.iata.org/ns/cargo> .
 
 <https://onerecord.iata.org/ns/cargo> rdf:type owl:Ontology ;
-                                       owl:versionIRI <https://onerecord.iata.org/ns/cargo/3.0.0-RC5b> ;
+                                       owl:versionIRI <https://onerecord.iata.org/ns/cargo/3.0.0-RC5c> ;
                                        dc:description "The ONE Record vocabulary, described using W3C RDF Schema and the Web Ontology Language."@en ;
                                        dc:title "ONE Record Ontology"@en ;
                                        terms:abstract "The ontology of the ONE Record standard is the core data model underlying the Linked Data solution drafted by the ONE Record standard: https://github.com/IATA-Cargo/ONE-Record. ONE Record is a standard for data sharing and creates a single record view of the shipment. This standard defines a common data model for the data that is shared via standardized and secured web API."@en ;
@@ -72,10 +72,12 @@ Version 3.0.0 RC5a
 - Added tactRateDescriptions, chargeTotals and otherCharges to Waybill to connect with the new LOs
 Version 3.0.0 RC5b
 - Moved chargesAtDestination from Waybill to TotalCharge
-- Added object property totalCollectCharges with Range Value and added it to TotalCharge"""@en ;
+- Added object property totalCollectCharges with Range Value and added it to TotalCharge
+Version 3.0.0 RC5c
+- Moved CustomsInformation from Piece to Shipment"""@en ;
                                        rdfs:isDefinedBy "https://www.iata.org/one-record/"^^xsd:anyURI ;
                                        rdfs:label "ONE Record Ontology"@en ;
-                                       owl:versionInfo "3.0.0 RC 5b"@en .
+                                       owl:versionInfo "3.0.0 RC 5c"@en .
 
 #################################################################
 #    Annotation properties
@@ -736,12 +738,20 @@ owl:thing rdf:type rdfs:Datatype .
 
 ###  https://onerecord.iata.org/ns/cargo#customsInformation
 :customsInformation rdf:type owl:ObjectProperty ;
-                    rdfs:domain :Piece ;
+                    rdfs:domain :Shipment ;
                     rdfs:range :CustomsInformation ;
                     rdfs:comment "Customs details"@en ;
                     rdfs:label "customsInformation"@en ;
                     owl:comment "Possible RDF good practice IRI: :hasCustomsInformation "@en ;
                     owl:versionInfo "v3.0 renamed from piece:customsInfo"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#customsInformationOfShipment
+:customsInformationOfShipment rdf:type owl:ObjectProperty ;
+                              rdfs:domain :CustomsInformation ;
+                              rdfs:range :Shipment ;
+                              rdfs:comment "Reference to the Shipment this CustomsInformation is for"@en ;
+                              rdfs:label "customsInformationOfShipment"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#declaredValueForCarriage
@@ -6941,11 +6951,11 @@ Condition: At least one of the three elements (Country Code, Information Identif
 :CustomsInformation rdf:type owl:Class ;
                     rdfs:subClassOf :LogisticsObject ,
                                     [ rdf:type owl:Restriction ;
-                                      owl:onProperty :issuedForPiece ;
-                                      owl:allValuesFrom :Piece
+                                      owl:onProperty :customsInformationOfShipment ;
+                                      owl:allValuesFrom :Shipment
                                     ] ,
                                     [ rdf:type owl:Restriction ;
-                                      owl:onProperty :issuedForPiece ;
+                                      owl:onProperty :customsInformationOfShipment ;
                                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                     ] ,
                                     [ rdf:type owl:Restriction ;
@@ -8726,10 +8736,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                          owl:allValuesFrom :Country
                        ] ,
                        [ rdf:type owl:Restriction ;
-                         owl:onProperty :customsInformation ;
-                         owl:allValuesFrom :CustomsInformation
-                       ] ,
-                       [ rdf:type owl:Restriction ;
                          owl:onProperty :dimensions ;
                          owl:allValuesFrom :Dimensions
                        ] ,
@@ -9924,6 +9930,10 @@ Condition: At least one of the three elements (Country Code, Information Identif
 ###  https://onerecord.iata.org/ns/cargo#Shipment
 :Shipment rdf:type owl:Class ;
           rdfs:subClassOf :LogisticsObject ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty :customsInformation ;
+                            owl:allValuesFrom :CustomsInformation
+                          ] ,
                           [ rdf:type owl:Restriction ;
                             owl:onProperty :deliveryLocation ;
                             owl:allValuesFrom :Location

--- a/working_draft/ontology/IATA-1R-DM-Ontology.ttl
+++ b/working_draft/ontology/IATA-1R-DM-Ontology.ttl
@@ -9,11 +9,11 @@
 @base <https://onerecord.iata.org/ns/cargo> .
 
 <https://onerecord.iata.org/ns/cargo> rdf:type owl:Ontology ;
-                                       owl:versionIRI <https://onerecord.iata.org/ns/cargo/3.0.0-RC5d> ;
+                                       owl:versionIRI <https://onerecord.iata.org/ns/cargo/3.0.0-RC5e> ;
                                        dc:description "The ONE Record vocabulary, described using W3C RDF Schema and the Web Ontology Language."@en ;
                                        dc:title "ONE Record Ontology"@en ;
                                        terms:abstract "The ontology of the ONE Record standard is the core data model underlying the Linked Data solution drafted by the ONE Record standard: https://github.com/IATA-Cargo/ONE-Record. ONE Record is a standard for data sharing and creates a single record view of the shipment. This standard defines a common data model for the data that is shared via standardized and secured web API."@en ;
-                                       terms:modified "02-08-2023" ;
+                                       terms:modified "07-08-2023" ;
                                        terms:title "ONE Record Ontology"@en ;
                                        rdfs:comment """Details availalble on GitHub https://github.com/IATA-Cargo/ONE-Record
 Version 2.0.0
@@ -83,10 +83,12 @@ Version 3.0.0 RC5d
 - Added onLoadingUnit property to UnitComposition
 - Added property inUnitComposition to LoadingUnit (inverse)
 - Added properties subLocations and subLocationOf to model hierarchical relationships between Locations
-- Renamed forActions to performedActions to better reflect its inverse property performedAtLocation"""@en ;
+- Renamed forActions to performedActions to better reflect its inverse property performedAt
+Version 3.0.0 RC5e
+- Renamed locationOfPerformance to performedAt to shorten it"""@en ;
                                        rdfs:isDefinedBy "https://www.iata.org/one-record/"^^xsd:anyURI ;
                                        rdfs:label "ONE Record Ontology"@en ;
-                                       owl:versionInfo "3.0.0 RC 5d"@en .
+                                       owl:versionInfo "3.0.0 RC 5e"@en .
 
 #################################################################
 #    Annotation properties
@@ -1606,13 +1608,13 @@ owl:thing rdf:type rdfs:Datatype .
                  owl:comment "Possible RDF good practice IRI: :isLocationOfAction "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#performedAtLocation
-:performedAtLocation rdf:type owl:ObjectProperty ;
-                     rdfs:domain :LogisticsAction ;
-                     rdfs:range :Location ;
-                     rdfs:comment "Reference to the Location the Action was performed at"@en ;
-                     rdfs:label "perfomedAtLocation"@en ;
-                     owl:comment "Possible RDF good practice IRI: :isPerformedAt "@en .
+###  https://onerecord.iata.org/ns/cargo#performedAt
+:performedAt rdf:type owl:ObjectProperty ;
+             rdfs:domain :LogisticsAction ;
+             rdfs:range :Location ;
+             rdfs:comment "Reference to the Location the Action was performed at"@en ;
+             rdfs:label "perfomedAt"@en ;
+             owl:comment "Possible RDF good practice IRI: :isPerformedAt "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#preferenceOfRequests
@@ -8159,7 +8161,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                    owl:allValuesFrom :Person
                                  ] ,
                                  [ rdf:type owl:Restriction ;
-                                   owl:onProperty :performedAtLocation ;
+                                   owl:onProperty :performedAt ;
                                    owl:allValuesFrom :Location
                                  ] ,
                                  [ rdf:type owl:Restriction ;
@@ -8167,7 +8169,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                    owl:allValuesFrom :LogisticsActivity
                                  ] ,
                                  [ rdf:type owl:Restriction ;
-                                   owl:onProperty :performedAtLocation ;
+                                   owl:onProperty :performedAt ;
                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                  ] ,
                                  [ rdf:type owl:Restriction ;

--- a/working_draft/ontology/IATA-1R-DM-Ontology.ttl
+++ b/working_draft/ontology/IATA-1R-DM-Ontology.ttl
@@ -6,14 +6,16 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix terms: <http://purl.org/dc/terms/> .
+@prefix ccodes: <<https://onerecord.iata.org/ns/coreCodeLists#> .
 @base <https://onerecord.iata.org/ns/cargo> .
 
 <https://onerecord.iata.org/ns/cargo> rdf:type owl:Ontology ;
-                                       owl:versionIRI <https://onerecord.iata.org/ns/cargo/3.0.0-RC5e> ;
+                                       owl:versionIRI <https://onerecord.iata.org/ns/cargo/3.0.0-RC5f> ;
+                                       owl:imports <https://onerecord.iata.org/ns/coreCodeLists/0.0.1> ;
                                        dc:description "The ONE Record vocabulary, described using W3C RDF Schema and the Web Ontology Language."@en ;
                                        dc:title "ONE Record Ontology"@en ;
                                        terms:abstract "The ontology of the ONE Record standard is the core data model underlying the Linked Data solution drafted by the ONE Record standard: https://github.com/IATA-Cargo/ONE-Record. ONE Record is a standard for data sharing and creates a single record view of the shipment. This standard defines a common data model for the data that is shared via standardized and secured web API."@en ;
-                                       terms:modified "07-08-2023" ;
+                                       terms:modified "23-08-2023" ;
                                        terms:title "ONE Record Ontology"@en ;
                                        rdfs:comment """Details availalble on GitHub https://github.com/IATA-Cargo/ONE-Record
 Version 2.0.0
@@ -85,10 +87,19 @@ Version 3.0.0 RC5d
 - Added properties subLocations and subLocationOf to model hierarchical relationships between Locations
 - Renamed forActions to performedActions to better reflect its inverse property performedAt
 Version 3.0.0 RC5e
-- Renamed locationOfPerformance to performedAt to shorten it"""@en ;
+- Renamed locationOfPerformance to performedAt to shorten it
+Version 3.0.0 RC5f - Code list integration part I - Integration playbook pending
+- Changed many enum-holding properties to object properties, referring to classes defining code lists as named individuals for type safety- detailed changelog will follow
+- Integrated all cXML-references as proper code lists in the /coreCodeLists/ ontology
+-  Added CodeListElement class with properties code, codeName, codeLevel, codeListName, codeListVersion and codeListReference as parent class for code lists and to add the ability to transmit codes in a structured way if no rdf code list exist yet
+- Renamed category to RegulatedEntityCategory
+- Renamed code to locationCode
+- Moved slac from LoadingUnit to UnitComposition; changed Domain to owl:Thing
+- Added partialEventIndicator to LogisticsEvent for part events
+- Added otherIdentifier to LogisticActions to be able to transmit custom identifiers such as Loading/Unloading lists in trucking/milk runs"""@en ;
                                        rdfs:isDefinedBy "https://www.iata.org/one-record/"^^xsd:anyURI ;
                                        rdfs:label "ONE Record Ontology"@en ;
-                                       owl:versionInfo "3.0.0 RC 5e"@en .
+                                       owl:versionInfo "3.0.0 RC 5f"@en .
 
 #################################################################
 #    Annotation properties
@@ -146,6 +157,15 @@ owl:thing rdf:type rdfs:Datatype .
 #    Object Properties
 #################################################################
 
+###  https://onerecord.iata.org/ns/cargo#actionTimeType
+:actionTimeType rdf:type owl:ObjectProperty ;
+                rdfs:domain :LogisticsAction ;
+                rdfs:range :ActionTimeType ;
+                rdfs:comment "Enum stating the type of the Action"@en ;
+                rdfs:label "actionTimeType"@en ;
+                owl:comment "Possible RDF good practice IRI: :isOfActionTimeType "@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#actions
 :actions rdf:type owl:ObjectProperty ;
          rdfs:domain :TransportMovement ;
@@ -182,6 +202,24 @@ owl:thing rdf:type rdfs:Datatype .
          owl:comment "Possible RDF good practice IRI: :hasAddress "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#addressCode
+:addressCode rdf:type owl:ObjectProperty ;
+             rdfs:domain :Address ;
+             rdfs:range :CodeListElement ;
+             rdfs:comment "Address identifier using special coding systems e.g. US CBP FIRMS code"@en ;
+             rdfs:label "addressCode"@en ;
+             owl:comment "Possible RDF good practice IRI: :hasAddressCode "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#addressCodeType
+:addressCodeType rdf:type owl:ObjectProperty ;
+                 rdfs:domain :Address ;
+                 rdfs:range :CodeListElement ;
+                 rdfs:comment "Type of address code e.g. US CBP FIRMS"@en ;
+                 rdfs:label "addressCodeType"@en ;
+                 owl:comment "Possible RDF good practice IRI: :hasAddressCodeType "@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#adjustments
 :adjustments rdf:type owl:ObjectProperty ;
              rdfs:domain :BillingDetails ;
@@ -191,11 +229,20 @@ owl:thing rdf:type rdfs:Datatype .
              owl:comment "Possible RDF good practice IRI: :hasAdjustment "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#aircraftPossibilityCode
+:aircraftPossibilityCode rdf:type owl:ObjectProperty ;
+                         rdfs:domain :Routing ;
+                         rdfs:range ccodes:AircraftPossibilityCode ;
+                         rdfs:comment "Aircraft possibility code - Refers to CXML Code List 1.46 that contains values such as \"Pure freighter flight carrying Loose Load Cargo - BBF\""@en ;
+                         rdfs:label "aircraftPossibilityCode"@en ;
+                         owl:comment "Possible RDF good practice IRI: :hasAircraftPossibilityCode "@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#amountTotal
 :amountTotal rdf:type owl:ObjectProperty ;
              rdfs:domain :TotalCharge ;
              rdfs:range :Value ;
-             rdfs:comment "PENDING"@en ;
+             rdfs:comment "Total amount prepaid or collect as per bullet points 20/21 - data elements 24A - 30B  from AWB"@en ;
              rdfs:label "amountTotal"@en .
 
 
@@ -233,7 +280,7 @@ owl:thing rdf:type rdfs:Datatype .
                  rdfs:comment "Piece on which the Packaging type is applicable"@en ;
                  rdfs:label "appliedOnPieces"@en ;
                  owl:comment "Possible RDF good practice IRI: :isAppliedOnPiece "@en ;
-                 owl:versionInfo "v3.0 renamed from packagingType:piece"@en .
+                 owl:versionInfo "v3. renamed from packagingType:piece"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#arrivalLocation
@@ -298,6 +345,15 @@ owl:thing rdf:type rdfs:Datatype .
                  rdfs:comment "Reference to the Location where the Organization is based at or headquartered"@en ;
                  rdfs:label "basedAtLocation"@en ;
                  owl:comment "Possible RDF good practice IRI: :isBasedAt "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#billingChargeIdentifier
+:billingChargeIdentifier rdf:type owl:ObjectProperty ;
+                         rdfs:domain :Ratings ;
+                         rdfs:range ccodes:ChargeIdentifier ;
+                         rdfs:comment "Billing charge identifiers to be used for CASS. Refer to CargoXML Code List 1.33"@en ;
+                         rdfs:label "billingChargeIdentifier"@en ;
+                         owl:comment "Possible RDF good practice IRI: :hasBillingChargeIdentifier "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#billingDetails
@@ -411,6 +467,16 @@ owl:thing rdf:type rdfs:Datatype .
          owl:deprecated "true"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#carrierChargeCode
+:carrierChargeCode rdf:type owl:ObjectProperty ;
+                   rdfs:domain owl:Thing ;
+                   rdfs:range ccodes:ChargeCode ;
+                   rdfs:comment "One letter charge code as per bullet point 12 - data element 13 from AWB"@en ;
+                   rdfs:label "carrierChargeCode"@en ;
+                   owl:comment "Possible RDF good practice IRI: :hasCarrierChargeCode "@en ;
+                   owl:versionInfo "v1.1 - changed comment to avoid non-unicode characters" .
+
+
 ###  https://onerecord.iata.org/ns/cargo#carrierDeclarationPlace
 :carrierDeclarationPlace rdf:type owl:ObjectProperty ;
                          rdfs:domain :Waybill ;
@@ -438,12 +504,39 @@ owl:thing rdf:type rdfs:Datatype .
                   owl:comment "Possible RDF good practice IRI: :isCertifiedByActor "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#chargeCode
+:chargeCode rdf:type owl:ObjectProperty ;
+            rdfs:domain :Ratings ;
+            rdfs:range ccodes:ChargeCode ;
+            rdfs:comment "Charge code, refer to CargoXML Code List 1.1"@en ;
+            rdfs:label "chargeCode"@en ;
+            owl:comment "Possible RDF good practice IRI: :hasChargeCode "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#chargePaymentType
+:chargePaymentType rdf:type owl:ObjectProperty ;
+                   rdfs:domain owl:Thing ;
+                   rdfs:range ccodes:PrepaidCollectIndicator ;
+                   rdfs:comment "Indicates if charge is prepaid or collect (P, C)"@en ;
+                   rdfs:label "chargePaymentType"@en ;
+                   owl:comment "Possible RDF good practice IRI: :hasChargePaymentType "@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#chargeTotals
 :chargeTotals rdf:type owl:ObjectProperty ;
               rdfs:domain :Waybill ;
               rdfs:range :TotalCharge ;
               rdfs:comment "Information about Total Charges applying to this Waybill"@en ;
               rdfs:label "chargeTotals"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#chargeType
+:chargeType rdf:type owl:ObjectProperty ;
+            rdfs:domain owl:Thing ;
+            rdfs:range ccodes:ChargeIdentifier ;
+            rdfs:comment "Charge type related to amount total as per bullet points 20/21 - data elements 24A - 30B  from AWB"@en ;
+            rdfs:label "chargeType"@en ;
+            owl:comment "Possible RDF good practice IRI: :hasChargeType "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#chargeableWeight
@@ -459,7 +552,7 @@ owl:thing rdf:type rdfs:Datatype .
 :chargeableWeightForRate rdf:type owl:ObjectProperty ;
                          rdfs:domain :TACTRateDescription ;
                          rdfs:range :Value ;
-                         rdfs:comment "PENDING"@en ;
+                         rdfs:comment "Chargeable weight for which the rate description details apply"@en ;
                          rdfs:label "chargeableWeightForRate"@en .
 
 
@@ -467,7 +560,7 @@ owl:thing rdf:type rdfs:Datatype .
 :chargesAtDestination rdf:type owl:ObjectProperty ;
                       rdfs:domain :TotalCharge ;
                       rdfs:range :Value ;
-                      rdfs:comment "PENDING"@en ;
+                      rdfs:comment "Additional charges added at destination as per bullet point 25 - data element 33C from AWB"@en ;
                       rdfs:label "chargesAtDestination"@en .
 
 
@@ -538,7 +631,7 @@ owl:thing rdf:type rdfs:Datatype .
 :collectChargesInDestinationCurrency rdf:type owl:ObjectProperty ;
                                      rdfs:domain :TotalCharge ;
                                      rdfs:range :Value ;
-                                     rdfs:comment "PENDING"@en ;
+                                     rdfs:comment "Total collect charges converted into destination currency"@en ;
                                      rdfs:label "collectChargesInDestinationCurrency"@en .
 
 
@@ -579,6 +672,15 @@ owl:thing rdf:type rdfs:Datatype .
                     owl:comment "Possible RDF good practice IRI: :hasCompositionActions "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#compositionType
+:compositionType rdf:type owl:ObjectProperty ;
+                 rdfs:domain :Composing ;
+                 rdfs:range :CompositionType ;
+                 rdfs:comment "Enum stating whether the CompositionAction describes build-up or break-down"@en ;
+                 rdfs:label "compositionType"@en ;
+                 owl:comment "Possible RDF good practice IRI: :isOfCompositionType "@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#connectedSensors
 :connectedSensors rdf:type owl:ObjectProperty ;
                   rdfs:domain :IotDevice ;
@@ -586,7 +688,7 @@ owl:thing rdf:type rdfs:Datatype .
                   rdfs:comment "Reference to the sensors linked to the device"@en ;
                   rdfs:label "connectedSensors"@en ;
                   owl:comment "Possible RDF good practice IRI: :hasConnectedSensor "@en ;
-                  owl:versionInfo "v3.0 renamed from iotDevice:sensors"@en .
+                  owl:versionInfo "v3. renamed from iotDevice:sensors"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#consignee
@@ -616,6 +718,16 @@ owl:thing rdf:type rdfs:Datatype .
               owl:comment "Possible RDF good practice IRI: :hasEpermitConsignment "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#contactDetailType
+:contactDetailType rdf:type owl:ObjectProperty ;
+                   rdfs:domain :ContactDetail ;
+                   rdfs:range :ContactDetailType ;
+                   rdfs:comment "Type of the contact details, e.g. Phone number, Mail address"@en ;
+                   rdfs:label "contactDetailType"@en ;
+                   owl:comment "Possible RDF good practice IRI: :isOfContactDetailType "@en ;
+                   owl:versionInfo "Added on v1.1"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#contactDetails
 :contactDetails rdf:type owl:ObjectProperty ;
                 rdfs:domain owl:Thing ;
@@ -633,6 +745,15 @@ owl:thing rdf:type rdfs:Datatype .
                 rdfs:label "contactPersons"@en ;
                 owl:comment "Possible RDF good practice IRI: :hasContactPerson "@en ;
                 owl:versionInfo "v1.1 renamed to contactPersons"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#contactRole
+:contactRole rdf:type owl:ObjectProperty ;
+             rdfs:domain :Person ;
+             rdfs:range :ContactRole ;
+             rdfs:comment "Contact type - e.g. Emergency contact, Customs contact, Customer contact"@en ;
+             rdfs:label "contactRole"@en ;
+             owl:comment "Possible RDF good practice IRI: :hasContactRole "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#containedItemInPiece
@@ -660,7 +781,7 @@ owl:thing rdf:type rdfs:Datatype .
                        rdfs:comment "Reference to the parent Piece if the Piece is contained within another Piece"@en ;
                        rdfs:label "containedPieceInPiece"@en ;
                        owl:comment "Possible RDF good practice IRI: :isContainedPieceInPiece "@en ;
-                       owl:versionInfo "v3.0 renamed from item:isInPiece"@en .
+                       owl:versionInfo "v3. renamed from item:isInPiece"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#containedPieces
@@ -673,6 +794,18 @@ owl:thing rdf:type rdfs:Datatype .
                  owl:versionInfo "v1.1 renamed to containedPieces"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#contentCode
+:contentCode rdf:type owl:ObjectProperty ;
+             rdfs:domain :CustomsInformation ;
+             rdfs:range :CodeListElement ;
+             rdfs:comment """Customs, Security and Regulatory Control Information Identifier. Coded indicator qualifying Customs related information: Item Number \"I\", Exemption Legend \"L\", System Downtime Reference \"S\", Unique Consignment Reference Number \"U\", Movement Reference Number \"M\" .
+Refers to Code List 1.1
+Condition: At least one of the three elements (Country Code, Information Identifier or Customs, Security and Regulatory Control Information Identifier) must be completed"""@en ;
+             rdfs:label "contentCode"@en ;
+             owl:comment "Possible RDF good practice IRI: :hasContentCode "@en ;
+             owl:versionInfo "v3. renamed from customsInformation:customsInfoContentCode"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#contentDescribedByProducts
 :contentDescribedByProducts rdf:type owl:ObjectProperty ;
                             rdfs:domain :Piece ;
@@ -680,7 +813,7 @@ owl:thing rdf:type rdfs:Datatype .
                             rdfs:comment "Product of the piece, mandatory when there are no items"@en ;
                             rdfs:label "contentDescribedByProducts"@en ;
                             owl:comment "Possible RDF good practice IRI: :hasContentDescribedByProduct "@en ;
-                            owl:versionInfo "v3.0 renamed from piece:product"@en .
+                            owl:versionInfo "v3. renamed from piece:product"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#contentOfDgProductRadioactive
@@ -699,7 +832,7 @@ owl:thing rdf:type rdfs:Datatype .
                           rdfs:comment "Goods production country, mandatory when there are no Items"@en ;
                           rdfs:label "contentProductionCountry"@en ;
                           owl:comment "Possible RDF good practice IRI: :hasContentProductionCountry "@en ;
-                          owl:versionInfo "v3.0 renamed from piece:containedProductsionCountry"@en .
+                          owl:versionInfo "v3. renamed from piece:containedProductsionCountry"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#conversionFactor
@@ -727,7 +860,7 @@ owl:thing rdf:type rdfs:Datatype .
                       rdfs:comment "Party covering the insurance "@en ;
                       rdfs:label "coveringOrganization"@en ;
                       owl:comment "Possible RDF good practice IRI: :isCoveredBy "@en ;
-                      owl:versionInfo "v3.0 renamed from insurance:coveringParty"@en .
+                      owl:versionInfo "v3. renamed from insurance:coveringParty"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#createdAtLocation
@@ -743,7 +876,7 @@ owl:thing rdf:type rdfs:Datatype .
 :currencyConversionRate rdf:type owl:ObjectProperty ;
                         rdfs:domain :TotalCharge ;
                         rdfs:range :Value ;
-                        rdfs:comment "PENDING"@en ;
+                        rdfs:comment "Currency conversion rate for charges in destination as per bullet point 25 - data element 33A from AWB"@en ;
                         rdfs:label "currencyConversionRate"@en .
 
 
@@ -754,7 +887,7 @@ owl:thing rdf:type rdfs:Datatype .
                     rdfs:comment "Customs details"@en ;
                     rdfs:label "customsInformation"@en ;
                     owl:comment "Possible RDF good practice IRI: :hasCustomsInformation "@en ;
-                    owl:versionInfo "v3.0 renamed from piece:customsInfo"@en .
+                    owl:versionInfo "v3. renamed from piece:customsInfo"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#customsInformationOfShipment
@@ -807,7 +940,7 @@ owl:thing rdf:type rdfs:Datatype .
                     rdfs:comment "URI of the product"@en ;
                     rdfs:label "describedByProduct"@en ;
                     owl:comment "Possible RDF good practice IRI: :isDescribedByProduct "@en ;
-                    owl:versionInfo "v3.0 renamed from item:product"@en .
+                    owl:versionInfo "v3. renamed from item:product"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#descriptionForContentOfPieces
@@ -817,7 +950,7 @@ owl:thing rdf:type rdfs:Datatype .
                                rdfs:comment "Reference to the pieces where the product can be found. This needs to be filled in case there is no Item"@en ;
                                rdfs:label "descriptionForContentOfPieces"@en ;
                                owl:comment "Possible RDF good practice IRI: :hasDescriptionForPieces "@en ;
-                               owl:versionInfo "v3.0 renamed from product:isInPieces"@en .
+                               owl:versionInfo "v3. renamed from product:isInPieces"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#descriptionForItems
@@ -827,7 +960,7 @@ owl:thing rdf:type rdfs:Datatype .
                      rdfs:comment "Reference to the Items in which the product can be found."@en ;
                      rdfs:label "descriptionForItems"@en ;
                      owl:comment "Possible RDF good practice IRI: :hasDescriptionForItems "@en ;
-                     owl:versionInfo "v3.0 renamed from product:isInItems"@en .
+                     owl:versionInfo "v3. renamed from product:isInItems"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#detailedWaybill
@@ -864,6 +997,15 @@ owl:thing rdf:type rdfs:Datatype .
             rdfs:comment "Dimensions details"@en ;
             rdfs:label "dimensions"@en ;
             owl:comment "Possible RDF good practice IRI: :hasDimensions "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#direction
+:direction rdf:type owl:ObjectProperty ;
+           rdfs:domain :MovementTime ;
+           rdfs:range :DirectionType ;
+           rdfs:comment "Direction to indicate if it's Inbound or Outbound"@en ;
+           rdfs:label "direction"@en ;
+           owl:comment "Possible RDF good practice IRI: :hasDirection "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#distanceCalculated
@@ -912,6 +1054,15 @@ owl:thing rdf:type rdfs:Datatype .
                   owl:comment "Possible RDF good practice IRI: :hasEmergencyContact "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#entitlement
+:entitlement rdf:type owl:ObjectProperty ;
+             rdfs:domain owl:Thing ;
+             rdfs:range ccodes:EntitlementCode ;
+             rdfs:comment "Entitlement code to define if charges are Due carrier (C) or Due agent (A). Refer to CXML Code List 1.3"@en ;
+             rdfs:label "entitlement"@en ;
+             owl:comment "Possible RDF good practice IRI: :hasEntitlementCode "@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#entity
 :entity rdf:type owl:ObjectProperty ;
         rdfs:domain :RegulatedEntity ;
@@ -928,6 +1079,25 @@ owl:thing rdf:type rdfs:Datatype .
          rdfs:comment "Reference to the Epermit of the consignment"@en ;
          rdfs:label "epermit"@en ;
          owl:comment "Possible RDF good practice IRI: :hasEpermit "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#eventCode
+:eventCode rdf:type owl:ObjectProperty ;
+           rdfs:domain :LogisticsEvent ;
+           rdfs:range :CodeListElement ;
+           rdfs:comment "Movement or milestone code. Can hold a named individual of the StatusCode core code list (corresponding to cXML code list 1.18), but can also be referring to different code lists."@en ;
+           rdfs:label "eventCode"@en ;
+           owl:comment "Possible RDF good practice IRI: :hasEventCode "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#eventTimeType
+:eventTimeType rdf:type owl:ObjectProperty ;
+               rdfs:domain :LogisticsEvent ;
+               rdfs:range :EventTimeType ;
+               rdfs:comment "Indicates type of event e.g.  Scheduled, Estimated, Actual"@en ;
+               rdfs:label "eventTimeType"@en ;
+               owl:comment "Possible RDF good practice IRI: :isOfEventTimeType "@en ;
+               owl:versionInfo "v3. renamed from logisticsEvent:eventTypeIndicator"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#events
@@ -956,6 +1126,15 @@ owl:thing rdf:type rdfs:Datatype .
                    rdfs:comment "Locations of excluded Via Points"@en ;
                    rdfs:label "excludedViaPoints"@en ;
                    owl:comment "Possible RDF good practice IRI: :hasExcludedViaPoint "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#executionStatus
+:executionStatus rdf:type owl:ObjectProperty ;
+                 rdfs:domain :LogisticsActivity ;
+                 rdfs:range :ExecutionStatus ;
+                 rdfs:comment "Enum stating the status of the Activity"@en ;
+                 rdfs:label "executionStatus"@en ;
+                 owl:comment "Possible RDF good practice IRI: :hasExecutionStatus "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#exportTradeCountry
@@ -1099,8 +1278,22 @@ owl:thing rdf:type rdfs:Datatype .
 :grossWeightForRate rdf:type owl:ObjectProperty ;
                     rdfs:domain :TACTRateDescription ;
                     rdfs:range :Value ;
-                    rdfs:comment "PENDING"@en ;
+                    rdfs:comment "Gross weight for which the rate description details apply"@en ;
                     rdfs:label "grossWeightForRate"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#groundsForExemption
+:groundsForExemption rdf:type owl:ObjectProperty ;
+                     rdfs:domain :SecurityDeclaration ;
+                     rdfs:range ccodes:ScreeningExemption ;
+                     rdfs:comment """Exemption code - e.g. BIOM- Bio-Medical Samples 
+SMUS - small undersized shipments MAIL - mail
+BIOM - bio-medical samples
+DIPL - diplomatic bags or diplomatic mail
+LFSM - life-saving materials NUCL - nuclear materials
+TRNS - transfer or transshipment"""@en ;
+                     rdfs:label "groundsForExemption"@en ;
+                     owl:comment "Possible RDF good practice IRI: :hasExemptionCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#handlingInstructions
@@ -1132,6 +1325,15 @@ owl:thing rdf:type rdfs:Datatype .
                owl:versionInfo "v1.1 renamed to containedWaybills"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#hsCode
+:hsCode rdf:type owl:ObjectProperty ;
+        rdfs:domain :Product ;
+        rdfs:range :CodeListElement ;
+        rdfs:comment "Harmonized Commodity code, refer to hsType used. 6 minimum digits are expected."@en ;
+        rdfs:label "hsCode"@en ;
+        owl:comment "Possible RDF good practice IRI: :hasHSCode "@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#identifier
 :identifier rdf:type owl:ObjectProperty ;
             rdfs:domain :RegulatedEntity ;
@@ -1140,7 +1342,7 @@ owl:thing rdf:type rdfs:Datatype .
             rdfs:label "identifier"@en ;
             owl:comment "Possible RDF good practice IRI: :hasRegulatedEntityIdentifier "@en ;
             owl:deprecated "true"@en ;
-            owl:versionInfo "v3.0 renamed from regulatedEntity:regulatedEntityIdentifier"@en .
+            owl:versionInfo "v3. renamed from regulatedEntity:regulatedEntityIdentifier"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#inUnitComposition
@@ -1167,7 +1369,7 @@ owl:thing rdf:type rdfs:Datatype .
                rdfs:comment "Insured amount - amount covered by the insurance policy"@en ;
                rdfs:label "insuredAmount"@en ;
                owl:comment "Possible RDF good practice IRI: :coversAmount "@en ;
-               owl:versionInfo "v3.0 renamed from insurance:insuranceAmount"@en .
+               owl:versionInfo "v3. renamed from insurance:insuranceAmount"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#insuredShipments
@@ -1177,7 +1379,7 @@ owl:thing rdf:type rdfs:Datatype .
                   rdfs:comment "Reference to the shipments insured"@en ;
                   rdfs:label "insuredShipments"@en ;
                   owl:comment "Possible RDF good practice IRI: :insuresShipment "@en ;
-                  owl:versionInfo "v3.0 renamed from insurance:insuranceShipment"@en .
+                  owl:versionInfo "v3. renamed from insurance:insuranceShipment"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#involvedInActions
@@ -1279,6 +1481,15 @@ owl:thing rdf:type rdfs:Datatype .
               owl:comment "Possible RDF good practice IRI: :isEventForObject "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#loadType
+:loadType rdf:type owl:ObjectProperty ;
+          rdfs:domain owl:Thing ;
+          rdfs:range :LoadType ;
+          rdfs:comment "Load type of the shipment or piece (Bulk, ULD, Pallet, Loose)"@en ;
+          rdfs:label "loadType"@en ;
+          owl:comment "Possible RDF good practice IRI: :hasLoadType "@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#loadedMaterials
 :loadedMaterials rdf:type owl:ObjectProperty ;
                  rdfs:domain :Loading ;
@@ -1323,6 +1534,24 @@ owl:thing rdf:type rdfs:Datatype .
                 rdfs:comment "References to all LoadingActions performed for the Loading Activity"@en ;
                 rdfs:label "loadingActions"@en ;
                 owl:comment "Possible RDF good practice IRI: :hasLoadingAction "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#loadingIndicator
+:loadingIndicator rdf:type owl:ObjectProperty ;
+                  rdfs:domain :LoadingUnit ;
+                  rdfs:range ccodes:ULDLoadingIndicator ;
+                  rdfs:comment "ULD height or loading limitation code. Refer CXML Code List 1.47,  e.g. R - ULD Height above 244 centimetres"@en ;
+                  rdfs:label "loadingIndicator"@en ;
+                  owl:comment "Possible RDF good practice IRI: :hasLoadingIndicator "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#loadingType
+:loadingType rdf:type owl:ObjectProperty ;
+             rdfs:domain :Loading ;
+             rdfs:range :LoadingType ;
+             rdfs:comment "Enum stating whether the LoadingAction describes onloading or offloading"@en ;
+             rdfs:label "loadingType"@en ;
+             owl:comment "Possible RDF good practice IRI: :isOfLoadingType "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#loadingUnit
@@ -1378,7 +1607,7 @@ owl:thing rdf:type rdfs:Datatype .
                     rdfs:label "measurementsGeoloc"@en ;
                     owl:comment "Possible RDF good practice IRI: :hasRecordedMeasurementGeoloc "@en ;
                     owl:deprecated "true"@en ;
-                    owl:versionInfo "v3.0 renamed from sensorGeoloc:val"@en .
+                    owl:versionInfo "v3. renamed from sensorGeoloc:val"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#measurementsOther
@@ -1389,7 +1618,34 @@ owl:thing rdf:type rdfs:Datatype .
                    rdfs:label "measurementsOther"@en ;
                    owl:comment "Possible RDF good practice IRI: :hasRecordedMeasurementOther "@en ;
                    owl:deprecated "true"@en ;
-                   owl:versionInfo "v3.0 renamed from sensorOther:val"@en .
+                   owl:versionInfo "v3. renamed from sensorOther:val"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#modeQualifier
+:modeQualifier rdf:type owl:ObjectProperty ;
+               rdfs:domain :TransportMovement ;
+               rdfs:range :ModeQualifier ;
+               rdfs:comment "Pre-Carriage, Main-Carriage or On-Carriage"@en ;
+               rdfs:label "modeQualifier"@en ;
+               owl:comment "Possible RDF good practice IRI: :hasModeQualifier "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#movementMilestone
+:movementMilestone rdf:type owl:ObjectProperty ;
+                   rdfs:domain :MovementTime ;
+                   rdfs:range ccodes:MovementIndicator ;
+                   rdfs:comment "The milestone list still needs to be defined, it includes elements from CXML Code List 1.92 but is not limited to those values, e.g. block-on and block-off times might be added as a comparison to wheels off and touchdown."@en ;
+                   rdfs:label "movementMilestone"@en ;
+                   owl:comment "Possible RDF good practice IRI: :hasMilestone "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#movementTimeType
+:movementTimeType rdf:type owl:ObjectProperty ;
+                  rdfs:domain :MovementTime ;
+                  rdfs:range :MovementTimeType ;
+                  rdfs:comment "The type of time can be Actual, Estimated ot Scheduled"@en ;
+                  rdfs:label "movementTimeType"@en ;
+                  owl:comment "Possible RDF good practice IRI: :isOfTimeType "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#movementTimes
@@ -1418,7 +1674,7 @@ owl:thing rdf:type rdfs:Datatype .
            rdfs:label "ofProduct"@en ;
            owl:comment "Possible RDF good practice IRI: :appliesToProduct "@en ;
            owl:deprecated "true"@en ;
-           owl:versionInfo "v3.0 renamed from characteristic:product"@en .
+           owl:versionInfo "v3. renamed from characteristic:product"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#onTransportMeans
@@ -1473,7 +1729,7 @@ owl:thing rdf:type rdfs:Datatype .
             rdfs:comment "Document originator details and contacts"@en ;
             rdfs:label "originator"@en ;
             owl:comment "Possible RDF good practice IRI: :hasOriginator "@en ;
-            owl:versionInfo "v3.0 renamed from externalReference:documentOriginator"@en .
+            owl:versionInfo "v3. renamed from externalReference:documentOriginator"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#otherCharacteristics
@@ -1483,15 +1739,24 @@ owl:thing rdf:type rdfs:Datatype .
                       rdfs:comment "Charateristics of the product"@en ;
                       rdfs:label "otherCharacteristics"@en ;
                       owl:comment "Possible RDF good practice IRI: :hasCharacteristic "@en ;
-                      owl:versionInfo "v3.0 renamed from product:characteristics"@en .
+                      owl:versionInfo "v3. renamed from product:characteristics"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#otherChargeAmount
 :otherChargeAmount rdf:type owl:ObjectProperty ;
                    rdfs:domain :OtherCharge ;
                    rdfs:range :Value ;
-                   rdfs:comment "PENDING"@en ;
+                   rdfs:comment "Other Charge amount"@en ;
                    rdfs:label "otherChargeAmount"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#otherChargeCode
+:otherChargeCode rdf:type owl:ObjectProperty ;
+                 rdfs:domain owl:Thing ;
+                 rdfs:range ccodes:OtherChargeCode ;
+                 rdfs:comment "Refer to CargoXML Code List 1.2 for Other Charges"@en ;
+                 rdfs:label "otherChargeCode" ;
+                 owl:comment "Possible RDF good practice IRI: :hasOtherChargeCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#otherCharges
@@ -1502,6 +1767,15 @@ owl:thing rdf:type rdfs:Datatype .
               rdfs:label "otherCharges"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#otherChargesIndicator
+:otherChargesIndicator rdf:type owl:ObjectProperty ;
+                       rdfs:domain :Waybill ;
+                       rdfs:range ccodes:PrepaidCollectIndicator ;
+                       rdfs:comment "Indicator whether the payment of Other Charges is to be made at origin (prepaid) or at destination (collect) as per bullet point 13 - data element 15a/15b from AWB"@en ;
+                       rdfs:label "otherChargesIndicator"@en ;
+                       owl:comment "Possible RDF good practice IRI: :isPrepaidOrCollect "@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#otherIdentifiers
 :otherIdentifiers rdf:type owl:ObjectProperty ;
                   rdfs:domain owl:Thing ;
@@ -1509,7 +1783,7 @@ owl:thing rdf:type rdfs:Datatype .
                   rdfs:comment "Details about any other identifier, depending on the context of use"@en ;
                   rdfs:label "otherIdentifiers" ;
                   owl:comment "Possible RDF good practice IRI: :hasOtherIdentifier "@en ;
-                  owl:versionInfo "v3.0 renamed from product:otherIdentifier"@en .
+                  owl:versionInfo "v3. renamed from product:otherIdentifier"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#otherMeasurement
@@ -1520,7 +1794,7 @@ owl:thing rdf:type rdfs:Datatype .
                   rdfs:label "otherMeasurement"@en ;
                   owl:comment "Possible RDF good practice IRI: :hasMeasurement "@en ;
                   owl:deprecated "true"@en ;
-                  owl:versionInfo "v3.0 renamed from measurementsOther:genericMeasurement"@en .
+                  owl:versionInfo "v3. renamed from measurementsOther:genericMeasurement"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#otherRegulatedEntities
@@ -1530,7 +1804,7 @@ owl:thing rdf:type rdfs:Datatype .
                         rdfs:comment "Any other regulated entity that accepts custody of the cargo and accepts the security status originally issued"@en ;
                         rdfs:label "otherRegulatedEntities"@en ;
                         owl:comment "Possible RDF good practice IRI: :hasOtherRegulatedEntity "@en ;
-                        owl:versionInfo "v3.0 renamed from securityDeclaration:otherRegulatedEntity"@en .
+                        owl:versionInfo "v3. renamed from securityDeclaration:otherRegulatedEntity"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#owningOrganization
@@ -1567,7 +1841,7 @@ owl:thing rdf:type rdfs:Datatype .
                  rdfs:comment "Reference to the IoT Device to which the sensor is linked"@en ;
                  rdfs:label "partOfIotDevice"@en ;
                  owl:comment "Possible RDF good practice IRI: :isPartOfIotDevice "@en ;
-                 owl:versionInfo "v3.0 renamed from sensor:iotDevice"@en .
+                 owl:versionInfo "v3. renamed from sensor:iotDevice"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#partOfShipment
@@ -1577,7 +1851,7 @@ owl:thing rdf:type rdfs:Datatype .
                 rdfs:comment "Shipment on which the piece is assigned to"@en ;
                 rdfs:label "partOfShipment"@en ;
                 owl:comment "Possible RDF good practice IRI: :isPartOfShipment "@en ;
-                owl:versionInfo "v3.0 renamed from piece:shipment"@en .
+                owl:versionInfo "v3. renamed from piece:shipment"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#partyDetails
@@ -1617,6 +1891,15 @@ owl:thing rdf:type rdfs:Datatype .
              owl:comment "Possible RDF good practice IRI: :isPerformedAt "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#postalCode
+:postalCode rdf:type owl:ObjectProperty ;
+            rdfs:domain :Address ;
+            rdfs:range :CodeListElement ;
+            rdfs:comment "Postal / ZIP code"@en ;
+            rdfs:label "postalCode"@en ;
+            owl:comment "Possible RDF good practice IRI: :hasPostalCode "@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#preferenceOfRequests
 :preferenceOfRequests rdf:type owl:ObjectProperty ;
                       rdfs:domain :Ratings ;
@@ -1642,6 +1925,15 @@ owl:thing rdf:type rdfs:Datatype .
        rdfs:comment "Price of the Booking (if different from the offer)"@en ;
        rdfs:label "price"@en ;
        owl:comment "Possible RDF good practice IRI: :hasPrice "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#productCode
+:productCode rdf:type owl:ObjectProperty ;
+             rdfs:domain :CarrierProduct ;
+             rdfs:range :CodeListElement ;
+             rdfs:comment "Carrier's product code"@en ;
+             rdfs:label "productCode"@en ;
+             owl:comment "Possible RDF good practice IRI: :hasProductCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#productionCountry
@@ -1684,16 +1976,42 @@ owl:thing rdf:type rdfs:Datatype .
 :rateCharge rdf:type owl:ObjectProperty ;
             rdfs:domain :TACTRateDescription ;
             rdfs:range :Value ;
-            rdfs:comment "PENDING"@en ;
+            rdfs:comment "TACT Rate for rate description details"@en ;
             rdfs:label "rateCharge"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#rateClassCode
+:rateClassCode rdf:type owl:ObjectProperty ;
+               rdfs:domain owl:Thing ;
+               rdfs:range ccodes:RateClassCode ;
+               rdfs:comment "Rate class code e.g. Q. Refer to CXML Code List 1.4 Rate Class Codes"@en ;
+               rdfs:label "rateClassCode"@en ;
+               owl:comment "Possible RDF good practice IRI: :hasRateClassCode "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#rateClassCodeBasic
+:rateClassCodeBasic rdf:type owl:ObjectProperty ;
+                    rdfs:domain :TACTRateDescription ;
+                    rdfs:range ccodes:BasicRateClassCode ;
+                    rdfs:comment "Rate Surcharge/Reduction - Basic Rate Class Code"@en ;
+                    rdfs:label "rateClassCodeBasic"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#ratePercentage
 :ratePercentage rdf:type owl:ObjectProperty ;
                 rdfs:domain :TACTRateDescription ;
                 rdfs:range :Value ;
-                rdfs:comment "PENDING"@en ;
+                rdfs:comment "Rate Surcharge/Reduction - Percebtage of  red. / surcharge"@en ;
                 rdfs:label "ratePercentage"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#ratingType
+:ratingType rdf:type owl:ObjectProperty ;
+            rdfs:domain :Ranges ;
+            rdfs:range ccodes:ULDChargeCode ;
+            rdfs:comment "rating type - Refer to CXML Code List 1.44 ULD Charge Codes"@en ;
+            rdfs:label "ratingType"@en ;
+            owl:comment "Possible RDF good practice IRI: :hasRatingType "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#ratings
@@ -1766,7 +2084,13 @@ owl:thing rdf:type rdfs:Datatype .
                        rdfs:comment "Refers to the Booking"@en ;
                        rdfs:label "referredBookingOption"@en ;
                        owl:comment "Possible RDF good practice IRI: :refersToBookingOption "@en ;
-                       owl:versionInfo "v3.0 renamed from waybill:booking"@en .
+                       owl:versionInfo "v3. renamed from waybill:booking"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#regulatedEntityCategory
+:regulatedEntityCategory rdf:type owl:ObjectProperty ;
+                         rdfs:domain :RegulatedEntity ;
+                         rdfs:range ccodes:RegulatedEntityCategoryCode .
 
 
 ###  https://onerecord.iata.org/ns/cargo#regulatedEntityIssuer
@@ -1813,6 +2137,16 @@ owl:thing rdf:type rdfs:Datatype .
              owl:comment "Possible RDF good practice IRI: :hasResultValue "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#role
+:role rdf:type owl:ObjectProperty ;
+      rdfs:domain :Party ;
+      rdfs:range ccodes:ParticipantIdentifier ;
+      rdfs:comment "Role fo the Company in the context. Can refer to Code List 1.36 in the CXML Toolkit"@en ;
+      rdfs:label "role"@en ;
+      owl:comment "Possible RDF good practice IRI: :hasRole "@en ;
+      owl:versionInfo "v3. renamed from party:partyRole"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#routing
 :routing rdf:type owl:ObjectProperty ;
          rdfs:domain :BookingOption ;
@@ -1829,7 +2163,7 @@ owl:thing rdf:type rdfs:Datatype .
                    rdfs:comment "Routing details that are part of the request, these details will be used to determine if the offer is a perfect match"@en ;
                    rdfs:label "routingPreference"@en ;
                    owl:comment "Possible RDF good practice IRI: :hasRoutingPreference "@en ;
-                   owl:versionInfo "v3.0 renamed from :hasRoutingPreferences" .
+                   owl:versionInfo "v3. renamed from :hasRoutingPreferences" .
 
 
 ###  https://onerecord.iata.org/ns/cargo#scheduledLegs
@@ -1841,6 +2175,24 @@ owl:thing rdf:type rdfs:Datatype .
                owl:comment "Possible RDF good practice IRI: :hasScheduledLegs "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#screeningMethods
+:screeningMethods rdf:type owl:ObjectProperty ;
+                  rdfs:domain :SecurityDeclaration ;
+                  rdfs:range ccodes:ScreeningMethod ;
+                  rdfs:comment """Screening methods which have been used to secure the cargo
+PHS – Physical Inspection and/or hand search 
+VCK - Visual check 
+XRY- X-ray equipment 
+EDS - Explosive detection system 
+EDD - Explosive detection dogs
+ETD - Explosive trace detection equipment - particles or vapor 
+CMD - Cargo metal detection
+AOM - Subjected to any other means: this entry should be followed by free text specifying what other mean was used to secure the cargo"""@en ;
+                  rdfs:label "screeningMethods"@en ;
+                  owl:comment "Possible RDF good practice IRI: :hasScreeningMethods "@en ;
+                  owl:versionInfo "v3. renamed from securityDeclaration:screeningMethod"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#securityDeclaration
 :securityDeclaration rdf:type owl:ObjectProperty ;
                      rdfs:domain :Piece ;
@@ -1849,6 +2201,24 @@ owl:thing rdf:type rdfs:Datatype .
                      rdfs:label "securityDeclaration"@en ;
                      owl:comment "Possible RDF good practice IRI: :hasSecurityDetails "@en ;
                      owl:versionInfo "Added on v1.1"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#securityStatus
+:securityStatus rdf:type owl:ObjectProperty ;
+                rdfs:domain :SecurityDeclaration ;
+                rdfs:range ccodes:SecurityStatus ;
+                rdfs:comment "Security status indicator (CXML 1.13) - e.g. SPX- Cargo Secure for Passenger and All-Cargo Aircraft "@en ;
+                rdfs:label "securityStatus"@en ;
+                owl:comment "Possible RDF good practice IRI: :hasSecurityStatus "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#sensorType
+:sensorType rdf:type owl:ObjectProperty ;
+            rdfs:domain :Sensor ;
+            rdfs:range :SensorType ;
+            rdfs:comment "Type of sensor as described in Interactive Cargo Recommended Practice"@en ;
+            rdfs:label "sensorType"@en ;
+            owl:comment "Possible RDF good practice IRI: :isOfSensorType "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#servedActivity
@@ -1869,6 +2239,14 @@ owl:thing rdf:type rdfs:Datatype .
                 owl:comment "Possible RDF good practice IRI: :isPartOfService "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#serviceCode
+:serviceCode rdf:type owl:ObjectProperty ;
+             rdfs:domain :Waybill ;
+             rdfs:range ccodes:ServiceCode ;
+             rdfs:comment "One letter service code as per bullet point 18.4 - data element 22Z from AWB"@en ;
+             rdfs:label "serviceCode"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#serviceRequest
 :serviceRequest rdf:type owl:ObjectProperty ;
                 rdfs:domain :Piece ;
@@ -1876,6 +2254,15 @@ owl:thing rdf:type rdfs:Datatype .
                 rdfs:label "serviceRequest"@en ;
                 owl:comment "Possible RDF good practice IRI: :hasServiceRequest "@en ;
                 owl:deprecated "true"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#serviceabilityCode
+:serviceabilityCode rdf:type owl:ObjectProperty ;
+                    rdfs:domain :LoadingUnit ;
+                    rdfs:range ccodes:ULDConditionCode ;
+                    rdfs:comment "Designator of serviceablity condition e.g. SER or DAM "@en ;
+                    rdfs:label "serviceabilityCode"@en ;
+                    owl:comment "Possible RDF good practice IRI: :hasServiceabilityCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#shipment
@@ -1904,6 +2291,15 @@ owl:thing rdf:type rdfs:Datatype .
                   rdfs:label "shipmentOfPieces"@en ;
                   owl:comment "Possible RDF good practice IRI: :isShipmentOfPiece "@en ;
                   owl:versionInfo "1.2 renamed to containedPieces"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#shipmentSecurityStatus
+:shipmentSecurityStatus rdf:type owl:ObjectProperty ;
+                        rdfs:domain owl:Thing ;
+                        rdfs:range ccodes:ShipmentSecurityStatus ;
+                        rdfs:comment "Indicate the secruty state of the shipment, screened or not"@en ;
+                        rdfs:label "shipmentSecurityStatus"@en ;
+                        owl:comment "Possible RDF good practice IRI: :hasShipmentSecurityStatus "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#shipper
@@ -1943,6 +2339,14 @@ owl:thing rdf:type rdfs:Datatype .
                  owl:deprecated "true"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#specialHandlingCodes
+:specialHandlingCodes rdf:type owl:ObjectProperty ;
+                      rdfs:domain :Piece ;
+                      rdfs:range ccodes:SpecialHandlingCode ;
+                      rdfs:comment "Three-letter special handling code (SPH)"@en ;
+                      rdfs:label "specialHandlingCodes"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#storedObjects
 :storedObjects rdf:type owl:ObjectProperty ;
                rdfs:domain :Storing ;
@@ -1959,6 +2363,15 @@ owl:thing rdf:type rdfs:Datatype .
                 rdfs:comment "References to all StoringActions performed for the Storing Activity"@en ;
                 rdfs:label "storingActions"@en ;
                 owl:comment "Possible RDF good practice IRI: :hasStoringActions "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#storingType
+:storingType rdf:type owl:ObjectProperty ;
+             rdfs:domain :Storing ;
+             rdfs:range :StoringType ;
+             rdfs:comment "Enum stating whether the StoringAction describes the store-in or the store-out"@en ;
+             rdfs:label "storingType"@en ;
+             owl:comment "Possible RDF good practice IRI: :isOfStoringType "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#subLocationOf
@@ -1984,6 +2397,17 @@ owl:thing rdf:type rdfs:Datatype .
                  rdfs:comment "References to all sub-Organizations"@en ;
                  rdfs:label "subOrganization"@en ;
                  owl:comment "Possible RDF good practice IRI: :hasSubOrganization "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#subjectCode
+:subjectCode rdf:type owl:ObjectProperty ;
+             rdfs:domain :CustomsInformation ;
+             rdfs:range :CodeListElement ;
+             rdfs:comment """Information Identifier. Code identifying a piece of information/entity e.g. \"IMP\" for import, \"EXP\" for export, \"AGT\" for Agent, \"ISS\" for The Regulated Agent Issuing the Security Status for a Consignment etc. 
+Condition: At least one of the three elements (Country Code, Information Identifier or Customs, Security and Regulatory Control Information Identifier) must be completed"""@en ;
+             rdfs:label "subjectCode"@en ;
+             owl:comment "Possible RDF good practice IRI: :hasSubjectCode "@en ;
+             owl:versionInfo "v3. renamed from customsInformation:customsInfoSubjectCode"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#tactRateDescriptions
@@ -2043,7 +2467,7 @@ owl:thing rdf:type rdfs:Datatype .
 :total rdf:type owl:ObjectProperty ;
        rdfs:domain :TACTRateDescription ;
        rdfs:range :Value ;
-       rdfs:comment "PENDING"@en ;
+       rdfs:comment "Charge total for rate description details"@en ;
        rdfs:label "total"@en .
 
 
@@ -2051,7 +2475,7 @@ owl:thing rdf:type rdfs:Datatype .
 :totalCollectCharges rdf:type owl:ObjectProperty ;
                      rdfs:domain :TotalCharge ;
                      rdfs:range :Value ;
-                     rdfs:comment "PENDING" ;
+                     rdfs:comment "Total collect charges in destination currency"@en ;
                      rdfs:label "totalCollectCharges"@en .
 
 
@@ -2142,7 +2566,7 @@ owl:thing rdf:type rdfs:Datatype .
 :typicalFuelConsumption rdf:type owl:ObjectProperty ;
                         rdfs:domain :TransportMeans ;
                         rdfs:range :Value ;
-                        rdfs:comment "Typical fuel comsumption (e.g. 20 000L / 1 000nm)"@en ;
+                        rdfs:comment "Typical fuel comsumption (e.g. 2 L / 1 nm)"@en ;
                         rdfs:label "typicalFuelConsumption"@en ;
                         owl:comment "Possible RDF good practice IRI: :hasFuelConsumption "@en .
 
@@ -2220,6 +2644,15 @@ owl:thing rdf:type rdfs:Datatype .
          owl:versionInfo "v2.1.1 renamed from :hasWaybillNumber"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#waybillType
+:waybillType rdf:type owl:ObjectProperty ;
+             rdfs:domain :Waybill ;
+             rdfs:range :WaybillType ;
+             rdfs:comment "Type of the Waybill: House, Direct or Master"@en ;
+             rdfs:label "waybillType"@en ;
+             owl:comment "Possible RDF good practice IRI: :isOfWaybillType "@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#weight
 :weight rdf:type owl:ObjectProperty ;
         rdfs:domain :Item ;
@@ -2227,6 +2660,15 @@ owl:thing rdf:type rdfs:Datatype .
         rdfs:comment "Weight of the item"@en ;
         rdfs:label "weight"@en ;
         owl:comment "Possible RDF good practice IRI: :hasWeight "@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#weightValuationIndicator
+:weightValuationIndicator rdf:type owl:ObjectProperty ;
+                          rdfs:domain :Waybill ;
+                          rdfs:range ccodes:PrepaidCollectIndicator ;
+                          rdfs:comment "Indicator whether the payment for the Weight/Valuation is to be made at origin (prepaid) or at destination (collect) as per bullet point 13 - data element 14a/14b from AWB"@en ;
+                          rdfs:label "weightValuationIndicator"@en ;
+                          owl:comment "Possible RDF good practice IRI: :hasWeightValuation "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#width
@@ -2241,6 +2683,14 @@ owl:thing rdf:type rdfs:Datatype .
 #################################################################
 #    Data properties
 #################################################################
+
+###  https://onerecord.iata.org/ns/cargo#CodeListReference
+:CodeListReference rdf:type owl:DatatypeProperty ;
+                   rdfs:domain :CodeListElement ;
+                   rdfs:range xsd:string ;
+                   rdfs:comment "URL to access the code list the code is taken from, for example \"https://unece.org/trade/cefact/unlocode-code-list-country-and-territory\" for UN/LOCODE."@en ;
+                   rdfs:label "codeListReference"@en .
+
 
 ###  https://onerecord.iata.org/ns/cargo#accountingInformation
 :accountingInformation rdf:type owl:DatatypeProperty ;
@@ -2259,7 +2709,7 @@ owl:thing rdf:type rdfs:Datatype .
                      rdfs:comment "Defined in Resolution Conf. 13.6 and is required for pre-Convention specimens (box 12b)"@en ;
                      rdfs:label "acquisitionDateTime"@en ;
                      owl:comment "Possible RDF good practice IRI: :hasAcquisitionDateTime "@en ;
-                     owl:versionInfo "v3.0 renamed from pieceLiveAnimals:acquisitionDatetime"@en .
+                     owl:versionInfo "v3. renamed from pieceLiveAnimals:acquisitionDatetime"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#actionEndTime
@@ -2280,35 +2730,6 @@ owl:thing rdf:type rdfs:Datatype .
                  owl:comment "Possible RDF good practice IRI: :hasActionStartTime "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#actionTimeType
-:actionTimeType rdf:type owl:DatatypeProperty ;
-                rdfs:domain :LogisticsAction ;
-                rdfs:range [ rdf:type rdfs:Datatype ;
-                             owl:oneOf [ rdf:type rdf:List ;
-                                         rdf:first "Actual" ;
-                                         rdf:rest [ rdf:type rdf:List ;
-                                                    rdf:first "Estimated" ;
-                                                    rdf:rest [ rdf:type rdf:List ;
-                                                               rdf:first "Expected" ;
-                                                               rdf:rest [ rdf:type rdf:List ;
-                                                                          rdf:first "Planned" ;
-                                                                          rdf:rest [ rdf:type rdf:List ;
-                                                                                     rdf:first "Requested" ;
-                                                                                     rdf:rest [ rdf:type rdf:List ;
-                                                                                                rdf:first "Scheduled" ;
-                                                                                                rdf:rest rdf:nil
-                                                                                              ]
-                                                                                   ]
-                                                                        ]
-                                                             ]
-                                                  ]
-                                       ]
-                           ] ;
-                rdfs:comment "Enum stating the type of the Action"@en ;
-                rdfs:label "actionTimeType"@en ;
-                owl:comment "Possible RDF good practice IRI: :isOfActionTimeType "@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#activityLevelMeasure
 :activityLevelMeasure rdf:type owl:DatatypeProperty ;
                       rdfs:domain :DgRadioactiveIsotope ;
@@ -2322,7 +2743,7 @@ owl:thing rdf:type rdfs:Datatype .
 :additionalHazardClassificationId rdf:type owl:DatatypeProperty ;
                                   rdfs:domain :ProductDg ;
                                   rdfs:range xsd:string ;
-                                  rdfs:comment "Identifies the subsidiary hazard class / division identification containing a numeric field separated by a decimal. There may be 0, 1 or 2 subsidiary risk classes or divisions. If there is more than one, each should be separated by a comma. The subsidiary risk must be shown in parentheses. "@en ;
+                                  rdfs:comment "Identifies the subsidiary hazard class / division identification containing a numeric field separated by a decimal. There may be , 1 or 2 subsidiary risk classes or divisions. If there is more than one, each should be separated by a comma. The subsidiary risk must be shown in parentheses. "@en ;
                                   rdfs:label "additionalHazardClassificationId"@en ;
                                   owl:comment "Possible RDF good practice IRI: :hasAdditionalHazardClassificationIdentifier "@en .
 
@@ -2336,24 +2757,6 @@ owl:thing rdf:type rdfs:Datatype .
                                owl:comment "Possible RDF good practice IRI: :hasAdditionalSecurityInformation "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#addressCode
-:addressCode rdf:type owl:DatatypeProperty ;
-             rdfs:domain :Address ;
-             rdfs:range xsd:string ;
-             rdfs:comment "Address identifier using special coding systems e.g. US CBP FIRMS code"@en ;
-             rdfs:label "addressCode"@en ;
-             owl:comment "Possible RDF good practice IRI: :hasAddressCode "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#addressCodeType
-:addressCodeType rdf:type owl:DatatypeProperty ;
-                 rdfs:domain :Address ;
-                 rdfs:range xsd:string ;
-                 rdfs:comment "Type of address code e.g. US CBP FIRMS"@en ;
-                 rdfs:label "addressCodeType"@en ;
-                 owl:comment "Possible RDF good practice IRI: :hasAddressCodeType "@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#aircraftLimitationInformation
 :aircraftLimitationInformation rdf:type owl:DatatypeProperty ;
                                rdfs:domain :DgDeclaration ;
@@ -2361,15 +2764,6 @@ owl:thing rdf:type rdfs:Datatype .
                                rdfs:comment "Contains the Special Handling Code related to the prescribed limitation. Hardcoded to PASSENGER AND CARGO AIRCRAFT or CARGO AIRCRAFT ONLY. This field is mandatory for air (Air) "@en ;
                                rdfs:label "aircraftLimitationInformation"@en ;
                                owl:comment "Possible RDF good practice IRI: :hasAircraftLimitationInformation "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#aircraftPossibilityCode
-:aircraftPossibilityCode rdf:type owl:DatatypeProperty ;
-                         rdfs:domain :Routing ;
-                         rdfs:range xsd:string ;
-                         rdfs:comment "Aircraft possibility code - Refers to CXML Code List 1.46 that contains values such as \"Pure freighter flight carrying Loose Load Cargo - BBF\""@en ;
-                         rdfs:label "aircraftPossibilityCode"@en ;
-                         owl:comment "Possible RDF good practice IRI: :hasAircraftPossibilityCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#airlineCode
@@ -2533,15 +2927,6 @@ owl:thing rdf:type rdfs:Datatype .
              owl:comment "Possible RDF good practice IRI: :hasBatchNumber "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#billingChargeIdentifier
-:billingChargeIdentifier rdf:type owl:DatatypeProperty ;
-                         rdfs:domain :Ratings ;
-                         rdfs:range xsd:string ;
-                         rdfs:comment "Billing charge identifiers to be used for CASS. Refer to CargoXML Code List 1.33"@en ;
-                         rdfs:label "billingChargeIdentifier"@en ;
-                         owl:comment "Possible RDF good practice IRI: :hasBillingChargeIdentifier "@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#bookingOptionStatus
 :bookingOptionStatus rdf:type owl:DatatypeProperty ;
                      rdfs:domain :BookingOption ;
@@ -2559,16 +2944,6 @@ owl:thing rdf:type rdfs:Datatype .
             rdfs:label "branchName"@en ;
             owl:comment "Possible RDF good practice IRI: :hasBranchName "@en ;
             owl:deprecated "true"@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#carrierChargeCode
-:carrierChargeCode rdf:type owl:DatatypeProperty ;
-                   rdfs:domain owl:Thing ;
-                   rdfs:range xsd:string ;
-                   rdfs:comment "Charge code for carrier, eg. CA, CB, etc"@en ;
-                   rdfs:label "carrierChargeCode"@en ;
-                   owl:comment "Possible RDF good practice IRI: :hasCarrierChargeCode "@en ;
-                   owl:versionInfo "v1.01 - changed comment to avoid non-unicode characters" .
 
 
 ###  https://onerecord.iata.org/ns/cargo#carrierDeclarationDate
@@ -2609,30 +2984,6 @@ owl:thing rdf:type rdfs:Datatype .
                   owl:deprecated "true"@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#category
-:category rdf:type owl:DatatypeProperty ;
-          rdfs:domain :RegulatedEntity ;
-          rdfs:range [ rdf:type rdfs:Datatype ;
-                       owl:oneOf [ rdf:type rdf:List ;
-                                   rdf:first "AO" ;
-                                   rdf:rest [ rdf:type rdf:List ;
-                                              rdf:first "KC" ;
-                                              rdf:rest [ rdf:type rdf:List ;
-                                                         rdf:first "RA" ;
-                                                         rdf:rest [ rdf:type rdf:List ;
-                                                                    rdf:first "RC" ;
-                                                                    rdf:rest rdf:nil
-                                                                  ]
-                                                       ]
-                                            ]
-                                 ]
-                     ] ;
-          rdfs:comment "Party type, should be one of the following RA - Regulated Agent, KC - Known Consignor, AO - Aircraft Operator, RC - Regulated Carrier"@en ;
-          rdfs:label "category"@en ;
-          owl:comment "Possible RDF good practice IRI: :isOfRegulatedAgentCategory "@en ;
-          owl:versionInfo "v3.0 renamed from regulatedEntity:regulatedEntityCategory"@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#categoryCode
 :categoryCode rdf:type owl:DatatypeProperty ;
               rdfs:domain :PieceLiveAnimals ;
@@ -2649,16 +3000,7 @@ owl:thing rdf:type rdfs:Datatype .
                     rdfs:comment "Product characteristics code - e.g. CLR - Color. Not restricted to a list."@en ;
                     rdfs:label "characteristicType"@en ;
                     owl:comment "Possible RDF good practice IRI: :isOfCharacteristicType "@en ;
-                    owl:versionInfo "v3.0 renamed from characteristic:characteristicsType"@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#chargeCode
-:chargeCode rdf:type owl:DatatypeProperty ;
-            rdfs:domain :Ratings ;
-            rdfs:range xsd:string ;
-            rdfs:comment "Charge code, refer to CargoXML Code List 1.1"@en ;
-            rdfs:label "chargeCode"@en ;
-            owl:comment "Possible RDF good practice IRI: :hasChargeCode "@en .
+                    owl:versionInfo "v3. renamed from characteristic:characteristicsType"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#chargeDescription
@@ -2668,32 +3010,6 @@ owl:thing rdf:type rdfs:Datatype .
                    rdfs:comment "Description of the charge e.g. Airfreight, fuel, etc."@en ;
                    rdfs:label "chargeDescription"@en ;
                    owl:comment "Possible RDF good practice IRI: :hasChargeDescription "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#chargePaymentType
-:chargePaymentType rdf:type owl:DatatypeProperty ;
-                   rdfs:domain owl:Thing ;
-                   rdfs:range [ rdf:type rdfs:Datatype ;
-                                owl:oneOf [ rdf:type rdf:List ;
-                                            rdf:first "C" ;
-                                            rdf:rest [ rdf:type rdf:List ;
-                                                       rdf:first "P" ;
-                                                       rdf:rest rdf:nil
-                                                     ]
-                                          ]
-                              ] ;
-                   rdfs:comment "Indicates if charge is prepaid or collect (P, C)"@en ;
-                   rdfs:label "chargePaymentType"@en ;
-                   owl:comment "Possible RDF good practice IRI: :hasChargePaymentType "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#chargeType
-:chargeType rdf:type owl:DatatypeProperty ;
-            rdfs:domain owl:Thing ;
-            rdfs:range xsd:string ;
-            rdfs:comment "Type of charge that should match the code expressed in either chargeCode, otherChargeCode or billingChargeIndentifier data properties."@en ;
-            rdfs:label "chargeType"@en ;
-            owl:comment "Possible RDF good practice IRI: :hasChargeType "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#checkRemark
@@ -2712,7 +3028,7 @@ owl:thing rdf:type rdfs:Datatype .
           rdfs:comment "Checksum of the document to validate its integrity"@en ;
           rdfs:label "checksum"@en ;
           owl:comment "Possible RDF good practice IRI: :hasChecksum "@en ;
-          owl:versionInfo "v3.0 renamed from externalReference:documentChecksum"@en .
+          owl:versionInfo "v3. renamed from externalReference:documentChecksum"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#cityCode
@@ -2735,11 +3051,42 @@ owl:thing rdf:type rdfs:Datatype .
 
 ###  https://onerecord.iata.org/ns/cargo#code
 :code rdf:type owl:DatatypeProperty ;
-      rdfs:domain :Location ;
+      rdfs:domain :CodeListElement ;
       rdfs:range xsd:string ;
-      rdfs:comment "Location code of airport, freight terminal, seaport, rail station. UN/LOCODE city code (5 letter) or IATA airport code (3 letter)"@en ;
-      rdfs:label "code"@en ;
-      owl:comment "Possible RDF good practice IRI: :hasLocationCode "@en .
+      rdfs:comment "Code or short version of a code, for example \"CH\" for Switzerland when referring to the UN/LOCODE code list"@en ;
+      rdfs:label "code" .
+
+
+###  https://onerecord.iata.org/ns/cargo#codeDescription
+:codeDescription rdf:type owl:DatatypeProperty ;
+                 rdfs:domain :CodeListElement ;
+                 rdfs:range xsd:string ;
+                 rdfs:comment "Description or long version of the code, for example \"Switzerland\" for Switzerland when referring to the UN/LOCODE code list"@en ;
+                 rdfs:label "codeDescription"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#codeLevel
+:codeLevel rdf:type owl:DatatypeProperty ;
+           rdfs:domain :CodeListElement ;
+           rdfs:range xsd:integer ;
+           rdfs:comment "Integer indicating the level of a code if a codelists is hierarchical, for example HS-Codes"@en ;
+           rdfs:label "codeLevel"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#codeListName
+:codeListName rdf:type owl:DatatypeProperty ;
+              rdfs:domain :CodeListElement ;
+              rdfs:range xsd:string ;
+              rdfs:comment "Official name of the code list without version number when direct reference is not possible, for example \"UN/LOCODE\" when referring to the UN/LOCODE code list"@en ;
+              rdfs:label "codeListName"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#codeListVersion
+:codeListVersion rdf:type owl:DatatypeProperty ;
+                 rdfs:domain :CodeListElement ;
+                 rdfs:range xsd:string ;
+                 rdfs:comment "Version of the code list, for example \"223-1\" for UN/LOCODE. Used if the property codeListName is used or the version is not apparent from the resource referred to in property codeListReference."@en ;
+                 rdfs:label "codeListVersion"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#coload
@@ -2825,23 +3172,6 @@ owl:thing rdf:type rdfs:Datatype .
                        owl:comment "Possible RDF good practice IRI: :hasCompositionIdentifier "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#compositionType
-:compositionType rdf:type owl:DatatypeProperty ;
-                 rdfs:domain :Composing ;
-                 rdfs:range [ rdf:type rdfs:Datatype ;
-                              owl:oneOf [ rdf:type rdf:List ;
-                                          rdf:first "BreakDown" ;
-                                          rdf:rest [ rdf:type rdf:List ;
-                                                     rdf:first "BuildUp" ;
-                                                     rdf:rest rdf:nil
-                                                   ]
-                                        ]
-                            ] ;
-                 rdfs:comment "Enum stating whether the CompositionAction describes build-up or break-down"@en ;
-                 rdfs:label "compositionType"@en ;
-                 owl:comment "Possible RDF good practice IRI: :isOfCompositionType "@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#consignorDeclarationSignature
 :consignorDeclarationSignature rdf:type owl:DatatypeProperty ;
                                rdfs:domain :Waybill ;
@@ -2851,77 +3181,6 @@ owl:thing rdf:type rdfs:Datatype .
                                owl:comment "Possible RDF good practice IRI: :hasConsignorDeclarationSignature "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#contactDetailType
-:contactDetailType rdf:type owl:DatatypeProperty ;
-                   rdfs:domain :ContactDetail ;
-                   rdfs:range [ rdf:type rdfs:Datatype ;
-                                owl:oneOf [ rdf:type rdf:List ;
-                                            rdf:first "Alternate email address" ;
-                                            rdf:rest [ rdf:type rdf:List ;
-                                                       rdf:first "Alternate phone number" ;
-                                                       rdf:rest [ rdf:type rdf:List ;
-                                                                  rdf:first "Email address" ;
-                                                                  rdf:rest [ rdf:type rdf:List ;
-                                                                             rdf:first "Fax number" ;
-                                                                             rdf:rest [ rdf:type rdf:List ;
-                                                                                        rdf:first "Other" ;
-                                                                                        rdf:rest [ rdf:type rdf:List ;
-                                                                                                   rdf:first "Phone number" ;
-                                                                                                   rdf:rest [ rdf:type rdf:List ;
-                                                                                                              rdf:first "Telex" ;
-                                                                                                              rdf:rest [ rdf:type rdf:List ;
-                                                                                                                         rdf:first "Website" ;
-                                                                                                                         rdf:rest rdf:nil
-                                                                                                                       ]
-                                                                                                            ]
-                                                                                                 ]
-                                                                                      ]
-                                                                           ]
-                                                                ]
-                                                     ]
-                                          ]
-                              ] ;
-                   rdfs:comment "Type of the contact details, e.g. Phone number, Mail address"@en ;
-                   rdfs:label "contactDetailType"@en ;
-                   owl:comment "Possible RDF good practice IRI: :isOfContactDetailType "@en ;
-                   owl:versionInfo "Added on v1.1"@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#contactRole
-:contactRole rdf:type owl:DatatypeProperty ;
-             rdfs:domain :Person ;
-             rdfs:range [ rdf:type rdfs:Datatype ;
-                          owl:oneOf [ rdf:type rdf:List ;
-                                      rdf:first "Customer contact" ;
-                                      rdf:rest [ rdf:type rdf:List ;
-                                                 rdf:first "Customs contact" ;
-                                                 rdf:rest [ rdf:type rdf:List ;
-                                                            rdf:first "Emergency contact" ;
-                                                            rdf:rest [ rdf:type rdf:List ;
-                                                                       rdf:first "Other" ;
-                                                                       rdf:rest rdf:nil
-                                                                     ]
-                                                          ]
-                                               ]
-                                    ]
-                        ] ;
-             rdfs:comment "Contact type - e.g. Emergency contact, Customs contact, Customer contact"@en ;
-             rdfs:label "contactRole"@en ;
-             owl:comment "Possible RDF good practice IRI: :hasContactRole "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#contentCode
-:contentCode rdf:type owl:DatatypeProperty ;
-             rdfs:domain :CustomsInformation ;
-             rdfs:range xsd:string ;
-             rdfs:comment """Customs, Security and Regulatory Control Information Identifier. Coded indicator qualifying Customs related information: Item Number \"I\", Exemption Legend \"L\", System Downtime Reference \"S\", Unique Consignment Reference Number \"U\", Movement Reference Number \"M\" .
-Refers to Code List 1.100
-Condition: At least one of the three elements (Country Code, Information Identifier or Customs, Security and Regulatory Control Information Identifier) must be completed"""@en ;
-             rdfs:label "contentCode"@en ;
-             owl:comment "Possible RDF good practice IRI: :hasContentCode "@en ;
-             owl:versionInfo "v3.0 renamed from customsInformation:customsInfoContentCode"@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#copyIndicator
 :copyIndicator rdf:type owl:DatatypeProperty ;
                rdfs:domain :LiveAnimalsEpermit ;
@@ -2929,7 +3188,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
                rdfs:comment "Indicates if the permit is a copy (true) or an original (false) (box 1)"@en ;
                rdfs:label "copyIndicator"@en ;
                owl:comment "Possible RDF good practice IRI: :hasCopyIndicator "@en ;
-               owl:versionInfo "v3.0 renamed from liveAnimalsEpermit:permitCopyIndicator"@en .
+               owl:versionInfo "v3. renamed from liveAnimalsEpermit:permitCopyIndicator"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#correctionNumber
@@ -2957,7 +3216,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
              rdfs:comment "Country ISO code. Refer ISO 3166-2. At least one of the three elements (Country Code, Information Identifier or Customs, Security and Regulatory Control Information Identifier) must be completed"@en ;
              rdfs:label "countryCode"@en ;
              owl:comment "Possible RDF good practice IRI: :hasCountryCode "@en ;
-             owl:versionInfo "v3.0 renamed from customsInformation:customsInfoCountryCode"@en .
+             owl:versionInfo "v3. renamed from customsInformation:customsInfoCountryCode"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#countryName
@@ -3095,7 +3354,7 @@ List to be provided by local authorities"""@en ;
              rdfs:comment "Commercial denomination of the device"@en ;
              rdfs:label "deviceModel"@en ;
              owl:comment "Possible RDF good practice IRI: :isOfDeviceModel "@en ;
-             owl:versionInfo "v3.0 renamed from iotDevice:deviceModel"@en .
+             owl:versionInfo "v3. renamed from iotDevice:deviceModel"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#dgRaTypeCode
@@ -3118,26 +3377,6 @@ List to be provided by local authorities"""@en ;
               owl:comment "Possible RDF good practice IRI: :hasDgRaTypeCode "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#direction
-:direction rdf:type owl:DatatypeProperty ;
-           rdfs:domain :MovementTime ;
-           rdfs:range [ rdf:type rdfs:Datatype ;
-                        owl:oneOf [ rdf:type rdf:List ;
-                                    rdf:first "Inbound" ;
-                                    rdf:rest [ rdf:type rdf:List ;
-                                               rdf:first "Outbound" ;
-                                               rdf:rest [ rdf:type rdf:List ;
-                                                          rdf:first "UnplannedStop" ;
-                                                          rdf:rest rdf:nil
-                                                        ]
-                                             ]
-                                  ]
-                      ] ;
-           rdfs:comment "Direction to indicate if it's Inbound or Outbound"@en ;
-           rdfs:label "direction"@en ;
-           owl:comment "Possible RDF good practice IRI: :hasDirection "@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#discount
 :discount rdf:type owl:DatatypeProperty ;
           rdfs:domain :BillingDetails ;
@@ -3154,7 +3393,7 @@ List to be provided by local authorities"""@en ;
                     rdfs:comment "Unique document identifier"@en ;
                     rdfs:label "documentIdentifier"@en ;
                     owl:comment "Possible RDF good practice IRI: :hasDocumentIdentifier "@en ;
-                    owl:versionInfo "v3.0 renamed from externalReference:documentId"@en .
+                    owl:versionInfo "v3. renamed from externalReference:documentId"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#documentLink
@@ -3164,7 +3403,7 @@ List to be provided by local authorities"""@en ;
               rdfs:comment "Link to the document, e.g. URL of the file where it is hosted"@en ;
               rdfs:label "documentLink"@en ;
               owl:comment "Possible RDF good practice IRI: :hasDocumentLink "@en ;
-              owl:versionInfo "v3.0 renamed from :hasDocumentLink"@en .
+              owl:versionInfo "v3. renamed from :hasDocumentLink"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#documentName
@@ -3180,7 +3419,7 @@ List to be provided by local authorities"""@en ;
 :documentType rdf:type owl:DatatypeProperty ;
               rdfs:domain :ExternalReference ;
               rdfs:range xsd:string ;
-              rdfs:comment "Type of the referenced document . Can refer UNEDIFACT 1001  e.g. 740 - Air Waybill, but not limited to"@en ;
+              rdfs:comment "Type of the referenced document . Can refer UNEDIFACT 11  e.g. 74 - Air Waybill, but not limited to"@en ;
               rdfs:label "documentType"@en ;
               owl:comment "Possible RDF good practice IRI: :isOfDocumentType "@en .
 
@@ -3212,23 +3451,6 @@ List to be provided by local authorities"""@en ;
             owl:comment "Possible RDF good practice IRI: :hasEmployeeIdentifier "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#entitlement
-:entitlement rdf:type owl:DatatypeProperty ;
-             rdfs:domain owl:Thing ;
-             rdfs:range [ rdf:type rdfs:Datatype ;
-                          owl:oneOf [ rdf:type rdf:List ;
-                                      rdf:first "A" ;
-                                      rdf:rest [ rdf:type rdf:List ;
-                                                 rdf:first "C" ;
-                                                 rdf:rest rdf:nil
-                                               ]
-                                    ]
-                        ] ;
-             rdfs:comment "Entitlement code to define if charges are Due carrier (C) or Due agent (A). Refer to CXML Code List 1.3"@en ;
-             rdfs:label "entitlement"@en ;
-             owl:comment "Possible RDF good practice IRI: :hasEntitlementCode "@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#epermitNumber
 :epermitNumber rdf:type owl:DatatypeProperty ;
                rdfs:domain :LiveAnimalsEpermit ;
@@ -3236,16 +3458,7 @@ List to be provided by local authorities"""@en ;
                rdfs:comment "The original number is a unique number allocated to each document by the relevant Management Authority. (box 1)"@en ;
                rdfs:label "epermitNumber"@en ;
                owl:comment "Possible RDF good practice IRI: :hasEpermitNumber "@en ;
-               owl:versionInfo "v3.0 renamed from liveAnimalsEpermit:permitNumber"@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#eventCode
-:eventCode rdf:type owl:DatatypeProperty ;
-           rdfs:domain :LogisticsEvent ;
-           rdfs:range xsd:string ;
-           rdfs:comment "Movement or milestone code. Can refer to CXML Code List 1.18, e.g. DEP, ARR, FOH, RCS but not restricted to it."@en ;
-           rdfs:label "eventCode"@en ;
-           owl:comment "Possible RDF good practice IRI: :hasEventCode "@en .
+               owl:versionInfo "v3. renamed from liveAnimalsEpermit:permitNumber"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#eventDate
@@ -3255,7 +3468,7 @@ List to be provided by local authorities"""@en ;
            rdfs:comment "Date and time of the event"@en ;
            rdfs:label "eventDate"@en ;
            owl:comment "Possible RDF good practice IRI: :hasEventDate "@en ;
-           owl:versionInfo "v3.0 renamed from logisticsEvent:dateTime"@en .
+           owl:versionInfo "v3. renamed from logisticsEvent:dateTime"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#eventName
@@ -3265,30 +3478,6 @@ List to be provided by local authorities"""@en ;
            rdfs:comment "If no EventCode provided, event name - e.g. Security clearance"@en ;
            rdfs:label "eventName"@en ;
            owl:comment "Possible RDF good practice IRI: :hasEventName "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#eventTimeType
-:eventTimeType rdf:type owl:DatatypeProperty ;
-               rdfs:domain :LogisticsEvent ;
-               rdfs:range [ rdf:type rdfs:Datatype ;
-                            owl:oneOf [ rdf:type rdf:List ;
-                                        rdf:first "Actual" ;
-                                        rdf:rest [ rdf:type rdf:List ;
-                                                   rdf:first "Expected" ;
-                                                   rdf:rest [ rdf:type rdf:List ;
-                                                              rdf:first "Planned" ;
-                                                              rdf:rest [ rdf:type rdf:List ;
-                                                                         rdf:first "Requested" ;
-                                                                         rdf:rest rdf:nil
-                                                                       ]
-                                                            ]
-                                                 ]
-                                      ]
-                          ] ;
-               rdfs:comment "Indicates type of event e.g.  Scheduled, Estimated, Actual"@en ;
-               rdfs:label "eventTimeType"@en ;
-               owl:comment "Possible RDF good practice IRI: :isOfEventTimeType "@en ;
-               owl:versionInfo "v3.0 renamed from logisticsEvent:eventTypeIndicator"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#exchangeRate
@@ -3309,29 +3498,6 @@ List to be provided by local authorities"""@en ;
                        owl:comment "Possible RDF good practice IRI: :hasExclusiveUseIndicator "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#executionStatus
-:executionStatus rdf:type owl:DatatypeProperty ;
-                 rdfs:domain :LogisticsActivity ;
-                 rdfs:range [ rdf:type rdfs:Datatype ;
-                              owl:oneOf [ rdf:type rdf:List ;
-                                          rdf:first "active" ;
-                                          rdf:rest [ rdf:type rdf:List ;
-                                                     rdf:first "cancelled" ;
-                                                     rdf:rest [ rdf:type rdf:List ;
-                                                                rdf:first "complete" ;
-                                                                rdf:rest [ rdf:type rdf:List ;
-                                                                           rdf:first "pending" ;
-                                                                           rdf:rest rdf:nil
-                                                                         ]
-                                                              ]
-                                                   ]
-                                        ]
-                            ] ;
-                 rdfs:comment "Enum stating the status of the Activity"@en ;
-                 rdfs:label "executionStatus"@en ;
-                 owl:comment "Possible RDF good practice IRI: :hasExecutionStatus "@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#expectedCommodities
 :expectedCommodities rdf:type owl:DatatypeProperty ;
                      rdfs:domain :BookingOptionRequest ;
@@ -3349,7 +3515,7 @@ List to be provided by local authorities"""@en ;
             rdfs:comment "Product expiry date - e.g. for perishables goods or goods with programmed obsolescence"@en ;
             rdfs:label "expiryDate"@en ;
             owl:comment "Possible RDF good practice IRI: :hasExpiryDate "@en ;
-            owl:versionInfo "v3.0 renamed from item:productExpiryDate"@en .
+            owl:versionInfo "v3. renamed from item:productExpiryDate"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#explosiveCompatibilityGroupCode
@@ -3439,7 +3605,7 @@ List to be provided by local authorities"""@en ;
                                                  ]
                                       ]
                           ] ;
-               rdfs:comment "Appendix number of the convention (I, II or III) (box 10)"@en ;
+               rdfs:comment "Appendix number of the convention (I, II or III) (box 1)"@en ;
                rdfs:label "goodsTypeCode"@en ;
                owl:comment "Possible RDF good practice IRI: :hasGoodsTypeCode "@en .
 
@@ -3477,7 +3643,7 @@ List to be provided by local authorities"""@en ;
                                                           ]
                                                ]
                                    ] ;
-                        rdfs:comment "Appendix number of the convention (I, II or III) (box 10)"@en ;
+                        rdfs:comment "Appendix number of the convention (I, II or III) (box 1)"@en ;
                         rdfs:label "goodsTypeExtensionCode"@en ;
                         owl:comment "Possible RDF good practice IRI: :hasGoodsTypeExtensionCode "@en .
 
@@ -3489,37 +3655,6 @@ List to be provided by local authorities"""@en ;
             rdfs:comment "Total price"@en ;
             rdfs:label "grandTotal"@en ;
             owl:comment "Possible RDF good practice IRI: :hasGrandTotal "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#groundsForExemption
-:groundsForExemption rdf:type owl:DatatypeProperty ;
-                     rdfs:domain :SecurityDeclaration ;
-                     rdfs:range [ rdf:type rdfs:Datatype ;
-                                  owl:oneOf [ rdf:type rdf:List ;
-                                              rdf:first "BIOM" ;
-                                              rdf:rest [ rdf:type rdf:List ;
-                                                         rdf:first "DIPL" ;
-                                                         rdf:rest [ rdf:type rdf:List ;
-                                                                    rdf:first "LFSM" ;
-                                                                    rdf:rest [ rdf:type rdf:List ;
-                                                                               rdf:first "SMUS" ;
-                                                                               rdf:rest [ rdf:type rdf:List ;
-                                                                                          rdf:first "TRNS" ;
-                                                                                          rdf:rest rdf:nil
-                                                                                        ]
-                                                                             ]
-                                                                  ]
-                                                       ]
-                                            ]
-                                ] ;
-                     rdfs:comment """Exemption code - e.g. BIOM- Bio-Medical Samples 
-SMUS - small undersized shipments MAIL - mail
-BIOM - bio-medical samples
-DIPL - diplomatic bags or diplomatic mail
-LFSM - life-saving materials NUCL - nuclear materials
-TRNS - transfer or transshipment"""@en ;
-                     rdfs:label "groundsForExemption"@en ;
-                     owl:comment "Possible RDF good practice IRI: :hasExemptionCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#handlingInformation
@@ -3549,7 +3684,7 @@ TRNS - transfer or transshipment"""@en ;
                           rdfs:comment "Refers to the type of handling information provided: Special Service Request (SSR), Special Handling Codes (SPH) or Other Service Information (OSI)"@en ;
                           rdfs:label "handlingInstructionsType"@en ;
                           owl:comment "Possible RDF good practice IRI: :isOfHandlingInstructionsType "@en ;
-                          owl:versionInfo "v3.0 renamed from handlingInstructions:serviceType"@en .
+                          owl:versionInfo "v3. renamed from handlingInstructions:serviceType"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#handlingInstructionsTypeCode
@@ -3560,7 +3695,7 @@ TRNS - transfer or transshipment"""@en ;
 Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                               rdfs:label "handlingInstructionsTypeCode"@en ;
                               owl:comment "Possible RDF good practice IRI: :isOfHandlingInstructionsTypeCode "@en ;
-                              owl:versionInfo "v3.0 renamed from handlingInstructions:serviceTypeCode"@en .
+                              owl:versionInfo "v3. renamed from handlingInstructions:serviceTypeCode"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#hazardClassificationId
@@ -3570,20 +3705,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                         rdfs:comment "Identifies the hazard class / division identification containing a numeric field separated by a decimal"@en ;
                         rdfs:label "hazardClassificationId"@en ;
                         owl:comment "Possible RDF good practice IRI: :hasHazardClassificationIdentifier "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#hsCode
-:hsCode rdf:type owl:DatatypeProperty ;
-        rdfs:domain :Product ;
-        rdfs:range [ rdf:type rdfs:Datatype ;
-                     owl:onDatatype xsd:string ;
-                     owl:withRestrictions ( [ xsd:minLength 6
-                                            ]
-                                          )
-                   ] ;
-        rdfs:comment "Harmonized Commodity code, refer to hsType used. 6 minimum digits are expected."@en ;
-        rdfs:label "hsCode"@en ;
-        owl:comment "Possible RDF good practice IRI: :hasHSCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#hsCommodityDescription
@@ -3624,7 +3745,7 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                                ] ,
                                [ rdf:type rdfs:Datatype ;
                                  owl:onDatatype xsd:string ;
-                                 owl:withRestrictions ( [ xsd:pattern "[0-9]+"
+                                 owl:withRestrictions ( [ xsd:pattern "[-9]+"
                                                         ]
                                                       )
                                ] ;
@@ -3645,7 +3766,7 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                                              ] ,
                                              [ rdf:type rdfs:Datatype ;
                                                owl:onDatatype xsd:string ;
-                                               owl:withRestrictions ( [ xsd:pattern "[0-9]+"
+                                               owl:withRestrictions ( [ xsd:pattern "[-9]+"
                                                                       ]
                                                                     )
                                              ] ;
@@ -3658,7 +3779,7 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
 :incoterms rdf:type owl:DatatypeProperty ;
            rdfs:domain :Shipment ;
            rdfs:range xsd:string ;
-           rdfs:comment "Standard codes as defined by UNCEFACT and ICC that correspond to international rules for the interpretation of the most commonly used trade terms in different countries. UNECE recommendation n. 5 Incoterms 2000."@en ;
+           rdfs:comment "Standard codes as defined by UNCEFACT and ICC that correspond to international rules for the interpretation of the most commonly used trade terms in different countries. UNECE recommendation n. 5 Incoterms 2."@en ;
            rdfs:label "incoterms"@en ;
            owl:comment "Possible RDF good practice IRI: :hasIncoterms "@en .
 
@@ -3753,29 +3874,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                    owl:comment "Possible RDF good practice IRI: :hasLegSequenceNumber "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#loadType
-:loadType rdf:type owl:DatatypeProperty ;
-          rdfs:domain owl:Thing ;
-          rdfs:range [ rdf:type rdfs:Datatype ;
-                       owl:oneOf [ rdf:type rdf:List ;
-                                   rdf:first "Bulk" ;
-                                   rdf:rest [ rdf:type rdf:List ;
-                                              rdf:first "Loose" ;
-                                              rdf:rest [ rdf:type rdf:List ;
-                                                         rdf:first "Pallet" ;
-                                                         rdf:rest [ rdf:type rdf:List ;
-                                                                    rdf:first "ULD" ;
-                                                                    rdf:rest rdf:nil
-                                                                  ]
-                                                       ]
-                                            ]
-                                 ]
-                     ] ;
-          rdfs:comment "Load type of the shipment or piece (Bulk, ULD, Pallet, Loose)"@en ;
-          rdfs:label "loadType"@en ;
-          owl:comment "Possible RDF good practice IRI: :hasLoadType "@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#loadingIdentifier
 :loadingIdentifier rdf:type owl:DatatypeProperty ;
                    rdfs:domain :LoadingActivity ;
@@ -3783,15 +3881,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                    rdfs:comment "Short text holding the process number if necessary"@en ;
                    rdfs:label "loadingIdentifier"@en ;
                    owl:comment "Possible RDF good practice IRI: :hasLoadingIdentifier "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#loadingIndicator
-:loadingIndicator rdf:type owl:DatatypeProperty ;
-                  rdfs:domain :LoadingUnit ;
-                  rdfs:range xsd:string ;
-                  rdfs:comment "ULD height or loading limitation code. Refer CXML Code List 1.47,  e.g. R - ULD Height above 244 centimetres"@en ;
-                  rdfs:label "loadingIndicator"@en ;
-                  owl:comment "Possible RDF good practice IRI: :hasLoadingIndicator "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#loadingPosition
@@ -3813,21 +3902,13 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                            owl:comment "Possible RDF good practice IRI: :hasLoadingPositionIdentifier "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#loadingType
-:loadingType rdf:type owl:DatatypeProperty ;
-             rdfs:domain :Loading ;
-             rdfs:range [ rdf:type rdfs:Datatype ;
-                          owl:oneOf [ rdf:type rdf:List ;
-                                      rdf:first "Offload" ;
-                                      rdf:rest [ rdf:type rdf:List ;
-                                                 rdf:first "Onload" ;
-                                                 rdf:rest rdf:nil
-                                               ]
-                                    ]
-                        ] ;
-             rdfs:comment "Enum stating whether the LoadingAction describes onloading or offloading"@en ;
-             rdfs:label "loadingType"@en ;
-             owl:comment "Possible RDF good practice IRI: :isOfLoadingType "@en .
+###  https://onerecord.iata.org/ns/cargo#locationCode
+:locationCode rdf:type owl:DatatypeProperty ;
+              rdfs:domain :Location ;
+              rdfs:range xsd:string ;
+              rdfs:comment "Location code of airport, freight terminal, seaport, rail station. UN/LOCODE city code (5 letter) or IATA airport code (3 letter)"@en ;
+              rdfs:label "locationCode"@en ;
+              owl:comment "Possible RDF good practice IRI: :hasLocationCode "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#locationName
@@ -3971,7 +4052,7 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
           rdfs:domain :TransportMovement ;
           rdfs:range [ rdf:type rdfs:Datatype ;
                        owl:oneOf [ rdf:type rdf:List ;
-                                   rdf:first "0" ;
+                                   rdf:first "" ;
                                    rdf:rest [ rdf:type rdf:List ;
                                               rdf:first "1" ;
                                               rdf:rest [ rdf:type rdf:List ;
@@ -4002,29 +4083,9 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                                             ]
                                  ]
                      ] ;
-          rdfs:comment "Mode of transport code, refer to UNECE Rec. 19 https://unece.org/fileadmin/DAM/cefact/recommendations/rec19/rec19_01cf19e.pdf"@en ;
+          rdfs:comment "Mode of transport code, refer to UNECE Rec. 19 https://unece.org/fileadmin/DAM/cefact/recommendations/rec19/rec19_1cf19e.pdf"@en ;
           rdfs:label "modeCode"@en ;
           owl:comment "Possible RDF good practice IRI: :hasModeCode "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#modeQualifier
-:modeQualifier rdf:type owl:DatatypeProperty ;
-               rdfs:domain :TransportMovement ;
-               rdfs:range [ rdf:type rdfs:Datatype ;
-                            owl:oneOf [ rdf:type rdf:List ;
-                                        rdf:first "Main-Carriage" ;
-                                        rdf:rest [ rdf:type rdf:List ;
-                                                   rdf:first "On-Carriage" ;
-                                                   rdf:rest [ rdf:type rdf:List ;
-                                                              rdf:first "Pre-Carriage" ;
-                                                              rdf:rest rdf:nil
-                                                            ]
-                                                 ]
-                                      ]
-                          ] ;
-               rdfs:comment "Pre-Carriage, Main-Carriage or On-Carriage"@en ;
-               rdfs:label "modeQualifier"@en ;
-               owl:comment "Possible RDF good practice IRI: :hasModeQualifier "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#modularCheckNumber
@@ -4034,35 +4095,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                     rdfs:comment "The check is a Modular 7 validation on the AWB number, recorded as a boolean."@en ;
                     rdfs:label "modularCheckNumber"@en ;
                     owl:comment "Possible RDF good practice IRI: :hasModularCheckNumber "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#movementMilestone
-:movementMilestone rdf:type owl:DatatypeProperty ;
-                   rdfs:domain :MovementTime ;
-                   rdfs:range xsd:string ;
-                   rdfs:comment "The milestone list still needs to be defined, it includes elements from CXML Code List 1.92 but is not limited to those values, e.g. block-on and block-off times might be added as a comparison to wheels off and touchdown."@en ;
-                   rdfs:label "movementMilestone"@en ;
-                   owl:comment "Possible RDF good practice IRI: :hasMilestone "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#movementTimeType
-:movementTimeType rdf:type owl:DatatypeProperty ;
-                  rdfs:domain :MovementTime ;
-                  rdfs:range [ rdf:type rdfs:Datatype ;
-                               owl:oneOf [ rdf:type rdf:List ;
-                                           rdf:first "Actual" ;
-                                           rdf:rest [ rdf:type rdf:List ;
-                                                      rdf:first "Departed" ;
-                                                      rdf:rest [ rdf:type rdf:List ;
-                                                                 rdf:first "Scheduled" ;
-                                                                 rdf:rest rdf:nil
-                                                               ]
-                                                    ]
-                                         ]
-                             ] ;
-                  rdfs:comment "The type of time can be Actual, Estimated ot Scheduled"@en ;
-                  rdfs:label "movementTimeType"@en ;
-                  owl:comment "Possible RDF good practice IRI: :isOfTimeType "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#movementTimestamp
@@ -4120,7 +4152,7 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
       rdfs:comment "Free text for customs remarks, not used in OCI Composition Rules Table"@en ;
       rdfs:label "note"@en ;
       owl:comment "Possible RDF good practice IRI: :hasCustomsNote "@en ;
-      owl:versionInfo "v3.0 renamed from customsInformation:customsInfoNote"@en .
+      owl:versionInfo "v3. renamed from customsInformation:customsInfoNote"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#numberOfDoors
@@ -4130,7 +4162,7 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                rdfs:comment "Number of doors"@en ;
                rdfs:label "numberOfDoors"@en ;
                owl:comment "Possible RDF good practice IRI: :hasNumberOfDoors "@en ;
-               owl:versionInfo "v3.0 renamed from loadingUnit:nbDoor"@en .
+               owl:versionInfo "v3. renamed from loadingUnit:nbDoor"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#numberOfFittings
@@ -4140,7 +4172,7 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                   rdfs:comment "Number of fittings"@en ;
                   rdfs:label "numberOfFittings"@en ;
                   owl:comment "Possible RDF good practice IRI: :hasNumberOfFittings "@en ;
-                  owl:versionInfo "v3.0 renamed from loadingUnit:nbFittings"@en .
+                  owl:versionInfo "v3. renamed from loadingUnit:nbFittings"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#numberOfNets
@@ -4150,7 +4182,7 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
               rdfs:comment "Number of nets"@en ;
               rdfs:label "numberOfNets"@en ;
               owl:comment "Possible RDF good practice IRI: :hasNumberOfNets "@en ;
-              owl:versionInfo "v3.0 renamed from loadingUnit:nbNets"@en .
+              owl:versionInfo "v3. renamed from loadingUnit:nbNets"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#numberOfStraps
@@ -4160,7 +4192,7 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                 rdfs:comment "Number of straps"@en ;
                 rdfs:label "numberOfStraps"@en ;
                 owl:comment "Possible RDF good practice IRI: :hasNumberOfStraps "@en ;
-                owl:versionInfo "v3.0 renamed from loadingUnit:nbStraps"@en .
+                owl:versionInfo "v3. renamed from loadingUnit:nbStraps"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#numericalValue
@@ -4204,7 +4236,7 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
 :odlnCode rdf:type owl:DatatypeProperty ;
           rdfs:domain :LoadingUnit ;
           rdfs:range xsd:string ;
-          rdfs:comment "Contains two designator codes of ODLN or Operational Damage Limit Notices. ODLN code is used to define type of damage after visually check the serviceability of ULDs section 7, Standard Specifications 40/3 or 40/4 in ULD Regulations"@en ;
+          rdfs:comment "Contains two designator codes of ODLN or Operational Damage Limit Notices. ODLN code is used to define type of damage after visually check the serviceability of ULDs section 7, Standard Specifications 4/3 or 4/4 in ULD Regulations"@en ;
           rdfs:label "odlnCode"@en ;
           owl:comment "Possible RDF good practice IRI: :hasOdlnCode "@en .
 
@@ -4234,7 +4266,7 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                                rdfs:comment "Issuing date for Origin reference permit or re-export reference Certificate (box 12)"@en ;
                                rdfs:label "originReferencePermitDateTime"@en ;
                                owl:comment "Possible RDF good practice IRI: :hasOriginReferencePermitDateTime "@en ;
-                               owl:versionInfo "v3.0 renamed from pieceLiveAnimals:originReferencePermitDatetime"@en .
+                               owl:versionInfo "v3. renamed from pieceLiveAnimals:originReferencePermitDatetime"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#originReferencePermitId
@@ -4255,32 +4287,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                                owl:comment "Possible RDF good practice IRI: :hasOriginReferencePermitTypeCode "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#otherChargeCode
-:otherChargeCode rdf:type owl:DatatypeProperty ;
-                 rdfs:domain owl:Thing ;
-                 rdfs:range xsd:string ;
-                 rdfs:comment "Refer to CargoXML Code List 1.2 for Other Charges"@en ;
-                 rdfs:label "otherChargeCode" ;
-                 owl:comment "Possible RDF good practice IRI: :hasOtherChargeCode "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#otherChargesIndicator
-:otherChargesIndicator rdf:type owl:DatatypeProperty ;
-                       rdfs:domain :Waybill ;
-                       rdfs:range [ rdf:type rdfs:Datatype ;
-                                    owl:oneOf [ rdf:type rdf:List ;
-                                                rdf:first "C" ;
-                                                rdf:rest [ rdf:type rdf:List ;
-                                                           rdf:first "P" ;
-                                                           rdf:rest rdf:nil
-                                                         ]
-                                              ]
-                                  ] ;
-                       rdfs:comment "payment of Other Charges will be made at origin (prepaid) or at destination (collect)"@en ;
-                       rdfs:label "otherChargesIndicator"@en ;
-                       owl:comment "Possible RDF good practice IRI: :isPrepaidOrCollect "@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#otherCustomsInformation
 :otherCustomsInformation rdf:type owl:DatatypeProperty ;
                          rdfs:domain :CustomsInformation ;
@@ -4288,7 +4294,7 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                          rdfs:comment "Supplementary Customs, Security and Regulatory Control Information"@en ;
                          rdfs:label "otherCustomsInformation"@en ;
                          owl:comment "Possible RDF good practice IRI: :hasOtherCustomsInformation "@en ;
-                         owl:versionInfo "v3.0 renamed from customsInformation:customsInformation"@en .
+                         owl:versionInfo "v3. renamed from customsInformation:customsInformation"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#otherIdentifierType
@@ -4401,6 +4407,14 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                           owl:comment "Possible RDF good practice IRI: :hasPackingInstructionNumber "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#partialEventIndicator
+:partialEventIndicator rdf:type owl:DatatypeProperty ;
+                       rdfs:domain :LogisticsEvent ;
+                       rdfs:range xsd:boolean ;
+                       rdfs:comment "Boolean indicating that the LogisticsEvent is only applicable for parts of the LogisticObject it was recorded for, for example for some Pieces of a Shipment"@en ;
+                       rdfs:label "partialEventIndicator"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#passed
 :passed rdf:type owl:DatatypeProperty ;
         rdfs:domain :CheckTotalResult ;
@@ -4426,7 +4440,7 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                             rdfs:comment "Description if TypeCode is Other (box 1)"@en ;
                             rdfs:label "permitTypeOtherDescription"@en ;
                             owl:comment "Possible RDF good practice IRI: :hasPermitTypeOtherDescription "@en ;
-                            owl:versionInfo "v3.0 renamed from liveAnimalsEpermit:permitTypeOther"@en .
+                            owl:versionInfo "v3. renamed from liveAnimalsEpermit:permitTypeOther"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#physicalChemicalForm
@@ -4453,7 +4467,7 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
 :pieceCountForRate rdf:type owl:DatatypeProperty ;
                    rdfs:domain :TACTRateDescription ;
                    rdfs:range xsd:integer ;
-                   rdfs:comment "PENDING"@en ;
+                   rdfs:comment "Number of pieces for which the rate description details apply"@en ;
                    rdfs:label "pieceCountForRate"@en .
 
 
@@ -4464,16 +4478,7 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                rdfs:comment "Post Office box number / code"@en ;
                rdfs:label "postOfficeBox"@en ;
                owl:comment "Possible RDF good practice IRI: :hasPostOfficeBox "@en ;
-               owl:versionInfo "v3.0 renamed from address:poBox"@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#postalCode
-:postalCode rdf:type owl:DatatypeProperty ;
-            rdfs:domain :Address ;
-            rdfs:range xsd:string ;
-            rdfs:comment "Postal / ZIP code"@en ;
-            rdfs:label "postalCode"@en ;
-            owl:comment "Possible RDF good practice IRI: :hasPostalCode "@en .
+               owl:versionInfo "v3. renamed from address:poBox"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#preferredTransportId
@@ -4496,14 +4501,14 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                    ] ,
                    [ rdf:type rdfs:Datatype ;
                      owl:onDatatype xsd:string ;
-                     owl:withRestrictions ( [ xsd:pattern "[0-9]+"
+                     owl:withRestrictions ( [ xsd:pattern "[-9]+"
                                             ]
                                           )
                    ] ;
         rdfs:comment "IATA three-numeric airline prefix number"@en ;
         rdfs:label "prefix"@en ;
         owl:comment "Possible RDF good practice IRI: :hasAirlinePrefix "@en ;
-        owl:versionInfo "v3.0 renamed from carrier:airlinePrefix"@en .
+        owl:versionInfo "v3. renamed from carrier:airlinePrefix"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#priceSpecification
@@ -4524,15 +4529,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                        owl:comment "Possible RDF good practice IRI: :hasPriceSpecificationRef "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#productCode
-:productCode rdf:type owl:DatatypeProperty ;
-             rdfs:domain :CarrierProduct ;
-             rdfs:range xsd:string ;
-             rdfs:comment "Carrier's product code"@en ;
-             rdfs:label "productCode"@en ;
-             owl:comment "Possible RDF good practice IRI: :hasProductCode "@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#productDescription
 :productDescription rdf:type owl:DatatypeProperty ;
                     rdfs:domain :CarrierProduct ;
@@ -4549,7 +4545,7 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                 rdfs:comment "Production date"@en ;
                 rdfs:label "productionDate"@en ;
                 owl:comment "Possible RDF good practice IRI: :hasProductionDate "@en ;
-                owl:versionInfo "v3.0 renamed from item:ofProductionDate"@en .
+                owl:versionInfo "v3. renamed from item:ofProductionDate"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#properShippingName
@@ -4615,23 +4611,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
                   owl:comment "Possible RDF good practice IRI: :isPartOfSection "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#rateClassCode
-:rateClassCode rdf:type owl:DatatypeProperty ;
-               rdfs:domain owl:Thing ;
-               rdfs:range xsd:string ;
-               rdfs:comment "Rate class code e.g. Q. Refer to CXML Code List 1.4 Rate Class Codes"@en ;
-               rdfs:label "rateClassCode"@en ;
-               owl:comment "Possible RDF good practice IRI: :hasRateClassCode "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#rateClassCodeBasic
-:rateClassCodeBasic rdf:type owl:DatatypeProperty ;
-                    rdfs:domain :TACTRateDescription ;
-                    rdfs:range xsd:string ;
-                    rdfs:comment "PENDING"@en ;
-                    rdfs:label "rateClassCodeBasic"@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#rateQuantity
 :rateQuantity rdf:type owl:DatatypeProperty ;
               rdfs:domain :Ratings ;
@@ -4639,15 +4618,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
               rdfs:comment "Used if there is an applicable quantity to the rate (Usually a Time or a Number)"@en ;
               rdfs:label "rateQuantity"@en ;
               owl:comment "Possible RDF good practice IRI: :hasRateQuantity "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#ratingType
-:ratingType rdf:type owl:DatatypeProperty ;
-            rdfs:domain :Ranges ;
-            rdfs:range xsd:string ;
-            rdfs:comment "rating type - Refer to CXML Code List 1.44 ULD Charge Codes"@en ;
-            rdfs:label "ratingType"@en ;
-            owl:comment "Possible RDF good practice IRI: :hasRatingType "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#ratingsType
@@ -4674,7 +4644,7 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
 :rcp rdf:type owl:DatatypeProperty ;
      rdfs:domain owl:Thing ;
      rdfs:range xsd:string ;
-     rdfs:comment "IATA 3-letter code of the rate combination point"@en ;
+     rdfs:comment "IATA 3-letter code of the rate combination point as defined in TACT"@en ;
      rdfs:label "rcp"@en ;
      owl:comment "Possible RDF good practice IRI: :hasRateCombinationPoint "@en .
 
@@ -4706,6 +4676,10 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
             owl:comment "Possible RDF good practice IRI: :hasRegionName "@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#regulatedEntityCategory
+:regulatedEntityCategory rdf:type owl:DatatypeProperty .
+
+
 ###  https://onerecord.iata.org/ns/cargo#regulatedEntityExpiryDate
 :regulatedEntityExpiryDate rdf:type owl:DatatypeProperty ;
                            rdfs:domain :RegulatedEntity ;
@@ -4722,7 +4696,7 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
          rdfs:comment "Remarks or Supplement Information"@en ;
          rdfs:label "remarks"@en ;
          owl:comment "Possible RDF good practice IRI: :hasRemarks "@en ;
-         owl:versionInfo "v3.0 renamed from loadingUnit:uldRemarks"@en .
+         owl:versionInfo "v3. renamed from loadingUnit:uldRemarks"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#reportableQuantity
@@ -4761,69 +4735,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
         owl:comment "Possible RDF good practice IRI: :hasRoadFeederService "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#role
-:role rdf:type owl:DatatypeProperty ;
-      rdfs:domain :Party ;
-      rdfs:range [ rdf:type rdfs:Datatype ;
-                   owl:oneOf [ rdf:type rdf:List ;
-                               rdf:first "Agent" ;
-                               rdf:rest [ rdf:type rdf:List ;
-                                          rdf:first "Airline" ;
-                                          rdf:rest [ rdf:type rdf:List ;
-                                                     rdf:first "Airport Authority" ;
-                                                     rdf:rest [ rdf:type rdf:List ;
-                                                                rdf:first "Broker" ;
-                                                                rdf:rest [ rdf:type rdf:List ;
-                                                                           rdf:first "Commissionable Agent" ;
-                                                                           rdf:rest [ rdf:type rdf:List ;
-                                                                                      rdf:first "Consignee" ;
-                                                                                      rdf:rest [ rdf:type rdf:List ;
-                                                                                                 rdf:first "Customs" ;
-                                                                                                 rdf:rest [ rdf:type rdf:List ;
-                                                                                                            rdf:first "Declarant" ;
-                                                                                                            rdf:rest [ rdf:type rdf:List ;
-                                                                                                                       rdf:first "Deconsolidator" ;
-                                                                                                                       rdf:rest [ rdf:type rdf:List ;
-                                                                                                                                  rdf:first "Freight Forwarder" ;
-                                                                                                                                  rdf:rest [ rdf:type rdf:List ;
-                                                                                                                                             rdf:first "Ground Handling Agent" ;
-                                                                                                                                             rdf:rest [ rdf:type rdf:List ;
-                                                                                                                                                        rdf:first "Nominated freight company" ;
-                                                                                                                                                        rdf:rest [ rdf:type rdf:List ;
-                                                                                                                                                                   rdf:first "Notify Party" ;
-                                                                                                                                                                   rdf:rest [ rdf:type rdf:List ;
-                                                                                                                                                                              rdf:first "Other Participant Identifier" ;
-                                                                                                                                                                              rdf:rest [ rdf:type rdf:List ;
-                                                                                                                                                                                         rdf:first "Post Office" ;
-                                                                                                                                                                                         rdf:rest [ rdf:type rdf:List ;
-                                                                                                                                                                                                    rdf:first "Shipper" ;
-                                                                                                                                                                                                    rdf:rest [ rdf:type rdf:List ;
-                                                                                                                                                                                                               rdf:first "Trucker" ;
-                                                                                                                                                                                                               rdf:rest rdf:nil
-                                                                                                                                                                                                             ]
-                                                                                                                                                                                                  ]
-                                                                                                                                                                                       ]
-                                                                                                                                                                            ]
-                                                                                                                                                                 ]
-                                                                                                                                                      ]
-                                                                                                                                           ]
-                                                                                                                                ]
-                                                                                                                     ]
-                                                                                                          ]
-                                                                                               ]
-                                                                                    ]
-                                                                         ]
-                                                              ]
-                                                   ]
-                                        ]
-                             ]
-                 ] ;
-      rdfs:comment "Role fo the Company in the context. Can refer to Code List 1.36 in the CXML Toolkit"@en ;
-      rdfs:label "role"@en ;
-      owl:comment "Possible RDF good practice IRI: :hasRole "@en ;
-      owl:versionInfo "v3.0 renamed from party:partyRole"@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#salutation
 :salutation rdf:type owl:DatatypeProperty ;
             rdfs:domain :Person ;
@@ -4856,50 +4767,6 @@ Refers to Code List 1.14 or 1.16 if service type is Special Handling."""@en ;
      owl:comment "Possible RDF good practice IRI: :hasSpecificCommodityRate "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#screeningMethods
-:screeningMethods rdf:type owl:DatatypeProperty ;
-                  rdfs:domain :SecurityDeclaration ;
-                  rdfs:range [ rdf:type rdfs:Datatype ;
-                               owl:oneOf [ rdf:type rdf:List ;
-                                           rdf:first "AOM" ;
-                                           rdf:rest [ rdf:type rdf:List ;
-                                                      rdf:first "CMD" ;
-                                                      rdf:rest [ rdf:type rdf:List ;
-                                                                 rdf:first "EDD" ;
-                                                                 rdf:rest [ rdf:type rdf:List ;
-                                                                            rdf:first "EDS" ;
-                                                                            rdf:rest [ rdf:type rdf:List ;
-                                                                                       rdf:first "ETD" ;
-                                                                                       rdf:rest [ rdf:type rdf:List ;
-                                                                                                  rdf:first "PHS" ;
-                                                                                                  rdf:rest [ rdf:type rdf:List ;
-                                                                                                             rdf:first "VCK" ;
-                                                                                                             rdf:rest [ rdf:type rdf:List ;
-                                                                                                                        rdf:first "XRY" ;
-                                                                                                                        rdf:rest rdf:nil
-                                                                                                                      ]
-                                                                                                           ]
-                                                                                                ]
-                                                                                     ]
-                                                                          ]
-                                                               ]
-                                                    ]
-                                         ]
-                             ] ;
-                  rdfs:comment """Screening methods which have been used to secure the cargo
-PHS – Physical Inspection and/or hand search 
-VCK - Visual check 
-XRY- X-ray equipment 
-EDS - Explosive detection system 
-EDD - Explosive detection dogs
-ETD - Explosive trace detection equipment - particles or vapor 
-CMD - Cargo metal detection
-AOM - Subjected to any other means: this entry should be followed by free text specifying what other mean was used to secure the cargo"""@en ;
-                  rdfs:label "screeningMethods"@en ;
-                  owl:comment "Possible RDF good practice IRI: :hasScreeningMethods "@en ;
-                  owl:versionInfo "v3.0 renamed from securityDeclaration:screeningMethod"@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#seal
 :seal rdf:type owl:DatatypeProperty ;
       rdfs:domain :TransportMovement ;
@@ -4916,7 +4783,7 @@ AOM - Subjected to any other means: this entry should be followed by free text s
             rdfs:comment "ULD seal number if applicable"@en ;
             rdfs:label "sealNumber"@en ;
             owl:comment "Possible RDF good practice IRI: :hasSealNumber "@en ;
-            owl:versionInfo "v3.0 renamed from loadingUnit:uldSealNumber"@en .
+            owl:versionInfo "v3. renamed from loadingUnit:uldSealNumber"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#securityStampId
@@ -4926,64 +4793,6 @@ AOM - Subjected to any other means: this entry should be followed by free text s
                  rdfs:comment "Security Stamp ID"@en ;
                  rdfs:label "securityStampId"@en ;
                  owl:comment "Possible RDF good practice IRI: :hasSecurityStampIdentifier "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#securityStatus
-:securityStatus rdf:type owl:DatatypeProperty ;
-                rdfs:domain :SecurityDeclaration ;
-                rdfs:range [ rdf:type rdfs:Datatype ;
-                             owl:oneOf [ rdf:type rdf:List ;
-                                         rdf:first "NSC" ;
-                                         rdf:rest [ rdf:type rdf:List ;
-                                                    rdf:first "SCO" ;
-                                                    rdf:rest [ rdf:type rdf:List ;
-                                                               rdf:first "SHR" ;
-                                                               rdf:rest [ rdf:type rdf:List ;
-                                                                          rdf:first "SPX" ;
-                                                                          rdf:rest rdf:nil
-                                                                        ]
-                                                             ]
-                                                  ]
-                                       ]
-                           ] ;
-                rdfs:comment "Security status indicator (CXML 1.103) - e.g. SPX- Cargo Secure for Passenger and All-Cargo Aircraft "@en ;
-                rdfs:label "securityStatus"@en ;
-                owl:comment "Possible RDF good practice IRI: :hasSecurityStatus "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#sensorType
-:sensorType rdf:type owl:DatatypeProperty ;
-            rdfs:domain :Sensor ;
-            rdfs:range [ rdf:type rdfs:Datatype ;
-                         owl:oneOf [ rdf:type rdf:List ;
-                                     rdf:first "Accelerometer" ;
-                                     rdf:rest [ rdf:type rdf:List ;
-                                                rdf:first "Geolocation" ;
-                                                rdf:rest [ rdf:type rdf:List ;
-                                                           rdf:first "Humidity" ;
-                                                           rdf:rest [ rdf:type rdf:List ;
-                                                                      rdf:first "Light" ;
-                                                                      rdf:rest [ rdf:type rdf:List ;
-                                                                                 rdf:first "Pressure" ;
-                                                                                 rdf:rest [ rdf:type rdf:List ;
-                                                                                            rdf:first "Thermometer" ;
-                                                                                            rdf:rest [ rdf:type rdf:List ;
-                                                                                                       rdf:first "Tilt" ;
-                                                                                                       rdf:rest [ rdf:type rdf:List ;
-                                                                                                                  rdf:first "Vibration" ;
-                                                                                                                  rdf:rest rdf:nil
-                                                                                                                ]
-                                                                                                     ]
-                                                                                          ]
-                                                                               ]
-                                                                    ]
-                                                         ]
-                                              ]
-                                   ]
-                       ] ;
-            rdfs:comment "Type of sensor as described in Interactive Cargo Recommended Practice"@en ;
-            rdfs:label "sensorType"@en ;
-            owl:comment "Possible RDF good practice IRI: :isOfSensorType "@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#sequenceNumber
@@ -5004,48 +4813,6 @@ AOM - Subjected to any other means: this entry should be followed by free text s
               owl:comment "Possible RDF good practice IRI: :hasSerialNumber "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#serviceCode
-:serviceCode rdf:type owl:DatatypeProperty ;
-             rdfs:domain :Waybill ;
-             rdfs:range xsd:string ;
-             rdfs:comment "PENDING"@en ;
-             rdfs:label "serviceCode"@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#serviceabilityCode
-:serviceabilityCode rdf:type owl:DatatypeProperty ;
-                    rdfs:domain :LoadingUnit ;
-                    rdfs:range [ rdf:type rdfs:Datatype ;
-                                 owl:oneOf [ rdf:type rdf:List ;
-                                             rdf:first "DAM" ;
-                                             rdf:rest [ rdf:type rdf:List ;
-                                                        rdf:first "SER" ;
-                                                        rdf:rest rdf:nil
-                                                      ]
-                                           ]
-                               ] ;
-                    rdfs:comment "Designator of serviceablity condition e.g. SER or DAM "@en ;
-                    rdfs:label "serviceabilityCode"@en ;
-                    owl:comment "Possible RDF good practice IRI: :hasServiceabilityCode "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#shipmentSecurityStatus
-:shipmentSecurityStatus rdf:type owl:DatatypeProperty ;
-                        rdfs:domain owl:Thing ;
-                        rdfs:range [ rdf:type rdfs:Datatype ;
-                                     owl:oneOf [ rdf:type rdf:List ;
-                                                 rdf:first "NCR" ;
-                                                 rdf:rest [ rdf:type rdf:List ;
-                                                            rdf:first "SCR" ;
-                                                            rdf:rest rdf:nil
-                                                          ]
-                                               ]
-                                   ] ;
-                        rdfs:comment "Indicate the secruty state of the shipment, screened or not"@en ;
-                        rdfs:label "shipmentSecurityStatus"@en ;
-                        owl:comment "Possible RDF good practice IRI: :hasShipmentSecurityStatus "@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#shipperDeclarationText
 :shipperDeclarationText rdf:type owl:DatatypeProperty ;
                         rdfs:domain :DgDeclaration ;
@@ -5062,7 +4829,7 @@ AOM - Subjected to any other means: this entry should be followed by free text s
               rdfs:comment "The shipper or its Agent may enter the appropriate optional shipping"@en ;
               rdfs:label "shippingInfo"@en ;
               owl:comment "Possible RDF good practice IRI: :hasOptionalShippingInfo "@en ;
-              owl:versionInfo "v3.0 renamed from waybill:optionalShippingInfo"@en .
+              owl:versionInfo "v3. renamed from waybill:optionalShippingInfo"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#shippingMarks
@@ -5081,7 +4848,7 @@ AOM - Subjected to any other means: this entry should be followed by free text s
                rdfs:comment "Optional shipping reference number if any"@en ;
                rdfs:label "shippingRefNo"@en ;
                owl:comment "Possible RDF good practice IRI: :hasOptionalShippingReferenceNumber "@en ;
-               owl:versionInfo "v3.0 renamed from waybill:optionalShippingRefNo"@en .
+               owl:versionInfo "v3. renamed from waybill:optionalShippingRefNo"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#shortName
@@ -5180,7 +4947,7 @@ AOM - Subjected to any other means: this entry should be followed by free text s
 
 ###  https://onerecord.iata.org/ns/cargo#slac
 :slac rdf:type owl:DatatypeProperty ;
-      rdfs:domain :PhysicalLogisticsObject ;
+      rdfs:domain owl:Thing ;
       rdfs:range xsd:integer ;
       rdfs:comment "Shipper's Load And Count  ( total contained piece count as provided by shipper)"@en ;
       rdfs:label "slac"@en ;
@@ -5203,13 +4970,6 @@ AOM - Subjected to any other means: this entry should be followed by free text s
                       rdfs:comment "A notation that the material is special form"@en ;
                       rdfs:label "specialFormIndicator"@en ;
                       owl:comment "Possible RDF good practice IRI: :isSpecialForm "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#specialHandlingCodes
-:specialHandlingCodes rdf:type owl:DatatypeProperty ;
-                      rdfs:domain :Piece ;
-                      rdfs:comment "Three-letter special handling code (SPH)"@en ;
-                      rdfs:label "specialHandlingCodes"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#specialProvisionId
@@ -5284,23 +5044,6 @@ AOM - Subjected to any other means: this entry should be followed by free text s
                    owl:comment "Possible RDF good practice IRI: :hasStoringIdentifier "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#storingType
-:storingType rdf:type owl:DatatypeProperty ;
-             rdfs:domain :Storing ;
-             rdfs:range [ rdf:type rdfs:Datatype ;
-                          owl:oneOf [ rdf:type rdf:List ;
-                                      rdf:first "StoreIn" ;
-                                      rdf:rest [ rdf:type rdf:List ;
-                                                 rdf:first "StoreOut" ;
-                                                 rdf:rest rdf:nil
-                                               ]
-                                    ]
-                        ] ;
-             rdfs:comment "Enum stating whether the StoringAction describes the store-in or the store-out"@en ;
-             rdfs:label "storingType"@en ;
-             owl:comment "Possible RDF good practice IRI: :isOfStoringType "@en .
-
-
 ###  https://onerecord.iata.org/ns/cargo#streetAddressLines
 :streetAddressLines rdf:type owl:DatatypeProperty ;
                     rdfs:domain :Address ;
@@ -5308,7 +5051,7 @@ AOM - Subjected to any other means: this entry should be followed by free text s
                     rdfs:comment "Street address including street name, street number, building number, apartment etc"@en ;
                     rdfs:label "streetAddressLines"@en ;
                     owl:comment "Possible RDF good practice IRI: :hasStreetAddress "@en ;
-                    owl:versionInfo "v3.0 renamed from address:street"@en .
+                    owl:versionInfo "v3. renamed from address:street"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#subTotal
@@ -5318,17 +5061,6 @@ AOM - Subjected to any other means: this entry should be followed by free text s
           rdfs:comment "Subtotal of the charge"@en ;
           rdfs:label "subTotal"@en ;
           owl:comment "Possible RDF good practice IRI: :hasSubTotal "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#subjectCode
-:subjectCode rdf:type owl:DatatypeProperty ;
-             rdfs:domain :CustomsInformation ;
-             rdfs:range xsd:string ;
-             rdfs:comment """Information Identifier. Code identifying a piece of information/entity e.g. \"IMP\" for import, \"EXP\" for export, \"AGT\" for Agent, \"ISS\" for The Regulated Agent Issuing the Security Status for a Consignment etc. 
-Condition: At least one of the three elements (Country Code, Information Identifier or Customs, Security and Regulatory Control Information Identifier) must be completed"""@en ;
-             rdfs:label "subjectCode"@en ;
-             owl:comment "Possible RDF good practice IRI: :hasSubjectCode "@en ;
-             owl:versionInfo "v3.0 renamed from customsInformation:customsInfoSubjectCode"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#supplementaryInfoPrefix
@@ -5437,7 +5169,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
                     rdfs:comment "Purpose of the transaction in free text (box 5a)"@en ;
                     rdfs:label "transactionPurpose"@en ;
                     owl:comment "Possible RDF good practice IRI: :hasTransactionPurpose "@en ;
-                    owl:versionInfo "v3.0 renamed from :hasTransactionPurposeText"@en .
+                    owl:versionInfo "v3. renamed from :hasTransactionPurposeText"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#transactionPurposeCode
@@ -5545,7 +5277,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
 :uldRateClassType rdf:type owl:DatatypeProperty ;
                   rdfs:domain :TACTRateDescription ;
                   rdfs:range xsd:integer ;
-                  rdfs:comment "PENDING"@en ;
+                  rdfs:comment "ULD Rate information - ULD Rate Class Type"@en ;
                   rdfs:label "uldRateClassType"@en .
 
 
@@ -5583,7 +5315,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
                   rdfs:comment "Manufacturer's unique product identifier"@en ;
                   rdfs:label "uniqueIdentifier"@en ;
                   owl:comment "Possible RDF good practice IRI: :hasUniqueIdentifier "@en ;
-                  owl:versionInfo "v3.0 renamed from product:productIdentifier"@en .
+                  owl:versionInfo "v3. renamed from product:productIdentifier"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#unit
@@ -5653,7 +5385,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
 :vehicleModel rdf:type owl:DatatypeProperty ;
               rdfs:domain :TransportMeans ;
               rdfs:range xsd:string ;
-              rdfs:comment "Model or make of the vehicle (e.g. A330-300)"@en ;
+              rdfs:comment "Model or make of the vehicle (e.g. A33-3)"@en ;
               rdfs:label "vehicleModel"@en ;
               owl:comment "Possible RDF good practice IRI: :isOfVehicleModel "@en .
 
@@ -5680,7 +5412,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
 :vehicleType rdf:type owl:DatatypeProperty ;
              rdfs:domain :TransportMeans ;
              rdfs:range xsd:string ;
-             rdfs:comment "Vehicle or container type. Refer UNECE28, e.g. 4.00.0 - Aircraft, type unknown.For Air refer to IATA Standard Schedules Information Manua in section ATA/IATA Aircraft Types"@en ;
+             rdfs:comment "Vehicle or container type. Refer UNECE28, e.g. 4.. - Aircraft, type unknown.For Air refer to IATA Standard Schedules Information Manua in section ATA/IATA Aircraft Types"@en ;
              rdfs:label "vehicleType"@en ;
              owl:comment "Possible RDF good practice IRI: :isOfVehicleType "@en .
 
@@ -5699,7 +5431,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
                rdfs:domain :Waybill ;
                rdfs:range [ rdf:type rdfs:Datatype ;
                             owl:onDatatype xsd:string ;
-                            owl:withRestrictions ( [ xsd:pattern "[0-9]+"
+                            owl:withRestrictions ( [ xsd:pattern "[-9]+"
                                                    ]
                                                  )
                           ] ;
@@ -5722,46 +5454,130 @@ Condition: At least one of the three elements (Country Code, Information Identif
                owl:comment "Possible RDF good practice IRI: :hasWaybillPrefix "@en .
 
 
-###  https://onerecord.iata.org/ns/cargo#waybillType
-:waybillType rdf:type owl:DatatypeProperty ;
-             rdfs:domain :Waybill ;
-             rdfs:range [ rdf:type rdfs:Datatype ;
-                          owl:oneOf [ rdf:type rdf:List ;
-                                      rdf:first "Direct" ;
-                                      rdf:rest [ rdf:type rdf:List ;
-                                                 rdf:first "House" ;
-                                                 rdf:rest [ rdf:type rdf:List ;
-                                                            rdf:first "Master" ;
-                                                            rdf:rest rdf:nil
-                                                          ]
-                                               ]
-                                    ]
-                        ] ;
-             rdfs:comment "Type of the Waybill: House, Direct or Master"@en ;
-             rdfs:label "waybillType"@en ;
-             owl:comment "Possible RDF good practice IRI: :isOfWaybillType "@en .
-
-
-###  https://onerecord.iata.org/ns/cargo#weightValuationIndicator
-:weightValuationIndicator rdf:type owl:DatatypeProperty ;
-                          rdfs:domain :Waybill ;
-                          rdfs:range [ rdf:type rdfs:Datatype ;
-                                       owl:oneOf [ rdf:type rdf:List ;
-                                                   rdf:first "C" ;
-                                                   rdf:rest [ rdf:type rdf:List ;
-                                                              rdf:first "P" ;
-                                                              rdf:rest rdf:nil
-                                                            ]
-                                                 ]
-                                     ] ;
-                          rdfs:comment "payment for the Weight/Valuation will be made at origin (prepaid) or at destination (collect)"@en ;
-                          rdfs:label "weightValuationIndicator"@en ;
-                          owl:comment "Possible RDF good practice IRI: :hasWeightValuation "@en .
-
-
 #################################################################
 #    Classes
 #################################################################
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#AircraftPossibilityCode
+ccodes:AircraftPossibilityCode rdf:type owl:Class ;
+                               rdfs:subClassOf :CodeListElement .
+
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#BasicRateClassCode
+ccodes:BasicRateClassCode rdf:type owl:Class ;
+                          rdfs:subClassOf :CodeListElement .
+
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#ChargeCode
+ccodes:ChargeCode rdf:type owl:Class ;
+                  rdfs:subClassOf :CodeListElement .
+
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#ChargeIdentifier
+ccodes:ChargeIdentifier rdf:type owl:Class ;
+                        rdfs:subClassOf :CodeListElement .
+
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#DangerousGoodsCode
+ccodes:DangerousGoodsCode rdfs:subClassOf :CodeListElement .
+
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#EntitlementCode
+ccodes:EntitlementCode rdf:type owl:Class ;
+                       rdfs:subClassOf :CodeListElement .
+
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#MovementIndicator
+ccodes:MovementIndicator rdf:type owl:Class ;
+                         rdfs:subClassOf :CodeListElement .
+
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#OtherChargeCode
+ccodes:OtherChargeCode rdf:type owl:Class ;
+                       rdfs:subClassOf :CodeListElement .
+
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#ParticipantIdentifier
+ccodes:ParticipantIdentifier rdf:type owl:Class ;
+                             rdfs:subClassOf :CodeListElement .
+
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#PrepaidCollectIndicator
+ccodes:PrepaidCollectIndicator rdf:type owl:Class ;
+                               rdfs:subClassOf :CodeListElement .
+
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#RateClassCode
+ccodes:RateClassCode rdf:type owl:Class ;
+                     rdfs:subClassOf :CodeListElement .
+
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#RegulatedEntityCategoryCode
+ccodes:RegulatedEntityCategoryCode rdfs:subClassOf :CodeListElement .
+
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#ScreeningExemption
+ccodes:ScreeningExemption rdf:type owl:Class ;
+                          rdfs:subClassOf :CodeListElement .
+
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#ScreeningMethod
+ccodes:ScreeningMethod rdf:type owl:Class ;
+                       rdfs:subClassOf :CodeListElement .
+
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#SecurityStatus
+ccodes:SecurityStatus rdf:type owl:Class ;
+                      rdfs:subClassOf :CodeListElement .
+
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#ServiceCode
+ccodes:ServiceCode rdf:type owl:Class ;
+                   rdfs:subClassOf :CodeListElement .
+
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#ShipmentSecurityStatus
+ccodes:ShipmentSecurityStatus rdf:type owl:Class ;
+                              rdfs:subClassOf :CodeListElement .
+
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#SpecialHandlingCode
+ccodes:SpecialHandlingCode rdf:type owl:Class ;
+                           rdfs:subClassOf :CodeListElement .
+
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#StatusCode
+ccodes:StatusCode rdf:type owl:Class ;
+                  rdfs:subClassOf :CodeListElement .
+
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#ULDChargeCode
+ccodes:ULDChargeCode rdf:type owl:Class ;
+                     rdfs:subClassOf :CodeListElement .
+
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#ULDConditionCode
+ccodes:ULDConditionCode rdf:type owl:Class ;
+                        rdfs:subClassOf :CodeListElement .
+
+
+###  <https://onerecord.iata.org/ns/coreCodeLists#ULDLoadingIndicator
+ccodes:ULDLoadingIndicator rdf:type owl:Class ;
+                           rdfs:subClassOf :CodeListElement .
+
+
+###  https://onerecord.iata.org/ns/cargo#ActionTimeType
+:ActionTimeType rdf:type owl:Class ;
+                owl:equivalentClass [ rdf:type owl:Class ;
+                                      owl:oneOf ( :ACTUAL
+                                                  :PLANNED
+                                                  :REQUESTED
+                                                )
+                                    ] ;
+                rdfs:subClassOf :CodeListElement ;
+                rdfs:comment "Restricted code list for acceptable action times"@en ;
+                rdfs:label "ActionTimeType"@en .
+
 
 ###  https://onerecord.iata.org/ns/cargo#ActivitySequence
 :ActivitySequence rdf:type owl:Class ;
@@ -5803,20 +5619,36 @@ Condition: At least one of the three elements (Country Code, Information Identif
 ###  https://onerecord.iata.org/ns/cargo#Address
 :Address rdf:type owl:Class ;
          rdfs:subClassOf [ rdf:type owl:Restriction ;
+                           owl:onProperty :addressCode ;
+                           owl:allValuesFrom :CodeListElement
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :addressCodeType ;
+                           owl:allValuesFrom :CodeListElement
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty :country ;
                            owl:allValuesFrom :Country
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :postalCode ;
+                           owl:allValuesFrom :CodeListElement
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :addressCode ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :addressCodeType ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :country ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty :addressCode ;
-                           owl:allValuesFrom xsd:string
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :addressCodeType ;
-                           owl:allValuesFrom xsd:string
+                           owl:onProperty :postalCode ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :cityCode ;
@@ -5828,10 +5660,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :postOfficeBox ;
-                           owl:allValuesFrom xsd:string
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :postalCode ;
                            owl:allValuesFrom xsd:string
                          ] ,
                          [ rdf:type owl:Restriction ;
@@ -5847,14 +5675,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                            owl:allValuesFrom xsd:string
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty :addressCode ;
-                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :addressCodeType ;
-                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                         ] ,
-                         [ rdf:type owl:Restriction ;
                            owl:onProperty :cityCode ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
@@ -5867,10 +5687,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty :postalCode ;
-                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                         ] ,
-                         [ rdf:type owl:Restriction ;
                            owl:onProperty :regionCode ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
@@ -5880,7 +5696,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
                          ] ;
          rdfs:comment "Address details"@en ;
          rdfs:label "Address"@en ;
-         owl:versionInfo 1.0 .
+         owl:versionInfo 1. .
 
 
 ###  https://onerecord.iata.org/ns/cargo#Adjustments
@@ -6083,7 +5899,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                   owl:onProperty :vatIndicator ;
                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                 ] ;
-                rdfs:comment "In the context of CASS2.0 process, BillingDetails object is used to integrate specific Billing and Settlement data requirements"@en ;
+                rdfs:comment "In the context of CASS2. process, BillingDetails object is used to integrate specific Billing and Settlement data requirements"@en ;
                 rdfs:label "BillingDetails"@en .
 
 
@@ -6150,6 +5966,10 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                  owl:allValuesFrom :Routing
                                ] ,
                                [ rdf:type owl:Restriction ;
+                                 owl:onProperty :shipmentSecurityStatus ;
+                                 owl:allValuesFrom ccodes:ShipmentSecurityStatus
+                               ] ,
+                               [ rdf:type owl:Restriction ;
                                  owl:onProperty :transportMovement ;
                                  owl:allValuesFrom :TransportMovement
                                ] ,
@@ -6186,6 +6006,10 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                ] ,
                                [ rdf:type owl:Restriction ;
+                                 owl:onProperty :shipmentSecurityStatus ;
+                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                               ] ,
+                               [ rdf:type owl:Restriction ;
                                  owl:onProperty :transportMovement ;
                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                ] ,
@@ -6200,10 +6024,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                [ rdf:type owl:Restriction ;
                                  owl:onProperty :requestMatchInd ;
                                  owl:allValuesFrom xsd:boolean
-                               ] ,
-                               [ rdf:type owl:Restriction ;
-                                 owl:onProperty :shipmentSecurityStatus ;
-                                 owl:allValuesFrom xsd:string
                                ] ,
                                [ rdf:type owl:Restriction ;
                                  owl:onProperty :validFrom ;
@@ -6223,10 +6043,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                ] ,
                                [ rdf:type owl:Restriction ;
                                  owl:onProperty :requestMatchInd ;
-                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                               ] ,
-                               [ rdf:type owl:Restriction ;
-                                 owl:onProperty :shipmentSecurityStatus ;
                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                ] ,
                                [ rdf:type owl:Restriction ;
@@ -6269,6 +6085,10 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                         owl:allValuesFrom :Shipment
                                       ] ,
                                       [ rdf:type owl:Restriction ;
+                                        owl:onProperty :shipmentSecurityStatus ;
+                                        owl:allValuesFrom ccodes:ShipmentSecurityStatus
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
                                         owl:onProperty :timePreferences ;
                                         owl:allValuesFrom :BookingTimes
                                       ] ,
@@ -6301,6 +6121,10 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                         owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                       ] ,
                                       [ rdf:type owl:Restriction ;
+                                        owl:onProperty :shipmentSecurityStatus ;
+                                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
                                         owl:onProperty :timePreferences ;
                                         owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                       ] ,
@@ -6325,15 +6149,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                         owl:allValuesFrom xsd:string
                                       ] ,
                                       [ rdf:type owl:Restriction ;
-                                        owl:onProperty :shipmentSecurityStatus ;
-                                        owl:allValuesFrom xsd:string
-                                      ] ,
-                                      [ rdf:type owl:Restriction ;
                                         owl:onProperty :allotment ;
-                                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                                      ] ,
-                                      [ rdf:type owl:Restriction ;
-                                        owl:onProperty :shipmentSecurityStatus ;
                                         owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                       ] ;
                       rdfs:comment "Request object, refers to the Quote request or Booking request "@en ;
@@ -6410,6 +6226,10 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                    owl:allValuesFrom :BookingOptionRequest
                                  ] ,
                                  [ rdf:type owl:Restriction ;
+                                   owl:onProperty :loadType ;
+                                   owl:allValuesFrom :LoadType
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
                                    owl:onProperty :preferredHandling ;
                                    owl:allValuesFrom :HandlingInstructions
                                  ] ,
@@ -6426,6 +6246,10 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                    owl:allValuesFrom :VolumetricWeight
                                  ] ,
                                  [ rdf:type owl:Restriction ;
+                                   owl:onProperty :loadType ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
                                    owl:onProperty :totalDimensions ;
                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                  ] ,
@@ -6442,10 +6266,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                    owl:allValuesFrom xsd:string
                                  ] ,
                                  [ rdf:type owl:Restriction ;
-                                   owl:onProperty :loadType ;
-                                   owl:allValuesFrom xsd:string
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
                                    owl:onProperty :textualHandlingInstructions ;
                                    owl:allValuesFrom xsd:string
                                  ] ,
@@ -6455,10 +6275,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                  ] ,
                                  [ rdf:type owl:Restriction ;
                                    owl:onProperty :goodsDescription ;
-                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty :loadType ;
                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                  ] ,
                                  [ rdf:type owl:Restriction ;
@@ -6618,20 +6434,20 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                   owl:allValuesFrom :BookingOption
                                 ] ,
                                 [ rdf:type owl:Restriction ;
+                                  owl:onProperty :productCode ;
+                                  owl:allValuesFrom :CodeListElement
+                                ] ,
+                                [ rdf:type owl:Restriction ;
                                   owl:onProperty :forBookingOption ;
                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                 ] ,
                                 [ rdf:type owl:Restriction ;
                                   owl:onProperty :productCode ;
-                                  owl:allValuesFrom xsd:string
+                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                 ] ,
                                 [ rdf:type owl:Restriction ;
                                   owl:onProperty :productDescription ;
                                   owl:allValuesFrom xsd:string
-                                ] ,
-                                [ rdf:type owl:Restriction ;
-                                  owl:onProperty :productCode ;
-                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                 ] ,
                                 [ rdf:type owl:Restriction ;
                                   owl:onProperty :productDescription ;
@@ -6669,7 +6485,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                 ] ;
                 rdfs:comment "Product additional details"@en ;
                 rdfs:label "Characteristic"@en ;
-                owl:versionInfo "v3.0 renamed from Characteristics"@en .
+                owl:versionInfo "v3. renamed from Characteristics"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#Check
@@ -6822,6 +6638,60 @@ Condition: At least one of the three elements (Country Code, Information Identif
                   rdfs:label "CheckTotalResult"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#CodeListElement
+:CodeListElement rdf:type owl:Class ;
+                 rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                   owl:onProperty :CodeListReference ;
+                                   owl:allValuesFrom xsd:string
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty :code ;
+                                   owl:allValuesFrom xsd:string
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty :codeDescription ;
+                                   owl:allValuesFrom xsd:string
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty :codeLevel ;
+                                   owl:allValuesFrom xsd:integer
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty :codeListName ;
+                                   owl:allValuesFrom xsd:string
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty :codeListVersion ;
+                                   owl:allValuesFrom xsd:string
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty :CodeListReference ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty :code ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty :codeDescription ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty :codeLevel ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty :codeListName ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty :codeListVersion ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ;
+                 rdfs:comment "Embedded object to transmit codes from non-RDF code lists in 1R in a semi-structured way. Code lists may be externally maintained codes (such as HS codes) or carrier-specific codes. If a code is present in RDF-form as Named Individual (like in the 1R core code lists ontology), it suffices to put in its IRI"@en ;
+                 rdfs:label "CodeListElement"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#CommonObjects
 :CommonObjects rdf:type owl:Class ;
                rdfs:subClassOf [ rdf:type owl:Restriction ;
@@ -6918,38 +6788,50 @@ Condition: At least one of the three elements (Country Code, Information Identif
                              owl:allValuesFrom :Piece
                            ] ,
                            [ rdf:type owl:Restriction ;
+                             owl:onProperty :compositionType ;
+                             owl:allValuesFrom :CompositionType
+                           ] ,
+                           [ rdf:type owl:Restriction ;
                              owl:onProperty :loadingUnit ;
                              owl:allValuesFrom :LoadingUnit
                            ] ,
                            [ rdf:type owl:Restriction ;
-                             owl:onProperty :loadingUnit ;
+                             owl:onProperty :compositionType ;
                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
                            ] ,
                            [ rdf:type owl:Restriction ;
-                             owl:onProperty :compositionType ;
-                             owl:allValuesFrom xsd:string
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty :compositionType ;
+                             owl:onProperty :loadingUnit ;
                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
                            ] ;
            rdfs:comment "Action to describe build-up or break-down of LoadingUnits"@en ;
            rdfs:label "Composing"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#CompositionType
+:CompositionType rdf:type owl:Class ;
+                 owl:equivalentClass [ rdf:type owl:Class ;
+                                       owl:oneOf ( :COMPOSITION
+                                                   :DECOMPOSITION
+                                                 )
+                                     ] ;
+                 rdfs:subClassOf :CodeListElement ;
+                 rdfs:comment "Restricted code list for Composing subtypes"@en ;
+                 rdfs:label "CompositionType"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#ContactDetail
 :ContactDetail rdf:type owl:Class ;
                rdfs:subClassOf [ rdf:type owl:Restriction ;
                                  owl:onProperty :contactDetailType ;
-                                 owl:allValuesFrom xsd:string
-                               ] ,
-                               [ rdf:type owl:Restriction ;
-                                 owl:onProperty :textualValue ;
-                                 owl:allValuesFrom xsd:string
+                                 owl:allValuesFrom :ContactDetailType
                                ] ,
                                [ rdf:type owl:Restriction ;
                                  owl:onProperty :contactDetailType ;
                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :textualValue ;
+                                 owl:allValuesFrom xsd:string
                                ] ,
                                [ rdf:type owl:Restriction ;
                                  owl:onProperty :textualValue ;
@@ -6957,7 +6839,21 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                ] ;
                rdfs:comment "Contact details"@en ;
                rdfs:label "ContactDetail"@en ;
-               owl:versionInfo "v3.0 renamed from Contact"@en .
+               owl:versionInfo "v3. renamed from Contact"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#ContactDetailType
+:ContactDetailType rdf:type owl:Class ;
+                   rdfs:subClassOf :CodeListElement ;
+                   rdfs:comment "Open code list for types of contact details"@en ;
+                   rdfs:label "ContactDetailType"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#ContactRole
+:ContactRole rdf:type owl:Class ;
+             rdfs:subClassOf :CodeListElement ;
+             rdfs:comment "Open code list for roles of a contact"@en ;
+             rdfs:label "ContactRole"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#Country
@@ -6986,16 +6882,28 @@ Condition: At least one of the three elements (Country Code, Information Identif
 :CustomsInformation rdf:type owl:Class ;
                     rdfs:subClassOf :LogisticsObject ,
                                     [ rdf:type owl:Restriction ;
+                                      owl:onProperty :contentCode ;
+                                      owl:allValuesFrom :CodeListElement
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
                                       owl:onProperty :customsInformationOfShipment ;
                                       owl:allValuesFrom :Shipment
                                     ] ,
                                     [ rdf:type owl:Restriction ;
+                                      owl:onProperty :subjectCode ;
+                                      owl:allValuesFrom :CodeListElement
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty :contentCode ;
+                                      owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
                                       owl:onProperty :customsInformationOfShipment ;
                                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                     ] ,
                                     [ rdf:type owl:Restriction ;
-                                      owl:onProperty :contentCode ;
-                                      owl:allValuesFrom xsd:string
+                                      owl:onProperty :subjectCode ;
+                                      owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                     ] ,
                                     [ rdf:type owl:Restriction ;
                                       owl:onProperty :countryCode ;
@@ -7010,14 +6918,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                       owl:allValuesFrom xsd:string
                                     ] ,
                                     [ rdf:type owl:Restriction ;
-                                      owl:onProperty :subjectCode ;
-                                      owl:allValuesFrom xsd:string
-                                    ] ,
-                                    [ rdf:type owl:Restriction ;
-                                      owl:onProperty :contentCode ;
-                                      owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                                    ] ,
-                                    [ rdf:type owl:Restriction ;
                                       owl:onProperty :countryCode ;
                                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                     ] ,
@@ -7027,15 +6927,11 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                     ] ,
                                     [ rdf:type owl:Restriction ;
                                       owl:onProperty :otherCustomsInformation ;
-                                      owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                                    ] ,
-                                    [ rdf:type owl:Restriction ;
-                                      owl:onProperty :subjectCode ;
                                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                     ] ;
                     rdfs:comment "Customs information details"@en ;
                     rdfs:label "CustomsInformation"@en ;
-                    owl:versionInfo "v3.0 renamed from CustomsInfo"@en .
+                    owl:versionInfo "v3. renamed from CustomsInfo"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#DgDeclaration
@@ -7253,6 +7149,19 @@ Condition: At least one of the three elements (Country Code, Information Identif
             rdfs:label "Dimensions"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#DirectionType
+:DirectionType rdf:type owl:Class ;
+               owl:equivalentClass [ rdf:type owl:Class ;
+                                     owl:oneOf ( :INBOUND
+                                                 :OUTBOUND
+                                                 :UNPLANNED_STOP
+                                               )
+                                   ] ;
+               rdfs:subClassOf :CodeListElement ;
+               rdfs:comment "Restricted code list for the direction of a MovementTime"@en ;
+               rdfs:label "DirectionType"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#EmbeddedObject
 :EmbeddedObject rdf:type owl:Class ;
                 rdfs:subClassOf [ rdf:type owl:Restriction ;
@@ -7370,6 +7279,21 @@ Condition: At least one of the three elements (Country Code, Information Identif
                   rdfs:label "EpermitSignature"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#EventTimeType
+:EventTimeType rdf:type owl:Class ;
+               owl:equivalentClass [ rdf:type owl:Class ;
+                                     owl:oneOf ( :ACTUAL
+                                                 :ESTIMATED
+                                                 :EXPECTED
+                                                 :PLANNED
+                                                 :REQUESTED
+                                               )
+                                   ] ;
+               rdfs:subClassOf :CodeListElement ;
+               rdfs:comment "Restricted code list for acceptable event times"@en ;
+               rdfs:label "EventTimeType"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#EventUld
 :EventUld rdf:type owl:Class ;
           rdfs:subClassOf :LogisticsEvent ,
@@ -7384,6 +7308,20 @@ Condition: At least one of the three elements (Country Code, Information Identif
           rdfs:comment "Subtype of Event"@en ;
           rdfs:label "EventUld"@en ;
           owl:deprecated "true"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#ExecutionStatus
+:ExecutionStatus rdf:type owl:Class ;
+                 owl:equivalentClass [ rdf:type owl:Class ;
+                                       owl:oneOf ( :ACTIVE
+                                                   :CANCELLED
+                                                   :COMPLETE
+                                                   :PENDING
+                                                 )
+                                     ] ;
+                 rdfs:subClassOf :CodeListElement ;
+                 rdfs:comment "Restricted code list for the execution status of activities"@en ;
+                 rdfs:label "ExecutionStatus"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#ExternalReference
@@ -7929,6 +7867,20 @@ Condition: At least one of the three elements (Country Code, Information Identif
                     rdfs:label "LiveAnimalsEpermit"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#LoadType
+:LoadType rdf:type owl:Class ;
+          owl:equivalentClass [ rdf:type owl:Class ;
+                                owl:oneOf ( :BULK
+                                            :LOOSE
+                                            :PALLET
+                                            :ULD
+                                          )
+                              ] ;
+          rdfs:subClassOf :CodeListElement ;
+          rdfs:comment "Restricted code list for the Load Type of a piece or shipment"@en ;
+          rdfs:label "LoadType"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#Loading
 :Loading rdf:type owl:Class ;
          rdfs:subClassOf :LogisticsAction ,
@@ -7945,10 +7897,18 @@ Condition: At least one of the three elements (Country Code, Information Identif
                            owl:allValuesFrom :LoadingUnit
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty :loadingType ;
+                           owl:allValuesFrom :LoadingType
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty :onTransportMeans ;
                            owl:allValuesFrom :TransportMeans
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty :loadingType ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty :onTransportMeans ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
@@ -7957,15 +7917,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
                            owl:allValuesFrom xsd:string
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty :loadingType ;
-                           owl:allValuesFrom xsd:string
-                         ] ,
-                         [ rdf:type owl:Restriction ;
                            owl:onProperty :loadingPositionIdentifier ;
-                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :loadingType ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ;
          rdfs:comment "Action to describe onloading or offloading TransportMeans"@en ;
@@ -8043,6 +7995,18 @@ Condition: At least one of the three elements (Country Code, Information Identif
                  rdfs:label "LoadingMaterial"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#LoadingType
+:LoadingType rdf:type owl:Class ;
+             owl:equivalentClass [ rdf:type owl:Class ;
+                                   owl:oneOf ( :LOADING
+                                               :UNLOADING
+                                             )
+                                 ] ;
+             rdfs:subClassOf :CodeListElement ;
+             rdfs:comment "Restricted code list for Loading subtypes"@en ;
+             rdfs:label "LoadingType"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#LoadingUnit
 :LoadingUnit rdf:type owl:Class ;
              rdfs:subClassOf :PhysicalLogisticsObject ,
@@ -8071,15 +8035,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                owl:allValuesFrom xsd:string
                              ] ,
                              [ rdf:type owl:Restriction ;
-                               owl:onProperty :slac ;
-                               owl:allValuesFrom xsd:integer
-                             ] ,
-                             [ rdf:type owl:Restriction ;
                                owl:onProperty :remarks ;
-                               owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                             ] ,
-                             [ rdf:type owl:Restriction ;
-                               owl:onProperty :slac ;
                                owl:maxCardinality "1"^^xsd:nonNegativeInteger
                              ] ;
              rdfs:comment "Common loading unit/container details"@en ;
@@ -8122,7 +8078,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
                           ] ,
                           [ rdf:type owl:Restriction ;
-                            owl:onProperty :code ;
+                            owl:onProperty :locationCode ;
                             owl:allValuesFrom xsd:string
                           ] ,
                           [ rdf:type owl:Restriction ;
@@ -8134,7 +8090,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
                             owl:allValuesFrom xsd:string
                           ] ,
                           [ rdf:type owl:Restriction ;
-                            owl:onProperty :code ;
+                            owl:onProperty :locationCode ;
                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
                           ] ,
                           [ rdf:type owl:Restriction ;
@@ -8153,12 +8109,20 @@ Condition: At least one of the three elements (Country Code, Information Identif
 :LogisticsAction rdf:type owl:Class ;
                  rdfs:subClassOf :LogisticsObject ,
                                  [ rdf:type owl:Restriction ;
+                                   owl:onProperty :actionTimeType ;
+                                   owl:allValuesFrom :ActionTimeType
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
                                    owl:onProperty :contactDetails ;
                                    owl:allValuesFrom :ContactDetail
                                  ] ,
                                  [ rdf:type owl:Restriction ;
                                    owl:onProperty :contactPersons ;
                                    owl:allValuesFrom :Person
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty :otherIdentifiers ;
+                                   owl:allValuesFrom :OtherIdentifier
                                  ] ,
                                  [ rdf:type owl:Restriction ;
                                    owl:onProperty :performedAt ;
@@ -8169,6 +8133,10 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                    owl:allValuesFrom :LogisticsActivity
                                  ] ,
                                  [ rdf:type owl:Restriction ;
+                                   owl:onProperty :actionTimeType ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
                                    owl:onProperty :performedAt ;
                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                  ] ,
@@ -8185,19 +8153,11 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                    owl:allValuesFrom xsd:dateTime
                                  ] ,
                                  [ rdf:type owl:Restriction ;
-                                   owl:onProperty :actionTimeType ;
-                                   owl:allValuesFrom xsd:string
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
                                    owl:onProperty :actionEndTime ;
                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                  ] ,
                                  [ rdf:type owl:Restriction ;
                                    owl:onProperty :actionStartTime ;
-                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty :actionTimeType ;
                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                  ] ;
                  rdfs:comment "Superclass: LogisticsAction is a specific task with a specific result performed on one or more physical LOs by one party in the context of an Activity"@en ;
@@ -8220,12 +8180,12 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                      owl:allValuesFrom :Person
                                    ] ,
                                    [ rdf:type owl:Restriction ;
-                                     owl:onProperty :servedServices ;
-                                     owl:allValuesFrom :LogisticsService
+                                     owl:onProperty :executionStatus ;
+                                     owl:allValuesFrom :ExecutionStatus
                                    ] ,
                                    [ rdf:type owl:Restriction ;
-                                     owl:onProperty :executionStatus ;
-                                     owl:allValuesFrom xsd:string
+                                     owl:onProperty :servedServices ;
+                                     owl:allValuesFrom :LogisticsService
                                    ] ,
                                    [ rdf:type owl:Restriction ;
                                      owl:onProperty :executionStatus ;
@@ -8245,6 +8205,14 @@ Condition: At least one of the three elements (Country Code, Information Identif
 ###  https://onerecord.iata.org/ns/cargo#LogisticsEvent
 :LogisticsEvent rdf:type owl:Class ;
                 rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                  owl:onProperty :eventCode ;
+                                  owl:allValuesFrom :CodeListElement
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty :eventTimeType ;
+                                  owl:allValuesFrom :EventTimeType
+                                ] ,
+                                [ rdf:type owl:Restriction ;
                                   owl:onProperty :externalReferences ;
                                   owl:allValuesFrom :ExternalReference
                                 ] ,
@@ -8265,6 +8233,14 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                   owl:allValuesFrom :Actor
                                 ] ,
                                 [ rdf:type owl:Restriction ;
+                                  owl:onProperty :eventCode ;
+                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty :eventTimeType ;
+                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                ] ,
+                                [ rdf:type owl:Restriction ;
                                   owl:onProperty :linkedObject ;
                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                 ] ,
@@ -8285,10 +8261,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                   owl:allValuesFrom xsd:dateTime
                                 ] ,
                                 [ rdf:type owl:Restriction ;
-                                  owl:onProperty :eventCode ;
-                                  owl:allValuesFrom xsd:string
-                                ] ,
-                                [ rdf:type owl:Restriction ;
                                   owl:onProperty :eventDate ;
                                   owl:allValuesFrom xsd:dateTime
                                 ] ,
@@ -8297,15 +8269,11 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                   owl:allValuesFrom xsd:string
                                 ] ,
                                 [ rdf:type owl:Restriction ;
-                                  owl:onProperty :eventTimeType ;
-                                  owl:allValuesFrom xsd:string
+                                  owl:onProperty :partialEventIndicator ;
+                                  owl:allValuesFrom xsd:boolean
                                 ] ,
                                 [ rdf:type owl:Restriction ;
                                   owl:onProperty :creationDate ;
-                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                                ] ,
-                                [ rdf:type owl:Restriction ;
-                                  owl:onProperty :eventCode ;
                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                 ] ,
                                 [ rdf:type owl:Restriction ;
@@ -8317,12 +8285,12 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                 ] ,
                                 [ rdf:type owl:Restriction ;
-                                  owl:onProperty :eventTimeType ;
+                                  owl:onProperty :partialEventIndicator ;
                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                 ] ;
                 rdfs:comment "Event details"@en ;
                 rdfs:label "LogisticsEvent"@en ;
-                owl:versionInfo "v3.0 renamed from Event"@en .
+                owl:versionInfo "v3. renamed from Event"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#LogisticsObject
@@ -8406,7 +8374,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
                              ] ;
              rdfs:comment "Measurements details for Sensors, either generic or geolocation measurements are recorded"@en ;
              rdfs:label "Measurement"@en ;
-             owl:versionInfo "v3.0 renamed from Measurements"@en .
+             owl:versionInfo "v3. renamed from Measurements"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#MeasurementsGeoloc
@@ -8433,23 +8401,32 @@ Condition: At least one of the three elements (Country Code, Information Identif
                    owl:deprecated "true"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#ModeQualifier
+:ModeQualifier rdf:type owl:Class ;
+               owl:equivalentClass [ rdf:type owl:Class ;
+                                     owl:oneOf ( :MAIN_CARRIAGE
+                                                 :ON_CARRIAGE
+                                                 :PRE_CARRIAGE
+                                               )
+                                   ] ;
+               rdfs:subClassOf :CodeListElement ;
+               rdfs:comment "Open code list for transport modes"@en ;
+               rdfs:label "ModeQualifier"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#MovementTime
 :MovementTime rdf:type owl:Class ;
               rdfs:subClassOf [ rdf:type owl:Restriction ;
                                 owl:onProperty :direction ;
-                                owl:allValuesFrom xsd:string
+                                owl:allValuesFrom :DirectionType
                               ] ,
                               [ rdf:type owl:Restriction ;
                                 owl:onProperty :movementMilestone ;
-                                owl:allValuesFrom xsd:string
+                                owl:allValuesFrom ccodes:MovementIndicator
                               ] ,
                               [ rdf:type owl:Restriction ;
                                 owl:onProperty :movementTimeType ;
-                                owl:allValuesFrom xsd:string
-                              ] ,
-                              [ rdf:type owl:Restriction ;
-                                owl:onProperty :movementTimestamp ;
-                                owl:allValuesFrom xsd:dateTime
+                                owl:allValuesFrom :MovementTimeType
                               ] ,
                               [ rdf:type owl:Restriction ;
                                 owl:onProperty :direction ;
@@ -8462,6 +8439,10 @@ Condition: At least one of the three elements (Country Code, Information Identif
                               [ rdf:type owl:Restriction ;
                                 owl:onProperty :movementTimeType ;
                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty :movementTimestamp ;
+                                owl:allValuesFrom xsd:dateTime
                               ] ,
                               [ rdf:type owl:Restriction ;
                                 owl:onProperty :movementTimestamp ;
@@ -8469,6 +8450,19 @@ Condition: At least one of the three elements (Country Code, Information Identif
                               ] ;
               rdfs:comment "Times refering to Transport Movements, used to describe specfic times such as Actual Departure time, etc."@en ;
               rdfs:label "MovementTime"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#MovementTimeType
+:MovementTimeType rdf:type owl:Class ;
+                  owl:equivalentClass [ rdf:type owl:Class ;
+                                        owl:oneOf ( :ACTUAL
+                                                    :ESTIMATED
+                                                    :SCHEDULED
+                                                  )
+                                      ] ;
+                  rdfs:subClassOf :CodeListElement ;
+                  rdfs:comment "Restricted code list for MovementTime subtypes"@en ;
+                  rdfs:label "MovementTimeType"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#Moving
@@ -8548,24 +8542,20 @@ Condition: At least one of the three elements (Country Code, Information Identif
 ###  https://onerecord.iata.org/ns/cargo#OtherCharge
 :OtherCharge rdf:type owl:Class ;
              rdfs:subClassOf [ rdf:type owl:Restriction ;
+                               owl:onProperty :chargePaymentType ;
+                               owl:allValuesFrom ccodes:PrepaidCollectIndicator
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty :entitlement ;
+                               owl:allValuesFrom ccodes:EntitlementCode
+                             ] ,
+                             [ rdf:type owl:Restriction ;
                                owl:onProperty :otherChargeAmount ;
                                owl:allValuesFrom :Value
                              ] ,
                              [ rdf:type owl:Restriction ;
-                               owl:onProperty :otherChargeAmount ;
-                               owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                             ] ,
-                             [ rdf:type owl:Restriction ;
-                               owl:onProperty :chargePaymentType ;
-                               owl:allValuesFrom xsd:string
-                             ] ,
-                             [ rdf:type owl:Restriction ;
-                               owl:onProperty :entitlement ;
-                               owl:allValuesFrom xsd:string
-                             ] ,
-                             [ rdf:type owl:Restriction ;
                                owl:onProperty :otherChargeCode ;
-                               owl:allValuesFrom xsd:string
+                               owl:allValuesFrom ccodes:OtherChargeCode
                              ] ,
                              [ rdf:type owl:Restriction ;
                                owl:onProperty :chargePaymentType ;
@@ -8573,13 +8563,17 @@ Condition: At least one of the three elements (Country Code, Information Identif
                              ] ,
                              [ rdf:type owl:Restriction ;
                                owl:onProperty :entitlement ;
+                               owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty :otherChargeAmount ;
                                owl:maxCardinality "1"^^xsd:nonNegativeInteger
                              ] ,
                              [ rdf:type owl:Restriction ;
                                owl:onProperty :otherChargeCode ;
                                owl:maxCardinality "1"^^xsd:nonNegativeInteger
                              ] ;
-             rdfs:comment "PENDING"@en ;
+             rdfs:comment "Other Charge details from AWB as per bullet point 19 - data element 23 from AWB"@en ;
              rdfs:label "OtherCharge"@en .
 
 
@@ -8647,16 +8641,16 @@ Condition: At least one of the three elements (Country Code, Information Identif
                          owl:allValuesFrom :Company
                        ] ,
                        [ rdf:type owl:Restriction ;
+                         owl:onProperty :role ;
+                         owl:allValuesFrom ccodes:ParticipantIdentifier
+                       ] ,
+                       [ rdf:type owl:Restriction ;
                          owl:onProperty :organization ;
                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
                        ] ,
                        [ rdf:type owl:Restriction ;
                          owl:onProperty :partyDetails ;
                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                       ] ,
-                       [ rdf:type owl:Restriction ;
-                         owl:onProperty :role ;
-                         owl:allValuesFrom xsd:string
                        ] ,
                        [ rdf:type owl:Restriction ;
                          owl:onProperty :role ;
@@ -8678,6 +8672,10 @@ Condition: At least one of the three elements (Country Code, Information Identif
                           owl:allValuesFrom :ContactDetail
                         ] ,
                         [ rdf:type owl:Restriction ;
+                          owl:onProperty :contactRole ;
+                          owl:allValuesFrom :ContactRole
+                        ] ,
+                        [ rdf:type owl:Restriction ;
                           owl:onProperty :documents ;
                           owl:allValuesFrom :ExternalReference
                         ] ,
@@ -8687,7 +8685,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
                         ] ,
                         [ rdf:type owl:Restriction ;
                           owl:onProperty :contactRole ;
-                          owl:allValuesFrom xsd:string
+                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
                         ] ,
                         [ rdf:type owl:Restriction ;
                           owl:onProperty :department ;
@@ -8716,10 +8714,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                         [ rdf:type owl:Restriction ;
                           owl:onProperty :salutation ;
                           owl:allValuesFrom xsd:string
-                        ] ,
-                        [ rdf:type owl:Restriction ;
-                          owl:onProperty :contactRole ;
-                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
                         ] ,
                         [ rdf:type owl:Restriction ;
                           owl:onProperty :department ;
@@ -8808,6 +8802,10 @@ Condition: At least one of the three elements (Country Code, Information Identif
                          owl:allValuesFrom :Party
                        ] ,
                        [ rdf:type owl:Restriction ;
+                         owl:onProperty :loadType ;
+                         owl:allValuesFrom :LoadType
+                       ] ,
+                       [ rdf:type owl:Restriction ;
                          owl:onProperty :otherIdentifiers ;
                          owl:allValuesFrom :OtherIdentifier
                        ] ,
@@ -8822,6 +8820,10 @@ Condition: At least one of the three elements (Country Code, Information Identif
                        [ rdf:type owl:Restriction ;
                          owl:onProperty :securityDeclaration ;
                          owl:allValuesFrom :SecurityDeclaration
+                       ] ,
+                       [ rdf:type owl:Restriction ;
+                         owl:onProperty :specialHandlingCodes ;
+                         owl:allValuesFrom ccodes:SpecialHandlingCode
                        ] ,
                        [ rdf:type owl:Restriction ;
                          owl:onProperty :uldReference ;
@@ -8845,6 +8847,10 @@ Condition: At least one of the three elements (Country Code, Information Identif
                        ] ,
                        [ rdf:type owl:Restriction ;
                          owl:onProperty :grossWeight ;
+                         owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                       ] ,
+                       [ rdf:type owl:Restriction ;
+                         owl:onProperty :loadType ;
                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
                        ] ,
                        [ rdf:type owl:Restriction ;
@@ -8877,10 +8883,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                        ] ,
                        [ rdf:type owl:Restriction ;
                          owl:onProperty :goodsDescription ;
-                         owl:allValuesFrom xsd:string
-                       ] ,
-                       [ rdf:type owl:Restriction ;
-                         owl:onProperty :loadType ;
                          owl:allValuesFrom xsd:string
                        ] ,
                        [ rdf:type owl:Restriction ;
@@ -8908,10 +8910,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                          owl:allValuesFrom xsd:integer
                        ] ,
                        [ rdf:type owl:Restriction ;
-                         owl:onProperty :specialHandlingCodes ;
-                         owl:allValuesFrom xsd:string
-                       ] ,
-                       [ rdf:type owl:Restriction ;
                          owl:onProperty :stackable ;
                          owl:allValuesFrom xsd:boolean
                        ] ,
@@ -8937,10 +8935,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                        ] ,
                        [ rdf:type owl:Restriction ;
                          owl:onProperty :goodsDescription ;
-                         owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                       ] ,
-                       [ rdf:type owl:Restriction ;
-                         owl:onProperty :loadType ;
                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
                        ] ,
                        [ rdf:type owl:Restriction ;
@@ -8977,7 +8971,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
                        ] ;
        rdfs:comment "Individual piece or virtual grouping of pieces"@en ;
        rdfs:label "Piece"@en ;
-       owl:versionInfo "v1.01 - piece:dgDeclaration annoted as deprecated"@en .
+       owl:versionInfo "v1.1 - piece:dgDeclaration annoted as deprecated"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#PieceDg
@@ -9170,6 +9164,10 @@ Condition: At least one of the three elements (Country Code, Information Identif
 :Price rdf:type owl:Class ;
        rdfs:subClassOf :LogisticsObject ,
                        [ rdf:type owl:Restriction ;
+                         owl:onProperty :carrierChargeCode ;
+                         owl:allValuesFrom ccodes:ChargeCode
+                       ] ,
+                       [ rdf:type owl:Restriction ;
                          owl:onProperty :forBookingOption ;
                          owl:allValuesFrom :BookingOption
                        ] ,
@@ -9182,6 +9180,10 @@ Condition: At least one of the three elements (Country Code, Information Identif
                          owl:allValuesFrom :Ratings
                        ] ,
                        [ rdf:type owl:Restriction ;
+                         owl:onProperty :carrierChargeCode ;
+                         owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                       ] ,
+                       [ rdf:type owl:Restriction ;
                          owl:onProperty :forBookingOption ;
                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
                        ] ,
@@ -9190,20 +9192,12 @@ Condition: At least one of the three elements (Country Code, Information Identif
                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
                        ] ,
                        [ rdf:type owl:Restriction ;
-                         owl:onProperty :carrierChargeCode ;
-                         owl:allValuesFrom xsd:string
-                       ] ,
-                       [ rdf:type owl:Restriction ;
                          owl:onProperty :grandTotal ;
                          owl:allValuesFrom xsd:double
                        ] ,
                        [ rdf:type owl:Restriction ;
                          owl:onProperty :validUntil ;
                          owl:allValuesFrom xsd:dateTime
-                       ] ,
-                       [ rdf:type owl:Restriction ;
-                         owl:onProperty :carrierChargeCode ;
-                         owl:maxCardinality "1"^^xsd:nonNegativeInteger
                        ] ,
                        [ rdf:type owl:Restriction ;
                          owl:onProperty :grandTotal ;
@@ -9225,6 +9219,10 @@ Condition: At least one of the three elements (Country Code, Information Identif
                            owl:allValuesFrom :Item
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty :hsCode ;
+                           owl:allValuesFrom :CodeListElement
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty :manufacturer ;
                            owl:allValuesFrom :Company
                          ] ,
@@ -9237,6 +9235,10 @@ Condition: At least one of the three elements (Country Code, Information Identif
                            owl:allValuesFrom :OtherIdentifier
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty :hsCode ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty :manufacturer ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
@@ -9246,10 +9248,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :description ;
-                           owl:allValuesFrom xsd:string
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :hsCode ;
                            owl:allValuesFrom xsd:string
                          ] ,
                          [ rdf:type owl:Restriction ;
@@ -9274,10 +9272,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :description ;
-                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :hsCode ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
@@ -9476,6 +9470,22 @@ Condition: At least one of the three elements (Country Code, Information Identif
 ###  https://onerecord.iata.org/ns/cargo#Ranges
 :Ranges rdf:type owl:Class ;
         rdfs:subClassOf [ rdf:type owl:Restriction ;
+                          owl:onProperty :rateClassCode ;
+                          owl:allValuesFrom ccodes:RateClassCode
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty :ratingType ;
+                          owl:allValuesFrom ccodes:ULDChargeCode
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty :rateClassCode ;
+                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty :ratingType ;
+                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                        ] ,
+                        [ rdf:type owl:Restriction ;
                           owl:onProperty :amount ;
                           owl:allValuesFrom xsd:double
                         ] ,
@@ -9486,14 +9496,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                         [ rdf:type owl:Restriction ;
                           owl:onProperty :minimumQuantity ;
                           owl:allValuesFrom xsd:double
-                        ] ,
-                        [ rdf:type owl:Restriction ;
-                          owl:onProperty :rateClassCode ;
-                          owl:allValuesFrom xsd:string
-                        ] ,
-                        [ rdf:type owl:Restriction ;
-                          owl:onProperty :ratingType ;
-                          owl:allValuesFrom xsd:string
                         ] ,
                         [ rdf:type owl:Restriction ;
                           owl:onProperty :scr ;
@@ -9513,14 +9515,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                         ] ,
                         [ rdf:type owl:Restriction ;
                           owl:onProperty :minimumQuantity ;
-                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                        ] ,
-                        [ rdf:type owl:Restriction ;
-                          owl:onProperty :rateClassCode ;
-                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                        ] ,
-                        [ rdf:type owl:Restriction ;
-                          owl:onProperty :ratingType ;
                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
                         ] ,
                         [ rdf:type owl:Restriction ;
@@ -9539,8 +9533,32 @@ Condition: At least one of the three elements (Country Code, Information Identif
 :Ratings rdf:type owl:Class ;
          rdfs:subClassOf :LogisticsObject ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty :billingChargeIdentifier ;
+                           owl:allValuesFrom ccodes:ChargeIdentifier
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :chargeCode ;
+                           owl:allValuesFrom ccodes:ChargeCode
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :chargePaymentType ;
+                           owl:allValuesFrom ccodes:PrepaidCollectIndicator
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :chargeType ;
+                           owl:allValuesFrom ccodes:ChargeIdentifier
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :entitlement ;
+                           owl:allValuesFrom ccodes:EntitlementCode
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty :forPrices ;
                            owl:allValuesFrom :Price
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :otherChargeCode ;
+                           owl:allValuesFrom ccodes:OtherChargeCode
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :preferenceOfRequests ;
@@ -9552,30 +9570,30 @@ Condition: At least one of the three elements (Country Code, Information Identif
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :billingChargeIdentifier ;
-                           owl:allValuesFrom xsd:double
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :chargeCode ;
-                           owl:allValuesFrom xsd:string
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :chargeDescription ;
-                           owl:allValuesFrom xsd:string
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :chargePaymentType ;
-                           owl:allValuesFrom xsd:string
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :chargeType ;
-                           owl:allValuesFrom xsd:string
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :entitlement ;
-                           owl:allValuesFrom xsd:string
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :otherChargeCode ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :chargeDescription ;
                            owl:allValuesFrom xsd:string
                          ] ,
                          [ rdf:type owl:Restriction ;
@@ -9603,31 +9621,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
                            owl:allValuesFrom xsd:double
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty :billingChargeIdentifier ;
-                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :chargeCode ;
-                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                         ] ,
-                         [ rdf:type owl:Restriction ;
                            owl:onProperty :chargeDescription ;
-                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :chargePaymentType ;
-                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :chargeType ;
-                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :entitlement ;
-                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :otherChargeCode ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
@@ -9673,6 +9667,10 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                    owl:allValuesFrom :Organization
                                  ] ,
                                  [ rdf:type owl:Restriction ;
+                                   owl:onProperty :regulatedEntityCategory ;
+                                   owl:allValuesFrom ccodes:RegulatedEntityCategoryCode
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
                                    owl:onProperty :entity ;
                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                  ] ,
@@ -9685,16 +9683,12 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                  ] ,
                                  [ rdf:type owl:Restriction ;
-                                   owl:onProperty :category ;
-                                   owl:allValuesFrom xsd:string
+                                   owl:onProperty :regulatedEntityCategory ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                  ] ,
                                  [ rdf:type owl:Restriction ;
                                    owl:onProperty :regulatedEntityExpiryDate ;
                                    owl:allValuesFrom xsd:dateTime
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty :category ;
-                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                  ] ,
                                  [ rdf:type owl:Restriction ;
                                    owl:onProperty :regulatedEntityExpiryDate ;
@@ -9707,6 +9701,10 @@ Condition: At least one of the three elements (Country Code, Information Identif
 ###  https://onerecord.iata.org/ns/cargo#Routing
 :Routing rdf:type owl:Class ;
          rdfs:subClassOf :LogisticsObject ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :aircraftPossibilityCode ;
+                           owl:allValuesFrom ccodes:AircraftPossibilityCode
+                         ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :excludedViaPoints ;
                            owl:allValuesFrom :Location
@@ -9724,16 +9722,16 @@ Condition: At least one of the three elements (Country Code, Information Identif
                            owl:allValuesFrom :ScheduledLegs
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty :aircraftPossibilityCode ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty :forBookingOption ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :forBookingOptionRequest ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :aircraftPossibilityCode ;
-                           owl:allValuesFrom xsd:string
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :latestArrivalDateTime ;
@@ -9750,10 +9748,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :rfsInd ;
                            owl:allValuesFrom xsd:boolean
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :aircraftPossibilityCode ;
-                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :latestArrivalDateTime ;
@@ -9833,6 +9827,10 @@ Condition: At least one of the three elements (Country Code, Information Identif
 :SecurityDeclaration rdf:type owl:Class ;
                      rdfs:subClassOf :LogisticsObject ,
                                      [ rdf:type owl:Restriction ;
+                                       owl:onProperty :groundsForExemption ;
+                                       owl:allValuesFrom ccodes:ScreeningExemption
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
                                        owl:onProperty :issuedBy ;
                                        owl:allValuesFrom :Person
                                      ] ,
@@ -9853,6 +9851,14 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                        owl:allValuesFrom :RegulatedEntity
                                      ] ,
                                      [ rdf:type owl:Restriction ;
+                                       owl:onProperty :screeningMethods ;
+                                       owl:allValuesFrom ccodes:ScreeningMethod
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty :securityStatus ;
+                                       owl:allValuesFrom ccodes:SecurityStatus
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
                                        owl:onProperty :issuedBy ;
                                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                      ] ,
@@ -9869,11 +9875,11 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                      ] ,
                                      [ rdf:type owl:Restriction ;
-                                       owl:onProperty :additionalSecurityInformation ;
-                                       owl:allValuesFrom xsd:string
+                                       owl:onProperty :securityStatus ;
+                                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                      ] ,
                                      [ rdf:type owl:Restriction ;
-                                       owl:onProperty :groundsForExemption ;
+                                       owl:onProperty :additionalSecurityInformation ;
                                        owl:allValuesFrom xsd:string
                                      ] ,
                                      [ rdf:type owl:Restriction ;
@@ -9885,23 +9891,11 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                        owl:allValuesFrom xsd:string
                                      ] ,
                                      [ rdf:type owl:Restriction ;
-                                       owl:onProperty :screeningMethods ;
-                                       owl:allValuesFrom xsd:string
-                                     ] ,
-                                     [ rdf:type owl:Restriction ;
-                                       owl:onProperty :securityStatus ;
-                                       owl:allValuesFrom xsd:string
-                                     ] ,
-                                     [ rdf:type owl:Restriction ;
                                        owl:onProperty :additionalSecurityInformation ;
                                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                      ] ,
                                      [ rdf:type owl:Restriction ;
                                        owl:onProperty :issuedOn ;
-                                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                                     ] ,
-                                     [ rdf:type owl:Restriction ;
-                                       owl:onProperty :securityStatus ;
                                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                      ] ;
                      rdfs:comment "Security declaration details"@en ;
@@ -9920,7 +9914,15 @@ Condition: At least one of the three elements (Country Code, Information Identif
                           owl:allValuesFrom :IotDevice
                         ] ,
                         [ rdf:type owl:Restriction ;
+                          owl:onProperty :sensorType ;
+                          owl:allValuesFrom :SensorType
+                        ] ,
+                        [ rdf:type owl:Restriction ;
                           owl:onProperty :partOfIotDevice ;
+                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty :sensorType ;
                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
                         ] ,
                         [ rdf:type owl:Restriction ;
@@ -9929,10 +9931,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                         ] ,
                         [ rdf:type owl:Restriction ;
                           owl:onProperty :name ;
-                          owl:allValuesFrom xsd:string
-                        ] ,
-                        [ rdf:type owl:Restriction ;
-                          owl:onProperty :sensorType ;
                           owl:allValuesFrom xsd:string
                         ] ,
                         [ rdf:type owl:Restriction ;
@@ -9945,10 +9943,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                         ] ,
                         [ rdf:type owl:Restriction ;
                           owl:onProperty :name ;
-                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                        ] ,
-                        [ rdf:type owl:Restriction ;
-                          owl:onProperty :sensorType ;
                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
                         ] ,
                         [ rdf:type owl:Restriction ;
@@ -9983,6 +9977,13 @@ Condition: At least one of the three elements (Country Code, Information Identif
              owl:deprecated "true"@en .
 
 
+###  https://onerecord.iata.org/ns/cargo#SensorType
+:SensorType rdf:type owl:Class ;
+            rdfs:subClassOf :CodeListElement ;
+            rdfs:comment "Open code list for sensor types"@en ;
+            rdfs:label "SensorType"@en .
+
+
 ###  https://onerecord.iata.org/ns/cargo#Shipment
 :Shipment rdf:type owl:Class ;
           rdfs:subClassOf :LogisticsObject ,
@@ -10005,6 +10006,10 @@ Condition: At least one of the three elements (Country Code, Information Identif
                           [ rdf:type owl:Restriction ;
                             owl:onProperty :shipmentOfPieces ;
                             owl:allValuesFrom :Piece
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty :specialHandlingCodes ;
+                            owl:allValuesFrom ccodes:SpecialHandlingCode
                           ] ,
                           [ rdf:type owl:Restriction ;
                             owl:onProperty :totalDimensions ;
@@ -10052,10 +10057,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                           ] ,
                           [ rdf:type owl:Restriction ;
                             owl:onProperty :incoterms ;
-                            owl:allValuesFrom xsd:string
-                          ] ,
-                          [ rdf:type owl:Restriction ;
-                            owl:onProperty :specialHandlingCodes ;
                             owl:allValuesFrom xsd:string
                           ] ,
                           [ rdf:type owl:Restriction ;
@@ -10113,23 +10114,35 @@ Condition: At least one of the three elements (Country Code, Information Identif
                            owl:allValuesFrom :PhysicalLogisticsObject
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty :storagePlaceIdentifier ;
-                           owl:allValuesFrom xsd:string
+                           owl:onProperty :storingType ;
+                           owl:allValuesFrom :StoringType
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :storingType ;
-                           owl:allValuesFrom xsd:string
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :storagePlaceIdentifier ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty :storingType ;
+                           owl:onProperty :storagePlaceIdentifier ;
+                           owl:allValuesFrom xsd:string
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :storagePlaceIdentifier ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ;
          rdfs:comment "Action to describe store-in or store-out"@en ;
          rdfs:label "Storing"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#StoringType
+:StoringType rdf:type owl:Class ;
+             owl:equivalentClass [ rdf:type owl:Class ;
+                                   owl:oneOf ( :STORE_IN
+                                               :STORE_OUT
+                                             )
+                                 ] ;
+             rdfs:subClassOf :CodeListElement ;
+             rdfs:comment "Restricted code list for Storing subtypes"@en ;
+             rdfs:label "StoringType"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#TACTRateDescription
@@ -10147,6 +10160,14 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                        owl:allValuesFrom :Value
                                      ] ,
                                      [ rdf:type owl:Restriction ;
+                                       owl:onProperty :rateClassCode ;
+                                       owl:allValuesFrom ccodes:RateClassCode
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty :rateClassCodeBasic ;
+                                       owl:allValuesFrom ccodes:BasicRateClassCode
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
                                        owl:onProperty :ratePercentage ;
                                        owl:allValuesFrom :Value
                                      ] ,
@@ -10167,6 +10188,14 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                      ] ,
                                      [ rdf:type owl:Restriction ;
+                                       owl:onProperty :rateClassCode ;
+                                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty :rateClassCodeBasic ;
+                                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
                                        owl:onProperty :ratePercentage ;
                                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                      ] ,
@@ -10183,14 +10212,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                        owl:allValuesFrom xsd:integer
                                      ] ,
                                      [ rdf:type owl:Restriction ;
-                                       owl:onProperty :rateClassCode ;
-                                       owl:allValuesFrom xsd:string
-                                     ] ,
-                                     [ rdf:type owl:Restriction ;
-                                       owl:onProperty :rateClassCodeBasic ;
-                                       owl:allValuesFrom xsd:string
-                                     ] ,
-                                     [ rdf:type owl:Restriction ;
                                        owl:onProperty :rcp ;
                                        owl:allValuesFrom xsd:string
                                      ] ,
@@ -10207,14 +10228,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                      ] ,
                                      [ rdf:type owl:Restriction ;
-                                       owl:onProperty :rateClassCode ;
-                                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                                     ] ,
-                                     [ rdf:type owl:Restriction ;
-                                       owl:onProperty :rateClassCodeBasic ;
-                                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                                     ] ,
-                                     [ rdf:type owl:Restriction ;
                                        owl:onProperty :rcp ;
                                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                      ] ,
@@ -10222,7 +10235,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                        owl:onProperty :uldRateClassType ;
                                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                      ] ;
-                     rdfs:comment "PENDING"@en ;
+                     rdfs:comment "Information from AWB Rate Description section as per bullet point 18 - data elements 22A - 22Z from AWB"@en ;
                      rdfs:label "TACTRateDescription"@en .
 
 
@@ -10233,6 +10246,14 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                owl:allValuesFrom :Value
                              ] ,
                              [ rdf:type owl:Restriction ;
+                               owl:onProperty :chargePaymentType ;
+                               owl:allValuesFrom ccodes:PrepaidCollectIndicator
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty :chargeType ;
+                               owl:allValuesFrom ccodes:ChargeIdentifier
+                             ] ,
+                             [ rdf:type owl:Restriction ;
                                owl:onProperty :chargesAtDestination ;
                                owl:allValuesFrom :Value
                              ] ,
@@ -10253,6 +10274,14 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                owl:maxCardinality "1"^^xsd:nonNegativeInteger
                              ] ,
                              [ rdf:type owl:Restriction ;
+                               owl:onProperty :chargePaymentType ;
+                               owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty :chargeType ;
+                               owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                             ] ,
+                             [ rdf:type owl:Restriction ;
                                owl:onProperty :chargesAtDestination ;
                                owl:maxCardinality "1"^^xsd:nonNegativeInteger
                              ] ,
@@ -10267,24 +10296,8 @@ Condition: At least one of the three elements (Country Code, Information Identif
                              [ rdf:type owl:Restriction ;
                                owl:onProperty :totalCollectCharges ;
                                owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                             ] ,
-                             [ rdf:type owl:Restriction ;
-                               owl:onProperty :chargePaymentType ;
-                               owl:allValuesFrom xsd:string
-                             ] ,
-                             [ rdf:type owl:Restriction ;
-                               owl:onProperty :chargeType ;
-                               owl:allValuesFrom xsd:string
-                             ] ,
-                             [ rdf:type owl:Restriction ;
-                               owl:onProperty :chargePaymentType ;
-                               owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                             ] ,
-                             [ rdf:type owl:Restriction ;
-                               owl:onProperty :chargeType ;
-                               owl:maxCardinality "1"^^xsd:nonNegativeInteger
                              ] ;
-             rdfs:comment "PENDING"@en ;
+             rdfs:comment "Prepaid and Collect charge totals from AWB"@en ;
              rdfs:label "TotalCharge"@en .
 
 
@@ -10395,6 +10408,10 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                      owl:allValuesFrom :Value
                                    ] ,
                                    [ rdf:type owl:Restriction ;
+                                     owl:onProperty :modeQualifier ;
+                                     owl:allValuesFrom :ModeQualifier
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
                                      owl:onProperty :movementTimes ;
                                      owl:allValuesFrom :MovementTime
                                    ] ,
@@ -10427,6 +10444,10 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                      owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                    ] ,
                                    [ rdf:type owl:Restriction ;
+                                     owl:onProperty :modeQualifier ;
+                                     owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
                                      owl:onProperty :operatingTransportMeans ;
                                      owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                    ] ,
@@ -10436,10 +10457,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                    ] ,
                                    [ rdf:type owl:Restriction ;
                                      owl:onProperty :modeCode ;
-                                     owl:allValuesFrom xsd:string
-                                   ] ,
-                                   [ rdf:type owl:Restriction ;
-                                     owl:onProperty :modeQualifier ;
                                      owl:allValuesFrom xsd:string
                                    ] ,
                                    [ rdf:type owl:Restriction ;
@@ -10456,10 +10473,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                    ] ,
                                    [ rdf:type owl:Restriction ;
                                      owl:onProperty :modeCode ;
-                                     owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                                   ] ,
-                                   [ rdf:type owl:Restriction ;
-                                     owl:onProperty :modeQualifier ;
                                      owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                    ] ,
                                    [ rdf:type owl:Restriction ;
@@ -10478,6 +10491,22 @@ Condition: At least one of the three elements (Country Code, Information Identif
 :Uld rdf:type owl:Class ;
      rdfs:subClassOf :LoadingUnit ,
                      [ rdf:type owl:Restriction ;
+                       owl:onProperty :loadingIndicator ;
+                       owl:allValuesFrom ccodes:ULDLoadingIndicator
+                     ] ,
+                     [ rdf:type owl:Restriction ;
+                       owl:onProperty :serviceabilityCode ;
+                       owl:allValuesFrom ccodes:ULDConditionCode
+                     ] ,
+                     [ rdf:type owl:Restriction ;
+                       owl:onProperty :loadingIndicator ;
+                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                     ] ,
+                     [ rdf:type owl:Restriction ;
+                       owl:onProperty :serviceabilityCode ;
+                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                     ] ,
+                     [ rdf:type owl:Restriction ;
                        owl:onProperty :ataDesignator ;
                        owl:allValuesFrom xsd:string
                      ] ,
@@ -10487,10 +10516,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                      ] ,
                      [ rdf:type owl:Restriction ;
                        owl:onProperty :demurrageCode ;
-                       owl:allValuesFrom xsd:string
-                     ] ,
-                     [ rdf:type owl:Restriction ;
-                       owl:onProperty :loadingIndicator ;
                        owl:allValuesFrom xsd:string
                      ] ,
                      [ rdf:type owl:Restriction ;
@@ -10519,10 +10544,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                      ] ,
                      [ rdf:type owl:Restriction ;
                        owl:onProperty :sealNumber ;
-                       owl:allValuesFrom xsd:string
-                     ] ,
-                     [ rdf:type owl:Restriction ;
-                       owl:onProperty :serviceabilityCode ;
                        owl:allValuesFrom xsd:string
                      ] ,
                      [ rdf:type owl:Restriction ;
@@ -10546,10 +10567,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
                      ] ,
                      [ rdf:type owl:Restriction ;
-                       owl:onProperty :loadingIndicator ;
-                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                     ] ,
-                     [ rdf:type owl:Restriction ;
                        owl:onProperty :numberOfDoors ;
                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
                      ] ,
@@ -10575,10 +10592,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                      ] ,
                      [ rdf:type owl:Restriction ;
                        owl:onProperty :sealNumber ;
-                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                     ] ,
-                     [ rdf:type owl:Restriction ;
-                       owl:onProperty :serviceabilityCode ;
                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
                      ] ,
                      [ rdf:type owl:Restriction ;
@@ -10613,7 +10626,15 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                    owl:allValuesFrom xsd:string
                                  ] ,
                                  [ rdf:type owl:Restriction ;
+                                   owl:onProperty :slac ;
+                                   owl:allValuesFrom xsd:integer
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
                                    owl:onProperty :compositionIdentifier ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty :slac ;
                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                  ] ;
                  rdfs:comment "Activity to describe composition and decomposition of LoadingUnits"@en ;
@@ -10676,6 +10697,10 @@ Condition: At least one of the three elements (Country Code, Information Identif
                            owl:allValuesFrom :BillingDetails
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty :carrierChargeCode ;
+                           owl:allValuesFrom ccodes:ChargeCode
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty :carrierDeclarationPlace ;
                            owl:allValuesFrom :Location
                          ] ,
@@ -10716,8 +10741,16 @@ Condition: At least one of the three elements (Country Code, Information Identif
                            owl:allValuesFrom :OtherCharge
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty :otherChargesIndicator ;
+                           owl:allValuesFrom ccodes:PrepaidCollectIndicator
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty :referredBookingOption ;
                            owl:allValuesFrom :Booking
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :serviceCode ;
+                           owl:allValuesFrom ccodes:ServiceCode
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :shipment ;
@@ -10728,11 +10761,23 @@ Condition: At least one of the three elements (Country Code, Information Identif
                            owl:allValuesFrom :TACTRateDescription
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty :waybillType ;
+                           owl:allValuesFrom :WaybillType
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :weightValuationIndicator ;
+                           owl:allValuesFrom ccodes:PrepaidCollectIndicator
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty :arrivalLocation ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :billingDetails ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :carrierChargeCode ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
@@ -10760,7 +10805,15 @@ Condition: At least one of the three elements (Country Code, Information Identif
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty :otherChargesIndicator ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty :referredBookingOption ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :serviceCode ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
@@ -10768,11 +10821,15 @@ Condition: At least one of the three elements (Country Code, Information Identif
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty :accountingInformation ;
-                           owl:allValuesFrom xsd:string
+                           owl:onProperty :waybillType ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty :carrierChargeCode ;
+                           owl:onProperty :weightValuationIndicator ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty :accountingInformation ;
                            owl:allValuesFrom xsd:string
                          ] ,
                          [ rdf:type owl:Restriction ;
@@ -10812,14 +10869,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                            owl:allValuesFrom xsd:string
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty :otherChargesIndicator ;
-                           owl:allValuesFrom xsd:string
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :serviceCode ;
-                           owl:allValuesFrom xsd:string
-                         ] ,
-                         [ rdf:type owl:Restriction ;
                            owl:onProperty :shippingInfo ;
                            owl:allValuesFrom xsd:string
                          ] ,
@@ -10836,19 +10885,7 @@ Condition: At least one of the three elements (Country Code, Information Identif
                            owl:allValuesFrom xsd:string
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty :waybillType ;
-                           owl:allValuesFrom xsd:string
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :weightValuationIndicator ;
-                           owl:allValuesFrom xsd:string
-                         ] ,
-                         [ rdf:type owl:Restriction ;
                            owl:onProperty :accountingInformation ;
-                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :carrierChargeCode ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
@@ -10884,14 +10921,6 @@ Condition: At least one of the three elements (Country Code, Information Identif
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty :otherChargesIndicator ;
-                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :serviceCode ;
-                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                         ] ,
-                         [ rdf:type owl:Restriction ;
                            owl:onProperty :shippingInfo ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ,
@@ -10906,17 +10935,370 @@ Condition: At least one of the three elements (Country Code, Information Identif
                          [ rdf:type owl:Restriction ;
                            owl:onProperty :waybillPrefix ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :waybillType ;
-                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty :weightValuationIndicator ;
-                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ;
          rdfs:comment "Waybill details"@en ;
          rdfs:label "Waybill"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#WaybillType
+:WaybillType rdf:type owl:Class ;
+             owl:equivalentClass [ rdf:type owl:Class ;
+                                   owl:oneOf ( :DIRECT
+                                               :HOUSE
+                                               :MASTER
+                                             )
+                                 ] ;
+             rdfs:subClassOf :CodeListElement ;
+             rdfs:comment "Restricted code list for Waybill types"@en ;
+             rdfs:label "WaybillType"@en .
+
+
+#################################################################
+#    Individuals
+#################################################################
+
+###  https://onerecord.iata.org/ns/cargo#ACCELEROMETER
+:ACCELEROMETER rdf:type owl:NamedIndividual ,
+                        :SensorType ;
+               rdfs:comment "Indicates the sensor type as accelerometer"@en ;
+               rdfs:label "ACCELEROMETER"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#ACTIVE
+:ACTIVE rdf:type owl:NamedIndividual ,
+                 :ExecutionStatus ;
+        rdfs:comment "Used when a LogisticsActivity is active"@en ;
+        rdfs:label "ACTIVE"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#ACTUAL
+:ACTUAL rdf:type owl:NamedIndividual ,
+                 :ActionTimeType ,
+                 :EventTimeType ,
+                 :MovementTimeType ;
+        rdfs:comment "Used when a time is actual"@en ;
+        rdfs:label "ACTUAL"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#ALTERNATE_EMAIL_ADDRESS
+:ALTERNATE_EMAIL_ADDRESS rdf:type owl:NamedIndividual ,
+                                  :ContactDetailType ;
+                         rdfs:comment "Indicates a contact detail as alternate email address"@en ;
+                         rdfs:label "ALTERNATE_EMAIL_ADDRESS"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#ALTERNATE_PHONE_NUMBER
+:ALTERNATE_PHONE_NUMBER rdf:type owl:NamedIndividual ,
+                                 :ContactDetailType ;
+                        rdfs:comment "Indicates a contact detail as alternate phone number"@en ;
+                        rdfs:label "ALTERNATE_PHONE_NUMBER"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#BULK
+:BULK rdf:type owl:NamedIndividual ,
+               :LoadType ;
+      rdfs:comment "Indicates the load type as bulk"@en ;
+      rdfs:label "BULK"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#CANCELLED
+:CANCELLED rdf:type owl:NamedIndividual ,
+                    :ExecutionStatus ;
+           rdfs:comment "Used when a LogisticsActivity is cancelled"@en ;
+           rdfs:label "CANCELLED"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#COMPLETE
+:COMPLETE rdf:type owl:NamedIndividual ,
+                   :ExecutionStatus ;
+          rdfs:comment "Used when a LogisticsActivity is complete"@en ;
+          rdfs:label "COMPLETE"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#COMPOSITION
+:COMPOSITION rdf:type owl:NamedIndividual ,
+                      :CompositionType ;
+             rdfs:comment "Describes a composition, for example the loading of a container or the build-up of an ULD"@en ;
+             rdfs:label "COMPOSITION"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#CUSTOMER_CONTACT
+:CUSTOMER_CONTACT rdf:type owl:NamedIndividual ,
+                           :ContactRole ;
+                  rdfs:comment "Indicates a contact person as customer contact"@en ;
+                  rdfs:label "CUSTOMER_CONTACT"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#CUSTOMS_CONTACT
+:CUSTOMS_CONTACT rdf:type owl:NamedIndividual ,
+                          :ContactRole ;
+                 rdfs:comment "Indicates a contact person as customs contact"@en ;
+                 rdfs:label "CUSTOMS_CONTACT"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#DECOMPOSITION
+:DECOMPOSITION rdf:type owl:NamedIndividual ,
+                        :CompositionType ;
+               rdfs:comment "Describes a decomposition, for example the unloading of a container or the break-down of an ULD"@en ;
+               rdfs:label "DECOMPOSITION"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#DIRECT
+:DIRECT rdf:type owl:NamedIndividual ,
+                 :WaybillType ;
+        rdfs:comment "Indicates a Direct waybill"@en ;
+        rdfs:label "DIRECT"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#EMAIL_ADDRESS
+:EMAIL_ADDRESS rdf:type owl:NamedIndividual ,
+                        :ContactDetailType ;
+               rdfs:comment "Indicates a contact detail as email address"@en ;
+               rdfs:label "EMAIL_ADDRESS"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#EMERGENCY_CONTACT
+:EMERGENCY_CONTACT rdf:type owl:NamedIndividual ,
+                            :ContactRole ;
+                   rdfs:comment "Indicates a contact person as emergency contact"@en ;
+                   rdfs:label "EMERGENCY_CONTACT"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#ESTIMATED
+:ESTIMATED rdf:type owl:NamedIndividual ,
+                    :EventTimeType ,
+                    :MovementTimeType ;
+           rdfs:comment "Used when a time is estimated"@en ;
+           rdfs:label "ESTIMATED"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#EXPECTED
+:EXPECTED rdf:type owl:NamedIndividual ,
+                   :EventTimeType ;
+          rdfs:comment "Used when a time is expected"@en ;
+          rdfs:label "EXPECTED"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#FAX_NUMBER
+:FAX_NUMBER rdf:type owl:NamedIndividual ,
+                     :ContactDetailType ;
+            rdfs:comment "Indicates a contact detail as fax number"@en ;
+            rdfs:label "FAX_NUMBER"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#GEOLOCATION
+:GEOLOCATION rdf:type owl:NamedIndividual ,
+                      :SensorType ;
+             rdfs:comment "Indicates the sensor type as geolocation"@en ;
+             rdfs:label "GEOLOCATION"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#HOUSE
+:HOUSE rdf:type owl:NamedIndividual ,
+                :WaybillType ;
+       rdfs:comment "Indicates a House Waybill"@en ;
+       rdfs:label "HOUSE"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#HUMIDITY
+:HUMIDITY rdf:type owl:NamedIndividual ,
+                   :SensorType ;
+          rdfs:comment "Indicates the sensor type as humidity"@en ;
+          rdfs:label "HUMIDITY"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#INBOUND
+:INBOUND rdf:type owl:NamedIndividual ,
+                  :DirectionType ;
+         rdfs:comment "Indicates the described direction in a movement time as inbound"@en ;
+         rdfs:label "INBOUND"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#LIGHT
+:LIGHT rdf:type owl:NamedIndividual ,
+                :SensorType ;
+       rdfs:comment "Indicates the sensor type as light"@en ;
+       rdfs:label "LIGHT"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#LOADING
+:LOADING rdf:type owl:NamedIndividual ,
+                  :LoadingType ;
+         rdfs:comment "Describes a loading process, for example putting an ULD on an aircraft or a piece in a truck"@en ;
+         rdfs:label "LOADING"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#LOOSE
+:LOOSE rdf:type owl:NamedIndividual ,
+                :LoadType ;
+       rdfs:comment "Indicates the load type as loose"@en ;
+       rdfs:label "LOOSE"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#MAIN_CARRIAGE
+:MAIN_CARRIAGE rdf:type owl:NamedIndividual ,
+                        :ModeQualifier ;
+               rdfs:comment "Indicates the mode qualifier as main carriage"@en ;
+               rdfs:label "MAIN_CARRIAGE"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#MASTER
+:MASTER rdf:type owl:NamedIndividual ,
+                 :WaybillType ;
+        rdfs:comment "Indicates a Master Waybill"@en ;
+        rdfs:label "MASTER"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#ON_CARRIAGE
+:ON_CARRIAGE rdf:type owl:NamedIndividual ,
+                      :ModeQualifier ;
+             rdfs:comment "Indicates the mode qualifier as on carriage"@en ;
+             rdfs:label "ON_CARRIAGE"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#OUTBOUND
+:OUTBOUND rdf:type owl:NamedIndividual ,
+                   :DirectionType ;
+          rdfs:comment "Indicates the described direction in a movement time as outbound"@en ;
+          rdfs:label "OUTBOUND"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#PALLET
+:PALLET rdf:type owl:NamedIndividual ,
+                 :LoadType ;
+        rdfs:comment "Indicates the load type as pallet"@en ;
+        rdfs:label "PALLET"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#PENDING
+:PENDING rdf:type owl:NamedIndividual ,
+                  :ExecutionStatus ;
+         rdfs:comment "Used when a LogisticsActivity is pending"@en ;
+         rdfs:label "PENDING"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#PHONE_NUMBER
+:PHONE_NUMBER rdf:type owl:NamedIndividual ,
+                       :ContactDetailType ;
+              rdfs:comment "Indicates a contact detail as phone number"@en ;
+              rdfs:label "PHONE_NUMBER"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#PLANNED
+:PLANNED rdf:type owl:NamedIndividual ,
+                  :ActionTimeType ,
+                  :EventTimeType ;
+         rdfs:comment "Used when a time is planned"@en ;
+         rdfs:label "PLANNED"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#PRESSURE
+:PRESSURE rdf:type owl:NamedIndividual ,
+                   :SensorType ;
+          rdfs:comment "Indicates the sensor type as pressure"@en ;
+          rdfs:label "PRESSURE"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#PRE_CARRIAGE
+:PRE_CARRIAGE rdf:type owl:NamedIndividual ,
+                       :ModeQualifier ;
+              rdfs:comment "Indicates the mode qualifier as pre carriage"@en ;
+              rdfs:label "PRE_CARRIAGE"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#REQUESTED
+:REQUESTED rdf:type owl:NamedIndividual ,
+                    :ActionTimeType ,
+                    :EventTimeType ;
+           rdfs:comment "Used when a time is requested"@en ;
+           rdfs:label "REQUESTED"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#SCHEDULED
+:SCHEDULED rdf:type owl:NamedIndividual ,
+                    :MovementTimeType ;
+           rdfs:comment "Used when a time is scheduled"@en ;
+           rdfs:label "SCHEDULED"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#STORE_IN
+:STORE_IN rdf:type owl:NamedIndividual ,
+                   :StoringType ;
+          rdfs:comment "Describes a store-in process, where a physical object is assigned to a specific location"@en ;
+          rdfs:label "STORE_IN"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#STORE_OUT
+:STORE_OUT rdf:type owl:NamedIndividual ,
+                    :StoringType ;
+           rdfs:comment "Describes a store-out process, where a physical object leaves a specific location"@en ;
+           rdfs:label "STORE_OUT"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#TELEX
+:TELEX rdf:type owl:NamedIndividual ,
+                :ContactDetailType ;
+       rdfs:comment "Indicates a contact detail as telex"@en ;
+       rdfs:label "TELEX"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#THERMOMETER
+:THERMOMETER rdf:type owl:NamedIndividual ,
+                      :SensorType ;
+             rdfs:comment "Indicates the sensor type as thermometer"@en ;
+             rdfs:label "THERMOMETER"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#TILT
+:TILT rdf:type owl:NamedIndividual ,
+               :SensorType ;
+      rdfs:comment "Indicates the sensor type as tilt"@en ;
+      rdfs:label "TILT"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#ULD
+:ULD rdf:type owl:NamedIndividual ,
+              :LoadType ;
+     rdfs:comment "Indicates the load type as uld"@en ;
+     rdfs:label "ULD"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#UNLOADING
+:UNLOADING rdf:type owl:NamedIndividual ,
+                    :LoadingType ;
+           rdfs:comment "Describes an unloading process, for example removing an ULD from an aircraft or a piece from a truck"@en ;
+           rdfs:label "UNLOADING"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#UNPLANNED_STOP
+:UNPLANNED_STOP rdf:type owl:NamedIndividual ,
+                         :DirectionType ;
+                rdfs:comment "Indicates the that the movement time describes an unplanned stop"@en ;
+                rdfs:label "UNPLANNED_STOP"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#VIBRATION
+:VIBRATION rdf:type owl:NamedIndividual ,
+                    :SensorType ;
+           rdfs:comment "Indicates the sensor type as vibration"@en ;
+           rdfs:label "VIBRATION"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#WEBSITE
+:WEBSITE rdf:type owl:NamedIndividual ,
+                  :ContactDetailType ;
+         rdfs:comment "Indicates a contact detail as website"@en ;
+         rdfs:label "WEBSITE"@en .
+
+
+#################################################################
+#    Annotations
+#################################################################
+
+:regulatedEntityCategory owl:versionInfo "v3. renamed from regulatedEntity:regulatedEntityCategory"@en ;
+                         rdfs:comment "Party type, should be one of the following RA - Regulated Agent, KC - Known Consignor, AO - Aircraft Operator, RC - Regulated Carrier"@en ;
+                         owl:comment "Possible RDF good practice IRI: :isOfRegulatedAgentCategory "@en ;
+                         rdfs:label "regulatedEntityCategory"@en .
 
 
 ###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi

--- a/working_draft/ontology/IATA-1R-DM-Ontology.ttl
+++ b/working_draft/ontology/IATA-1R-DM-Ontology.ttl
@@ -9,11 +9,11 @@
 @base <https://onerecord.iata.org/ns/cargo> .
 
 <https://onerecord.iata.org/ns/cargo> rdf:type owl:Ontology ;
-                                       owl:versionIRI <https://onerecord.iata.org/ns/cargo/3.0.0-RC5a> ;
+                                       owl:versionIRI <https://onerecord.iata.org/ns/cargo/3.0.0-RC5b> ;
                                        dc:description "The ONE Record vocabulary, described using W3C RDF Schema and the Web Ontology Language."@en ;
                                        dc:title "ONE Record Ontology"@en ;
                                        terms:abstract "The ontology of the ONE Record standard is the core data model underlying the Linked Data solution drafted by the ONE Record standard: https://github.com/IATA-Cargo/ONE-Record. ONE Record is a standard for data sharing and creates a single record view of the shipment. This standard defines a common data model for the data that is shared via standardized and secured web API."@en ;
-                                       terms:modified "10-07-2023" ;
+                                       terms:modified "12-07-2023" ;
                                        terms:title "ONE Record Ontology"@en ;
                                        rdfs:comment """Details availalble on GitHub https://github.com/IATA-Cargo/ONE-Record
 Version 2.0.0
@@ -58,7 +58,7 @@ Version 3.0.0 RC 4.1
 - Renamed \"forBookingOptions\" to \"forBookingOption\" for consistency
 - Addded \"resultOfCheck\" and \"usedInCheck\" properties as backlinks from CheckTotalResult and CheckTemplate to Check
 - Fixed \"describedByProduct\" restriction in Item LO
-Version 3.0.0 RC5
+Version 3.0.0 RC5a
 - Fixed missing label and description in subtotal and billing charges properties
 - Changed Shipment from PhysicalLO to LO
 - Lifted cardinality restriction from insuredShipment property and changed name and IRI suffix to insuredShipments
@@ -69,10 +69,13 @@ Version 3.0.0 RC5
 - Added TACTRateDescription, OtherCharge, TotalCharge classes and respective properties
 - Changed domain of re-used properties to owl:Thing of the abovementioned classes
 - Added properties serviceCode, chargesAtDestination and carrierCharge code to Waybill
-- Added tactRateDescriptions, chargeTotals and otherCharges to Waybill to connect with the new LOs"""@en ;
+- Added tactRateDescriptions, chargeTotals and otherCharges to Waybill to connect with the new LOs
+Version 3.0.0 RC5b
+- Moved chargesAtDestination from Waybill to TotalCharge
+- Added object property totalCollectCharges with Range Value and added it to TotalCharge"""@en ;
                                        rdfs:isDefinedBy "https://www.iata.org/one-record/"^^xsd:anyURI ;
                                        rdfs:label "ONE Record Ontology"@en ;
-                                       owl:versionInfo "3.0.0 RC 5a"@en .
+                                       owl:versionInfo "3.0.0 RC 5b"@en .
 
 #################################################################
 #    Annotation properties
@@ -449,7 +452,7 @@ owl:thing rdf:type rdfs:Datatype .
 
 ###  https://onerecord.iata.org/ns/cargo#chargesAtDestination
 :chargesAtDestination rdf:type owl:ObjectProperty ;
-                      rdfs:domain :Waybill ;
+                      rdfs:domain :TotalCharge ;
                       rdfs:range :Value ;
                       rdfs:comment "PENDING"@en ;
                       rdfs:label "chargesAtDestination"@en .
@@ -1997,6 +2000,14 @@ owl:thing rdf:type rdfs:Datatype .
        rdfs:range :Value ;
        rdfs:comment "PENDING"@en ;
        rdfs:label "total"@en .
+
+
+###  https://onerecord.iata.org/ns/cargo#totalCollectCharges
+:totalCollectCharges rdf:type owl:ObjectProperty ;
+                     rdfs:domain :TotalCharge ;
+                     rdfs:range :Value ;
+                     rdfs:comment "PENDING" ;
+                     rdfs:label "totalCollectCharges"@en .
 
 
 ###  https://onerecord.iata.org/ns/cargo#totalDimensions
@@ -10156,11 +10167,19 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                owl:allValuesFrom :Value
                              ] ,
                              [ rdf:type owl:Restriction ;
+                               owl:onProperty :chargesAtDestination ;
+                               owl:allValuesFrom :Value
+                             ] ,
+                             [ rdf:type owl:Restriction ;
                                owl:onProperty :collectChargesInDestinationCurrency ;
                                owl:allValuesFrom :Value
                              ] ,
                              [ rdf:type owl:Restriction ;
                                owl:onProperty :currencyConversionRate ;
+                               owl:allValuesFrom :Value
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty :totalCollectCharges ;
                                owl:allValuesFrom :Value
                              ] ,
                              [ rdf:type owl:Restriction ;
@@ -10168,11 +10187,19 @@ Condition: At least one of the three elements (Country Code, Information Identif
                                owl:maxCardinality "1"^^xsd:nonNegativeInteger
                              ] ,
                              [ rdf:type owl:Restriction ;
+                               owl:onProperty :chargesAtDestination ;
+                               owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                             ] ,
+                             [ rdf:type owl:Restriction ;
                                owl:onProperty :collectChargesInDestinationCurrency ;
                                owl:maxCardinality "1"^^xsd:nonNegativeInteger
                              ] ,
                              [ rdf:type owl:Restriction ;
                                owl:onProperty :currencyConversionRate ;
+                               owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty :totalCollectCharges ;
                                owl:maxCardinality "1"^^xsd:nonNegativeInteger
                              ] ,
                              [ rdf:type owl:Restriction ;


### PR DESCRIPTION
- Added TACT-Information o the cargo ontology
- Added MCD 2.0 properties and classes to the cargo ontology
- Added type-safe implementation of 43 code lists used in 1R as NamedIndividuals as new coreCodeLists ontology
- Changed the cargo ontology to depend on the coreCodeLists ontology
- Changed to type-safe implementation of all Enums as NamedIndividuals in the cargo ontology
- Minor tweaks and refactorization - Details in the cargo ontology
__________________________________________________

Open issues:
- Type-safe implementation of Value objects
- General clean-up in MCD 2.0 and Activity/Action-layers