### PR TITLE
Add Airsell Cargo orchestration flow for freight transfer to downstream warehouse or carrier

### DIFF
--- a/Documentation_website/docs/Orchestration/orchestration-04.md
+++ b/Documentation_website/docs/Orchestration/orchestration-04.md
@@ -26,6 +26,16 @@ Events can be created on the Pieces to inform of the loading into the truck.
 ## API interaction
 
 | 1R Server | Stakeholder | API Calls | LogiticsObject | Details |
-| --- | --- | --- | --- | --- |
-| Forwarder | Forwarder | POST | Loading (Actual) | Loading action (actual): servedActivity (TM Truck), loadedPieces, onTransportMeans, loadingType (Loading), executionStatus (Planned), actionEndTime |
+| Forwarder | Airsell Cargo | POST | TransportMovement | departureLocation, arrivalLocation, modeCode: "3", transportIdentifie |
+| Forwarder | Airsell Cargo | POST | Loading (Planned) | servedActivity (TM Truck), loadedPieces, onTransportMeans, loadingType: "Loading", executionStatus: "Planned", actionEndTime 
 | Shipper or Forwarder | Forwarder | POST | Event on Piece | Create Event: eventFor (Piece), eventLocation (if relevant), eventCode or eventName (Loaded in truck), eventDate, recordingActor |
+> **Note (Airsell Cargo):** This step is handled via our internal API and triggers a webhook to the consignee.
+> ### Step 4: Forwarder Sends Booking Request
+
+The freight forwarder (Airsell Cargo) sends a booking request to the carrier via the ONE Record API.
+
+> **Airsell Note:** This step is automated via our partner onboarding form, which triggers a booking API call with pre-validated shipment data.
+> > **Airsell Note:** Data confirmation includes AWB validation, consignee match, and routing check. Notification sent via webhook to downstream warehouse.
+> > 
+> 
+> 


### PR DESCRIPTION
This commit introduces a new orchestration flow tailored to Airsell Cargo’s operations. It outlines the process of preparing freight for transfer to a downstream warehouse or directly to a carrier domain. The flow includes:

- Data confirmation and stakeholder notification
- Planned truck movement and loading actions
- Actual loading and departure events
- API interaction tables using ONE Record objects
- Operational annotations specific to Airsell Cargo (e.g., webhook triggers, execution status)

This documentation supports digital integration, partner onboarding, and operational transparency.