### PR TITLE
Fix broken documentation links and correct file extensions

### DIFF
--- a/Documentation_website/docs/Orchestration/orchestration-cxml.md
+++ b/Documentation_website/docs/Orchestration/orchestration-cxml.md
@@ -20,8 +20,8 @@ The selected messages for mapping are the following:
 | Message | Message name | Message version | Comments |
 | --- | --- | --- | --- |
 | XFWB | XML Waybill Message [Download here](./assets/XFWB-5.0.0-mapping.xlsx){:download="XFWB-5.0.0-mapping.xlsx"} | 5.00 | 1st version |
-| XFZB | XML HouseWaybill Message [Download here](./assets/XFZB-4.0.0-mapping.xslx){:download="XFZB-4.0.0-mapping.xlsx"} | 4.00 | 1st version |
-| XFHL | XML House Manifest Message [Download here](./assets/XFHL-3.0.0-mapping.xslx){:download="XFHL-3.0.0-mapping.xlsx"} | 3.00 | 1st version |
+| XFZB | XML HouseWaybill Message [Download here](./assets/XFZB-4.0.0-mapping.xlsx){:download="XFZB-4.0.0-mapping.xlsx"} | 4.00 | 1st version |
+| XFHL | XML House Manifest Message [Download here](./assets/XFHL-3.0.0-mapping.xlsx){:download="XFHL-3.0.0-mapping.xlsx"} | 3.00 | 1st version |
 | XSDG | XML Shippers' Declaration for Dangerous Goods Message | 6.00 | To be assessed |
 | XFSU | XML Status Message | 6.00 | Ongoing |
 | XFFM | XML Flight Manifest Message | 4.00 | Ongoing |


### PR DESCRIPTION
Changed `.xslx` → `.xlsx` to match actual file types  
Otherwise it cannot be parsed and downloaded from the website
<img width="942" alt="1744450000668" src="https://github.com/user-attachments/assets/b10e3e1b-c0f5-4bcc-94f4-b80c1dc504bd" />



