### PR TITLE
Use api:hasError in ChangeRequest_with_error.json

### DIFF
--- a/Documentation_website/docs/API-Security/examples/ChangeRequest_with_error.json
+++ b/Documentation_website/docs/API-Security/examples/ChangeRequest_with_error.json
@@ -9,7 +9,7 @@
         "@language": "en-US"
     },
     "@type": "api:ChangeRequest",
-    "api#errors": [
+    "api:hasError": [
         {
             "@type": "api:Error",
             "api:hasTitle": "Conflict with Logistics Object revision number",


### PR DESCRIPTION
Partially fixes #423.

`ChangeRequest_with_error.json` carried its errors under the key `"api#errors"`. That is neither a term defined in the file's own `@context` nor an absolute IRI, so a conformant JSON-LD processor does not expand it and drops it along with everything nested under it. The example exists to show how errors are reported on a `ChangeRequest`; after expansion it showed a `ChangeRequest` with no errors.

The ontology declares `api:hasError` on `:ActionRequest`, inherited by `:ChangeRequest`, and the `api` prefix is already bound in the file — so the fix is one key.

Verified the file still parses as JSON, and that `api:hasError` is now the only non-`@` top-level key.

**Not in this PR.** The other two files named in #423 — `AuditTrail.json` and `AuditTrail_example2.json` — are invalid JSON because of the prose placeholder `...this contains a complete Change object...` inside an object body. Fixing those means choosing between inlining a full `Change` object and keeping a JSON-legal abbreviation, which is an editorial decision. Happy to send a follow-up PR once you say which you prefer.