### PR TITLE
[Orch] Loading/Unloading rows name executionStatus, which those classes do not have

### DIFF
--- a/Documentation_website/docs/Orchestration/orchestration-01.md
+++ b/Documentation_website/docs/Orchestration/orchestration-01.md
@@ -83,7 +83,7 @@ Flight details are directly retrieved from the Booking.
 | Forwarder | Forwarder | POST | TransportMovement (Truck Movement) | Add backlink Waybill>Shipment |
 | Forwarder | Forwarder | POST | TransportMeans (Truck) | Create TransportMeans or Identify existing one and add link to TransportMovement (Truck): operatedTransportMovement, vehicleType, vehicleModel, vehicleRegistration, transportOrganization |
 | Forwarder | Forwarder | PATCH | TransportMovement (Truck Movement) | Add backlink TransportMeans > TransportMovement (Truck) |
-| Forwarder | Forwarder | POST | Loading (Planned) | Loading action (planned): servedActivity (TM Truck), loadedPieces, onTransportMeans, loadingType (Loading), executionStatus (Planned), actionEndTime |
+| Forwarder | Forwarder | POST | Loading (Planned) | Loading action (planned): servedActivity (TM Truck), loadedPieces, onTransportMeans, loadingType (Loading), actionTimeType (Planned), actionEndTime |
 
 # 10. Share planning for pickup all involved Service Suppliers
 

--- a/Documentation_website/docs/Orchestration/orchestration-02.md
+++ b/Documentation_website/docs/Orchestration/orchestration-02.md
@@ -30,5 +30,5 @@ Events can be created on the Pieces to inform of the loading into the truck
 
 | 1R Server | Stakeholder | API Calls | LogiticsObject | Details |
 | --- | --- | --- | --- | --- |
-| Forwarder | Forwarder | POST | Loading (Actual) | Loading action (Actual): servedActivity (TM Truck), loadedPieces, onTransportMeans, loadingType (Loading), executionStatus (Actual), actionEndTime |
+| Forwarder | Forwarder | POST | Loading (Actual) | Loading action (Actual): servedActivity (TM Truck), loadedPieces, onTransportMeans, loadingType (Loading), actionTimeType (Actual), actionEndTime |
 | Shipper  | Forwarder | POST | Event on Piece | Create Event: eventFor (Piece), eventLocation (if relevant), eventCode or eventName, eventDate, recordingActor |

--- a/Documentation_website/docs/Orchestration/orchestration-04.md
+++ b/Documentation_website/docs/Orchestration/orchestration-04.md
@@ -13,7 +13,7 @@ Forwarder creates TransportMovements for truck movement and Loading (planned) ac
 | 1R Server | Stakeholder | API Calls | LogiticsObject | Details |
 | --- | --- | --- | --- | --- |
 | Forwarder | Forwarder | POST | TransportMovement (Truck Movement) | Create TM (Truck): departureLocation, arrivalLocation, modeCode (3?), transportIdentifier |
-| Forwarder | Forwarder | POST | Loading (Planned) | Loading action (planned): servedActivity (TM Truck), loadedPieces, onTransportMeans, loadingType (Loading), executionStatus (Planned), actionEndTime |
+| Forwarder | Forwarder | POST | Loading (Planned) | Loading action (planned): servedActivity (TM Truck), loadedPieces, onTransportMeans, loadingType (Loading), actionTimeType (Planned), actionEndTime |
 
 # 03. Loaded truck departs forwarder branch facility ot hub
 
@@ -27,5 +27,5 @@ Events can be created on the Pieces to inform of the loading into the truck.
 
 | 1R Server | Stakeholder | API Calls | LogiticsObject | Details |
 | --- | --- | --- | --- | --- |
-| Forwarder | Forwarder | POST | Loading (Actual) | Loading action (actual): servedActivity (TM Truck), loadedPieces, onTransportMeans, loadingType (Loading), executionStatus (Planned), actionEndTime |
+| Forwarder | Forwarder | POST | Loading (Actual) | Loading action (actual): servedActivity (TM Truck), loadedPieces, onTransportMeans, loadingType (Loading), actionTimeType (Planned), actionEndTime |
 | Shipper or Forwarder | Forwarder | POST | Event on Piece | Create Event: eventFor (Piece), eventLocation (if relevant), eventCode or eventName (Loaded in truck), eventDate, recordingActor |

--- a/Documentation_website/docs/Orchestration/orchestration-05.md
+++ b/Documentation_website/docs/Orchestration/orchestration-05.md
@@ -21,7 +21,7 @@ Forwarder creates TransportMovements for truck movement from warehouse to carrie
 | 1R Server | Stakeholder | API Calls | LogiticsObject | Details |
 | --- | --- | --- | --- | --- |
 | Forwarder | Forwarder | POST | TransportMovement (Truck Movement) | Create TM (Truck): departureLocation, arrivalLocation, modeCode (3?), transportIdentifier |
-| Forwarder | Forwarder | POST | Loading (Planned) | Loading action (planned): servedActivity (TM Truck), loadedPieces, onTransportMeans, loadingType (Loading), executionStatus (Planned), actionEndTime |
+| Forwarder | Forwarder | POST | Loading (Planned) | Loading action (planned): servedActivity (TM Truck), loadedPieces, onTransportMeans, loadingType (Loading), actionTimeType (Planned), actionEndTime |
 
 # 03. Transmit (H)AWB electronic data to carrier/customs/AVSEC
 

--- a/Documentation_website/docs/Orchestration/orchestration-mvt01.md
+++ b/Documentation_website/docs/Orchestration/orchestration-mvt01.md
@@ -22,4 +22,4 @@ Unloading (actuals) are created and linked with TransportMovement (truck) and Pi
 | --- | --- | --- | --- | --- |
 | Forwarder | Forwarder | POST | Event on TransportMovement (Truck) | Create Event: eventFor (TM-Truck), eventLocation (forwarder warehouse), eventName (Arrival at forwarder warehouse), eventDate, recordingActor |
 | Forwarder | Forwarder | POST | Optional - MovementTime on TransportMovement (Truck) | Create MovementTime: movementTimeType (actual), movementMilestone (AB), movementTimestamp |
-| Forwarder | Forwarder | POST | Loading (Actual) | Loading action (Actual): servedActivity (TM Truck), loadedPieces, onTransportMeans, loadingType (Unloading), executionStatus (Actual), actionEndTime |
+| Forwarder | Forwarder | POST | Loading (Actual) | Loading action (Actual): servedActivity (TM Truck), loadedPieces, onTransportMeans, loadingType (Unloading), actionTimeType (Actual), actionEndTime |

--- a/Documentation_website/docs/Orchestration/orchestration-mvt02.md
+++ b/Documentation_website/docs/Orchestration/orchestration-mvt02.md
@@ -23,4 +23,4 @@ Unloading (actuals) are created and linked with TransportMovement (truck) and Pi
 | --- | --- | --- | --- | --- |
 | Forwarder | Forwarder | POST | Event on TransportMovement (Truck) | Create Event: eventFor (TM-Truck), eventLocation (forwarder hub), eventName (Arrival at forwarder hub), eventDate, recordingActor |
 | Forwarder | Forwarder | POST | Optional - MovementTime on TransportMovement (Truck) | Create MovementTime: movementTimeType (actual), movementMilestone (AA), movementTimestamp |
-| Forwarder | Forwarder | POST | Loading (Actual) | Unloading action (actual): servedActivity (TM Truck), loadedPieces, onTransportMeans, loadingType (Unloading), executionStatus (Planned), actionEndTime |
+| Forwarder | Forwarder | POST | Loading (Actual) | Unloading action (actual): servedActivity (TM Truck), loadedPieces, onTransportMeans, loadingType (Unloading), actionTimeType (Planned), actionEndTime |

--- a/Documentation_website/docs/Orchestration/orchestration-mvt03.md
+++ b/Documentation_website/docs/Orchestration/orchestration-mvt03.md
@@ -14,7 +14,7 @@ Event is added on the Truck TransportMovement indicating departure from warehous
 
 | 1R Server | Stakeholder | API Calls | LogiticsObject | Details |
 | --- | --- | --- | --- | --- |
-| Forwarder | Forwarder | POST | Loading (Actual) | Loading action (actual): servedActivity (TM Truck), loadedPieces, onTransportMeans, loadingType (Loading), executionStatus (Planned), actionEndTime |
+| Forwarder | Forwarder | POST | Loading (Actual) | Loading action (actual): servedActivity (TM Truck), loadedPieces, onTransportMeans, loadingType (Loading), actionTimeType (Planned), actionEndTime |
 | Shipper or Forwarder | Forwarder | POST | Event on Piece | Create Event: eventFor (Piece), eventLocation (if relevant), eventCode or eventName (Loaded in truck), eventDate, recordingActor |
 | Shipper or Forwarder | Forwarder | POST | Event on TransportMovement (Truck) | Create Event: eventFor (TM-Truck), eventLocation (forwarder warehouse), eventName (Departure from forwarder warehouse), eventDate, recordingActor |
 


### PR DESCRIPTION
Eight rows in the MOP corpus name `executionStatus` on a Loading or Unloading action. That property is not available there, and the value the rows carry is not one of its values.

`Loading` and `Unloading` are `LogisticsAction` subclasses. `executionStatus` is declared on `LogisticsActivity` — a different superclass — and its enum is `ACTIVE` / `CANCELLED` / `COMPLETE` / `PENDING`. The value these rows actually write is `Planned` or `Actual`, which belongs to `actionTimeType` on `LogisticsAction` (`ActionTimeType`: `ACTUAL` / `PLANNED` / `REQUESTED`), and `Loading` inherits it.

The corpus already spells it correctly in **26 other places** for the same field in the same kind of row — for example `orchestration-16.md` line 14:

```
| Forwarder | Forwarder | POST | Loading (Planned) | Loading action: servedActivity (TM-Truck), loadedPieces (Pieces) and/or loadedUnits (ULDs/Pallets), loadingType (loading), actionTimeType (planned), onTransportMeans (if relevant at that stage) |
```

So this is an internal inconsistency in the corpus, not a naming convention. This PR changes only the property name and leaves each row's value exactly as it was.

## The eight rows

| File | Line | Value as written |
| --- | --- | --- |
| `orchestration-01.md` | 86 | `(Planned)` |
| `orchestration-02.md` | 33 | `(Actual)` |
| `orchestration-04.md` | 16 | `(Planned)` |
| `orchestration-04.md` | 30 | `(Planned)` |
| `orchestration-05.md` | 24 | `(Planned)` |
| `orchestration-mvt01.md` | 25 | `(Actual)` |
| `orchestration-mvt02.md` | 26 | `(Planned)` |
| `orchestration-mvt03.md` | 17 | `(Planned)` |

## Separate observation, deliberately not changed here

Four of these rows contradict themselves on the value, independently of the property name. Renaming the property preserves the contradiction rather than hiding it, so we left it for you to decide:

- `orchestration-04.md:30` — the row is titled `Loading (Actual)` and the prose says "Loading action (actual)", but the field says `(Planned)`.
- `orchestration-mvt02.md:26` — the row is titled `Loading (Actual)`, the prose says "**Un**loading action (actual)", `loadingType` says `(Unloading)`, and the field says `(Planned)`.
- `orchestration-mvt03.md:17` — titled `Loading (Actual)`, prose "Loading action (actual)", field `(Planned)`.
- `orchestration-mvt01.md:25` — titled `Loading (Actual)` with `loadingType (Unloading)`.

If the intent is that the value follows the row title, three of them should read `(Actual)`; `mvt01` looks like a `loadingType` copy-paste. We did not guess.

## How this was verified

The property facts were checked against the ontology shipped in this repository (`2026-07`, cargo 3.3.0), not from memory: `actionTimeType` exists on `LogisticsAction`, `executionStatus` exists on `LogisticsActivity`, and `Loading` has no `executionStatus`. The eight occurrences and the 26 correct ones were enumerated by grep over `Documentation_website/docs/Orchestration/`. The same eight lines are present in the `2026-07` tag and on `master` — this is not a report against a stale snapshot.
