### PR TITLE
Align Collection property names with the API ontology

### DIFF
--- a/Documentation_website/docs/API-Security/examples/LogisticsEvents_filtered_list.json
+++ b/Documentation_website/docs/API-Security/examples/LogisticsEvents_filtered_list.json
@@ -6,7 +6,7 @@
   "@id": "https://1r.example.com/logistics-objects/1a8ded38-1804-467c-a369-81a411416b3c/logistics-events",
   "@type": "api:Collection",
   "api:hasTotalItems": 1,
-  "api:hasItems": {
+  "api:hasItem": {
     "@id": "https://1r.example.com/logistics-objects/1a8ded38-1804-467c-a369-81a411416b3c/logistics-events/afb4b8cf-288a-459c-97fd-ccd538ec527f",
     "@type": "cargo:LogisticsEvent",
     "cargo:creationDate": {

--- a/Documentation_website/docs/API-Security/logistics-events.md
+++ b/Documentation_website/docs/API-Security/logistics-events.md
@@ -522,7 +522,7 @@ classDiagram
 The ONE Record API employs the [Collection](https://onerecord.iata.org/ns/api#Collection) class to return an array of objects. This class encompasses two properties:
 
 - [api:hasItem](https://onerecord.iata.org/ns/api#hasItem) returns the array of objects.
-- [api:hasTotalItem](https://onerecord.iata.org/ns/api#hasTotalItem) returns the count of elements for the defined filter without taking into account pagination (i.e. skip or limit parameter).
+- [api:hasTotalItems](https://onerecord.iata.org/ns/api#hasTotalItems) returns the count of elements for the defined filter without taking into account pagination (i.e. skip or limit parameter).
 
 In this particular case, @id property in the response body MUST be equal to the Endpoint defined in the [Endpoint section](#endpoint_2) (i.e.: https://1r.example.com/logistics-objects/2a7d1338-9033-13xc-b665-81a411418978/logistics-events). 
 
@@ -531,9 +531,9 @@ In this particular case, @id property in the response body MUST be equal to the 
 
     The ONE Record standard fully adopts the JSON-LD specification, and as a result, the presence of the [api:hasItem](https://onerecord.iata.org/ns/api#hasItem) property of [Collection](https://onerecord.iata.org/ns/api#Collection) is contingent on the number of Logistics Events returned byt the specified query. Specifically:
         
-    - If the specified query returns zero Logistics Events, [api:hasItem](https://onerecord.iata.org/ns/api#hasItem) may not appear in the JSON, and [api:hasTotalItem](https://onerecord.iata.org/ns/api#hasTotalItem) must be 0.
-    - When the specified query returns exactly one Logistics Event, [api:hasItem](https://onerecord.iata.org/ns/api#hasItem) will directly represent that Logistics Event, and [api:hasTotalItem](https://onerecord.iata.org/ns/api#hasTotalItem) must be 1.
-    - In cases where the specified query returns multiple Logistics Events, [api:hasItem](https://onerecord.iata.org/ns/api#hasItem) will be an array containing those Logistics Events, and [api:hasTotalItem](https://onerecord.iata.org/ns/api#hasTotalItem) must be equal to the number of Logistics Events retrieved by the specified query.
+    - If the specified query returns zero Logistics Events, [api:hasItem](https://onerecord.iata.org/ns/api#hasItem) may not appear in the JSON, and [api:hasTotalItems](https://onerecord.iata.org/ns/api#hasTotalItems) must be 0.
+    - When the specified query returns exactly one Logistics Event, [api:hasItem](https://onerecord.iata.org/ns/api#hasItem) will directly represent that Logistics Event, and [api:hasTotalItems](https://onerecord.iata.org/ns/api#hasTotalItems) must be 1.
+    - In cases where the specified query returns multiple Logistics Events, [api:hasItem](https://onerecord.iata.org/ns/api#hasItem) will be an array containing those Logistics Events, and [api:hasTotalItems](https://onerecord.iata.org/ns/api#hasTotalItems) must be equal to the number of Logistics Events retrieved by the specified query.
 
     During the implementation phase, it is highly recommended to utilize a JSON-LD library for parsing responses.
     To discover JSON-LD libraries for various programming languages, consult the [implementation guidelines](./implementation-guidelines.md#serialization-and-data-formats).


### PR DESCRIPTION
Fixes #421.

The API ontology defines `api:hasItem` and `api:hasTotalItems`. The documentation and one example each used a different spelling, in opposite directions.

**`logistics-events.md`** — `api:hasTotalItem` (singular) → `api:hasTotalItems`, 8 occurrences on lines 525 and 534-536. Each occurrence appeared twice per line, as link text and as link target, so the rendered documentation linked to `https://onerecord.iata.org/ns/api#hasTotalItem`, which is not defined in any release. The class diagram in the same file (`:511`) already used the correct plural.

**`examples/LogisticsEvents_filtered_list.json`** — `api:hasItems` → `api:hasItem`, 1 occurrence. Verified the file still parses as JSON after the edit.

No other file in the repository used either misspelling. The ontology is not touched — it is the reference both edits follow.